### PR TITLE
verkle: fix flush when computing commitment

### DIFF
--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -508,8 +508,8 @@ func computeCommitment(ctx *cli.Context) error {
 		if !ok {
 			panic("verkle tree has invalid root node")
 		}
-		rootNode.Flush(nodesCh)
 		comm := t.ComputeCommitment(ks, lg1)
+		rootNode.Flush(nodesCh)
 		root := common.BytesToHash(bls.ToCompressedG1(comm))
 		out <- root
 	}


### PR DESCRIPTION
Curious why the order matters in this case :think: