### PR TITLE
trie: pass TestDerivableList

### DIFF
--- a/core/types/derive_sha.go
+++ b/core/types/derive_sha.go
@@ -43,7 +43,7 @@ func DeriveSha(list DerivableList, hasher Hasher) common.Hash {
 	// hash order, which is not the order that `list` provides
 	// hashes in. This insertion sequence ensures that the
 	// order is correct.
-	for i := 1; i < list.Len() && i < 0x7f; i++ {
+	for i := 1; i < list.Len() && i <= 0x7f; i++ {
 		keybuf.Reset()
 		rlp.Encode(keybuf, uint(i))
 		hasher.Update(keybuf.Bytes(), list.GetRlp(i))

--- a/trie/database.go
+++ b/trie/database.go
@@ -99,6 +99,15 @@ type rawNode []byte
 func (n rawNode) cache() (hashNode, bool)   { panic("this should never end up in a live trie") }
 func (n rawNode) fstring(ind string) string { panic("this should never end up in a live trie") }
 
+func (n rawNode) EncodeRLP(w io.Writer) error {
+	count, err := w.Write([]byte(n))
+	if err != nil && count != len(n) {
+		err = fmt.Errorf("rawNode: could not write full length")
+	}
+
+	return err
+}
+
 // rawFullNode represents only the useful data content of a full node, with the
 // caches and flags stripped out to minimize its data storage. This type honors
 // the same RLP encoding as the original parent.
@@ -199,7 +208,7 @@ func forGatherChildren(n node, onChild func(hash common.Hash)) {
 		}
 	case hashNode:
 		onChild(common.BytesToHash(n))
-	case valueNode, nil:
+	case valueNode, nil, rawNode:
 	default:
 		panic(fmt.Sprintf("unknown node type: %T", n))
 	}

--- a/trie/database.go
+++ b/trie/database.go
@@ -101,11 +101,7 @@ func (n rawNode) fstring(ind string) string { panic("this should never end up in
 
 func (n rawNode) EncodeRLP(w io.Writer) error {
 	_, err := w.Write([]byte(n))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // rawFullNode represents only the useful data content of a full node, with the

--- a/trie/database.go
+++ b/trie/database.go
@@ -100,12 +100,12 @@ func (n rawNode) cache() (hashNode, bool)   { panic("this should never end up in
 func (n rawNode) fstring(ind string) string { panic("this should never end up in a live trie") }
 
 func (n rawNode) EncodeRLP(w io.Writer) error {
-	count, err := w.Write([]byte(n))
-	if err != nil && count != len(n) {
-		err = fmt.Errorf("rawNode: could not write full length")
+	_, err := w.Write([]byte(n))
+	if err != nil {
+		return err
 	}
 
-	return err
+	return nil
 }
 
 // rawFullNode represents only the useful data content of a full node, with the

--- a/trie/encoding.go
+++ b/trie/encoding.go
@@ -51,6 +51,35 @@ func hexToCompact(hex []byte) []byte {
 	return buf
 }
 
+// hexToCompactInPlace places the compact key in input buffer, returning the length
+// needed for the representation
+func hexToCompactInPlace(hex []byte) int {
+	var (
+		hexLen    = len(hex) // length of the hex input
+		firstByte = byte(0)
+	)
+	// Check if we have a terminator there
+	if hexLen > 0 && hex[hexLen-1] == 16 {
+		firstByte = 1 << 5
+		hexLen-- // last part was the terminator, ignore that
+	}
+	var (
+		binLen = hexLen/2 + 1
+		ni     = 0 // index in hex
+		bi     = 1 // index in bin (compact)
+	)
+	if hexLen&1 == 1 {
+		firstByte |= 1 << 4 // odd flag
+		firstByte |= hex[0] // first nibble is contained in the first byte
+		ni++
+	}
+	for ; ni < hexLen; bi, ni = bi+1, ni+2 {
+		hex[bi] = hex[ni]<<4 | hex[ni+1]
+	}
+	hex[0] = firstByte
+	return binLen
+}
+
 func compactToHex(compact []byte) []byte {
 	if len(compact) == 0 {
 		return compact

--- a/trie/encoding_test.go
+++ b/trie/encoding_test.go
@@ -18,6 +18,8 @@ package trie
 
 import (
 	"bytes"
+	"encoding/hex"
+	"math/rand"
 	"testing"
 )
 
@@ -71,6 +73,40 @@ func TestHexKeybytes(t *testing.T) {
 		}
 		if k := hexToKeybytes(test.hexIn); !bytes.Equal(k, test.key) {
 			t.Errorf("hexToKeybytes(%x) -> %x, want %x", test.hexIn, k, test.key)
+		}
+	}
+}
+
+func TestHexToCompactInPlace(t *testing.T) {
+	for i, keyS := range []string{
+		"00",
+		"060a040c0f000a090b040803010801010900080d090a0a0d0903000b10",
+		"10",
+	} {
+		hexBytes, _ := hex.DecodeString(keyS)
+		exp := hexToCompact(hexBytes)
+		sz := hexToCompactInPlace(hexBytes)
+		got := hexBytes[:sz]
+		if !bytes.Equal(exp, got) {
+			t.Fatalf("test %d: encoding err\ninp %v\ngot %x\nexp %x\n", i, keyS, got, exp)
+		}
+	}
+}
+
+func TestHexToCompactInPlaceRandom(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		l := rand.Intn(128)
+		key := make([]byte, l)
+		rand.Read(key)
+		hexBytes := keybytesToHex(key)
+		hexOrig := []byte(string(hexBytes))
+		exp := hexToCompact(hexBytes)
+		sz := hexToCompactInPlace(hexBytes)
+		got := hexBytes[:sz]
+
+		if !bytes.Equal(exp, got) {
+			t.Fatalf("encoding err \ncpt %x\nhex %x\ngot %x\nexp %x\n",
+				key, hexOrig, got, exp)
 		}
 	}
 }

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -369,7 +369,7 @@ func (st *StackTrie) Hash() (h common.Hash) {
 		h := newHasher(false)
 		defer returnHasherToPool(h)
 		h.sha.Reset()
-		h.sha.Write(h.tmp)
+		h.sha.Write(st.val)
 		h.sha.Read(ret)
 		return common.BytesToHash(ret)
 	}

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -371,7 +371,6 @@ func (st *StackTrie) hash() {
 		// Do all db implementations copy the value provided?
 		st.db.Put(st.val, h.tmp)
 	}
-	return
 }
 
 // Hash returns the hash of the current node

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -280,7 +280,6 @@ func (st *StackTrie) hash() {
 	/* Shortcut if node is already hashed */
 	if st.nodeType == hashedNode {
 		return
-		//return st.val
 	}
 	// The 'hasher' is taken from a pool, but we don't actually
 	// claim an instance until all children are done with their hashing,
@@ -379,9 +378,9 @@ func (st *StackTrie) hash() {
 func (st *StackTrie) Hash() (h common.Hash) {
 	st.hash()
 	if len(st.val) != 32 {
-		// If the nodetype isn't hashedNode, the preimage
-		// (the  rlp-encoding of the node). For the top level node, we need
-		// to force the hashing
+		// If the node's RLP isn't 32 bytes long, the node will not
+		// be hashed, and instead contain the  rlp-encoding of the
+		// node. For the top level node, we need to force the hashing.
 		ret := make([]byte, 32)
 		h := newHasher(false)
 		defer returnHasherToPool(h)

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -3,11 +3,12 @@ package trie
 import (
 	"bytes"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/rlp"
 	"math/big"
 	mrand "math/rand"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"


### PR DESCRIPTION
These are the changes needed for `TestDerivableList` to pass:

* include the required change for `rawNode` to be serialized correctly
* alternative to `force`: make sure that the root of a trie is hashed if its length is less than 32 bytes
* remove one of @holiman's alloc optimization because it doesn't seem to work properly, have to investigate why