### PR TITLE
Fix and polish eth2 API

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1535,6 +1535,45 @@ func (bc *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 	return n, err
 }
 
+// InsertChainWithoutSealVerification works exactly the same 
+// except for seal verification, seal verification is omitted
+func (bc *BlockChain) InsertChainWithoutSealVerification(chain types.Blocks) (int, error) {
+	// Sanity check that we have something meaningful to import
+	if len(chain) == 0 {
+		return 0, nil
+	}
+
+	bc.blockProcFeed.Send(true)
+	defer bc.blockProcFeed.Send(false)
+
+	// Remove already known canon-blocks
+	var (
+		block, prev *types.Block
+	)
+	// Do a sanity check that the provided chain is actually ordered and linked
+	for i := 1; i < len(chain); i++ {
+		block = chain[i]
+		prev = chain[i-1]
+		if block.NumberU64() != prev.NumberU64()+1 || block.ParentHash() != prev.Hash() {
+			// Chain broke ancestry, log a message (programming error) and skip insertion
+			log.Error("Non contiguous block insert", "number", block.Number(), "hash", block.Hash(),
+				"parent", block.ParentHash(), "prevnumber", prev.Number(), "prevhash", prev.Hash())
+
+			return 0, fmt.Errorf("non contiguous insert: item %d is #%d [%x…], item %d is #%d [%x…] (parent [%x…])", i-1, prev.NumberU64(),
+				prev.Hash().Bytes()[:4], i, block.NumberU64(), block.Hash().Bytes()[:4], block.ParentHash().Bytes()[:4])
+		}
+	}
+	// Pre-checks passed, start the full block imports
+	bc.wg.Add(1)
+	bc.chainmu.Lock()
+	n, err := bc.insertChain(chain, false)
+	bc.chainmu.Unlock()
+	bc.wg.Done()
+
+	return n, err
+}
+
+
 // insertChain is the internal implementation of InsertChain, which assumes that
 // 1) chains are contiguous, and 2) The chain mutex is held.
 //

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1535,7 +1535,7 @@ func (bc *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 	return n, err
 }
 
-// InsertChainWithoutSealVerification works exactly the same 
+// InsertChainWithoutSealVerification works exactly the same
 // except for seal verification, seal verification is omitted
 func (bc *BlockChain) InsertChainWithoutSealVerification(chain types.Blocks) (int, error) {
 	// Sanity check that we have something meaningful to import
@@ -1572,7 +1572,6 @@ func (bc *BlockChain) InsertChainWithoutSealVerification(chain types.Blocks) (in
 
 	return n, err
 }
-
 
 // insertChain is the internal implementation of InsertChain, which assumes that
 // 1) chains are contiguous, and 2) The chain mutex is held.

--- a/eth/api.go
+++ b/eth/api.go
@@ -388,7 +388,7 @@ func (api *Eth2API) makeEnv(parent *types.Block, header *types.Header) error {
 	return nil
 }
 
-func (api *Eth2API) ProduceBlock(parentHash common.Hash) ([]byte, error) {	
+func (api *Eth2API) ProduceBlock(parentHash common.Hash) ([]byte, error) {
 	log.Info("Produce block", "parentHash", parentHash)
 
 	bc := api.eth.BlockChain()


### PR DESCRIPTION
## What was done?
- `eth2_produceBlock`
  - add a delay that waits for a second if block is about to be produced with the same `timestamp` as its parent, otherwise produced block fails on import
  - `log.Info("Produce block", "parentHash", parentHash)`
- `eth2_insertBlock`
  - replace  `InsertChain` with `InsertChainWithoutSealVerification` in `eth2_insertBlock`
- `eth2_setHead`
  - replace `api.eth.BlockChain().GetBlockByHash(api.head)` with `api.eth.BlockChain().CurrentBlock()`
  - take a quit if given head is the same as the current one