### PR TITLE
Update witness gas charging to differentiate between access events and write events

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -669,5 +669,6 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 	}
 	state.AddBalance(header.Coinbase, reward)
 	coinbase := utils.GetTreeKeyBalance(header.Coinbase.Bytes())
-	state.Witness().TouchAddress(coinbase, state.GetBalance(header.Coinbase).Bytes(), true)
+	state.Witness().TouchAddressOnReadAndChargeGas(coinbase)
+	state.Witness().SetLeafValue(coinbase, state.GetBalance(header.Coinbase).Bytes())
 }

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -669,5 +669,5 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 	}
 	state.AddBalance(header.Coinbase, reward)
 	coinbase := utils.GetTreeKeyBalance(header.Coinbase.Bytes())
-	state.Witness().TouchAddress(coinbase, state.GetBalance(header.Coinbase).Bytes())
+	state.Witness().TouchAddress(coinbase, state.GetBalance(header.Coinbase).Bytes(), true)
 }

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -378,11 +378,11 @@ func TestProcessStateless(t *testing.T) {
 	blockchain, _ := NewBlockChain(db, nil, gspec.Config, ethash.NewFaker(), vm.Config{}, nil, nil)
 	defer blockchain.Stop()
 	chain, _ := GenerateVerkleChain(gspec.Config, genesis, ethash.NewFaker(), db, 1, func(_ int, gen *BlockGen) {
-		tx, _ := types.SignTx(types.NewTransaction(0, common.Address{1, 2, 3}, big.NewInt(999), params.TxGas, big.NewInt(875000000), nil), signer, testKey)
+		tx, _ := types.SignTx(types.NewTransaction(0, common.Address{1, 2, 3}, big.NewInt(999), 28600, big.NewInt(875000000), nil), signer, testKey)
 		gen.AddTx(tx)
-		tx, _ = types.SignTx(types.NewTransaction(1, common.Address{}, big.NewInt(999), params.TxGas, big.NewInt(875000000), nil), signer, testKey)
+		tx, _ = types.SignTx(types.NewTransaction(1, common.Address{}, big.NewInt(999), 28600, big.NewInt(875000000), nil), signer, testKey)
 		gen.AddTx(tx)
-		tx, _ = types.SignTx(types.NewTransaction(2, common.Address{}, big.NewInt(0), params.TxGas, big.NewInt(875000000), nil), signer, testKey)
+		tx, _ = types.SignTx(types.NewTransaction(2, common.Address{}, big.NewInt(0), 28600, big.NewInt(875000000), nil), signer, testKey)
 		gen.AddTx(tx)
 
 	})

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -301,9 +301,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	if st.gas < gas {
-		return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, gas)
-	}
+
 	if st.evm.TxContext.Accesses != nil {
 		if msg.To() != nil {
 			toBalance := trieUtils.GetTreeKeyBalance(msg.To().Bytes())
@@ -330,6 +328,9 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		st.evm.TxContext.Accesses.SetLeafValue(fromNonce, preFN[:])
 		gas += st.evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(fromBalance)
 		st.evm.TxContext.Accesses.SetLeafValue(fromBalance, preFB[:])
+	}
+	if st.gas < gas {
+		return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, gas)
 	}
 	st.gas -= gas
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -308,22 +308,24 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		if msg.To() != nil {
 			toBalance := trieUtils.GetTreeKeyBalance(msg.To().Bytes())
 			pre := st.state.GetBalance(*msg.To())
-			gas += st.evm.TxContext.Accesses.TouchAddressAndChargeGas(toBalance, pre.Bytes())
+			if !msg.Value().Cmp(big.NewInt(0)) != 0 {
+				gas += st.evm.TxContext.Accesses.TouchAddressAndChargeGas(toBalance, pre.Bytes(), true)
+			}
 
 			// NOTE: Nonce also needs to be charged, because it is needed for execution
 			// on the statless side.
 			var preTN [8]byte
 			fromNonce := trieUtils.GetTreeKeyNonce(msg.To().Bytes())
 			binary.BigEndian.PutUint64(preTN[:], st.state.GetNonce(*msg.To()))
-			gas += st.evm.TxContext.Accesses.TouchAddressAndChargeGas(fromNonce, preTN[:])
+			gas += st.evm.TxContext.Accesses.TouchAddressAndChargeGas(fromNonce, preTN[:], true)
 		}
 		fromBalance := trieUtils.GetTreeKeyBalance(msg.From().Bytes())
 		preFB := st.state.GetBalance(msg.From()).Bytes()
 		fromNonce := trieUtils.GetTreeKeyNonce(msg.From().Bytes())
 		var preFN [8]byte
 		binary.BigEndian.PutUint64(preFN[:], st.state.GetNonce(msg.From()))
-		gas += st.evm.TxContext.Accesses.TouchAddressAndChargeGas(fromNonce, preFN[:])
-		gas += st.evm.TxContext.Accesses.TouchAddressAndChargeGas(fromBalance, preFB[:])
+		gas += st.evm.TxContext.Accesses.TouchAddressAndChargeGas(fromNonce, preFN[:], true)
+		gas += st.evm.TxContext.Accesses.TouchAddressAndChargeGas(fromBalance, preFB[:], true)
 	}
 	st.gas -= gas
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -308,9 +308,9 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		if msg.To() != nil {
 			toBalance := trieUtils.GetTreeKeyBalance(msg.To().Bytes())
 			pre := st.state.GetBalance(*msg.To())
-			if !msg.Value().Cmp(big.NewInt(0)) != 0 {
+			if msg.Value().Cmp(big.NewInt(0)) != 0 {
 				gas += st.evm.TxContext.Accesses.TouchAddressOnWriteAndChargeGas(toBalance)
-				st.evmTxContext.Accesses.SetLeafValue(toBalance, pre.Bytes())
+				st.evm.TxContext.Accesses.SetLeafValue(toBalance, pre.Bytes())
 			}
 
 			// NOTE: Nonce also needs to be charged, because it is needed for execution
@@ -327,9 +327,9 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		var preFN [8]byte
 		binary.BigEndian.PutUint64(preFN[:], st.state.GetNonce(msg.From()))
 		gas += st.evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(fromNonce)
-		st.evm.TxContext.SetLeafValue(fromNonce, preFN[:])
+		st.evm.TxContext.Accesses.SetLeafValue(fromNonce, preFN[:])
 		gas += st.evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(fromBalance)
-		st.evm.TxContext.SetLeafValue(fromBalance, preFB[:])
+		st.evm.TxContext.Accesses.SetLeafValue(fromBalance, preFB[:])
 	}
 	st.gas -= gas
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -174,7 +174,7 @@ func (evm *EVM) tryTouchWitnessAndConsumeGas(key, value []byte, gasLeft *uint64)
 	gasConsumed := evm.Accesses.TouchAddressOnReadAndChargeGas(key)
 
 	if gasConsumed > *gasLeft {
-		*gas = 0
+		*gasLeft = 0
 		return false
 	}
 
@@ -248,32 +248,27 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		} else {
 			// Touch the account data
 			var data [32]byte
-			if !evm.tryTouchWitnessAndConsumeGas(utils.GetTreeKeyVersion(addr.Bytes()), data[:], gas)
-			{
+			if !evm.tryTouchWitnessAndConsumeGas(utils.GetTreeKeyVersion(addr.Bytes()), data[:], &gas) {
 				evm.StateDB.RevertToSnapshot(snapshot)
-				return []byte{}, ErrOutOfGas, gas
+				return []byte{}, gas, ErrOutOfGas
 			}
 			binary.BigEndian.PutUint64(data[:], evm.StateDB.GetNonce(addr))
-			if !evm.tryTouchWitnessAndConsumeGas(utils.GetTreeKeyNonce(addr.Bytes()), data[:], gas)
-			{
+			if !evm.tryTouchWitnessAndConsumeGas(utils.GetTreeKeyNonce(addr.Bytes()), data[:], &gas) {
 				evm.StateDB.RevertToSnapshot(snapshot)
-				return []byte{}, ErrOutOfGas, gas
+				return []byte{}, gas, ErrOutOfGas
 			}
-			if !evm.tryTouchWitnessAndConsumeGas(utils.GetTreeKeyBalance(addr.Bytes()), data[:], gas)
-			{
+			if !evm.tryTouchWitnessAndConsumeGas(utils.GetTreeKeyBalance(addr.Bytes()), data[:], &gas) {
 				evm.StateDB.RevertToSnapshot(snapshot)
-				return []byte{}, ErrOutOfGas, gas
+				return []byte{}, gas, ErrOutOfGas
 			}
 			binary.BigEndian.PutUint64(data[:], uint64(len(code)))
-			if !evm.tryTouchWitnessAndConsumeGas(utils.GetTreeKeyCodeSize(addr.Bytes()), data[:], gas)
-			{
+			if !evm.tryTouchWitnessAndConsumeGas(utils.GetTreeKeyCodeSize(addr.Bytes()), data[:], &gas) {
 				evm.StateDB.RevertToSnapshot(snapshot)
-				return []byte{}, ErrOutOfGas, gas
+				return []byte{}, gas, ErrOutOfGas
 			}
-			if !evm.tryTouchWitnessAndConsumeGas(utils.GetTreeKeyCodeKeccak(addr.Bytes()), data[:], gas)
-			{
+			if !evm.tryTouchWitnessAndConsumeGas(utils.GetTreeKeyCodeKeccak(addr.Bytes()), data[:], &gas) {
 				evm.StateDB.RevertToSnapshot(snapshot)
-				return []byte{}, ErrOutOfGas, gas
+				return []byte{}, gas, ErrOutOfGas
 			}
 
 			addrCopy := addr

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -93,7 +93,7 @@ func gasExtCodeSize(evm *EVM, contract *Contract, stack *Stack, mem *Memory, mem
 	slot := stack.Back(0)
 	if evm.accesses != nil {
 		index := trieUtils.GetTreeKeyCodeSize(slot.Bytes())
-		usedGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index, nil)
+		usedGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index)
 	}
 
 	return usedGas, nil
@@ -129,7 +129,7 @@ func gasCodeCopy(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
 
 			// TODO make a version of GetTreeKeyCodeChunk without the bigint
 			index := trieUtils.GetTreeKeyCodeChunk(addr[:], uint256.NewInt(chunk))
-			statelessGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index, nil)
+			statelessGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index)
 		}
 
 	}
@@ -160,7 +160,7 @@ func gasExtCodeCopy(evm *EVM, contract *Contract, stack *Stack, mem *Memory, mem
 		for ; chunk < endChunk; chunk++ {
 			// TODO(@gballet) make a version of GetTreeKeyCodeChunk without the bigint
 			index := trieUtils.GetTreeKeyCodeChunk(addr[:], uint256.NewInt(chunk))
-			statelessGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index, nil)
+			statelessGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index)
 		}
 
 	}
@@ -175,7 +175,7 @@ func gasSLoad(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySiz
 		where := stack.Back(0)
 		addr := contract.Address()
 		index := trieUtils.GetTreeKeyStorageSlot(addr[:], where)
-		usedGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index, nil)
+		usedGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index)
 	}
 
 	return usedGas, nil
@@ -426,7 +426,7 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 		// Charge witness costs
 		for i := trieUtils.VersionLeafKey; i <= trieUtils.CodeSizeLeafKey; i++ {
 			index := trieUtils.GetTreeKeyAccountLeaf(address[:], byte(i))
-			gas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index, nil)
+			gas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index)
 		}
 	}
 

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -93,7 +93,7 @@ func gasExtCodeSize(evm *EVM, contract *Contract, stack *Stack, mem *Memory, mem
 	slot := stack.Back(0)
 	if evm.accesses != nil {
 		index := trieUtils.GetTreeKeyCodeSize(slot.Bytes())
-		usedGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index)
+		usedGas += evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(index)
 	}
 
 	return usedGas, nil
@@ -129,7 +129,7 @@ func gasCodeCopy(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
 
 			// TODO make a version of GetTreeKeyCodeChunk without the bigint
 			index := trieUtils.GetTreeKeyCodeChunk(addr[:], uint256.NewInt(chunk))
-			statelessGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index)
+			statelessGas += evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(index)
 		}
 
 	}
@@ -160,7 +160,7 @@ func gasExtCodeCopy(evm *EVM, contract *Contract, stack *Stack, mem *Memory, mem
 		for ; chunk < endChunk; chunk++ {
 			// TODO(@gballet) make a version of GetTreeKeyCodeChunk without the bigint
 			index := trieUtils.GetTreeKeyCodeChunk(addr[:], uint256.NewInt(chunk))
-			statelessGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index)
+			statelessGas += evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(index)
 		}
 
 	}
@@ -175,7 +175,7 @@ func gasSLoad(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySiz
 		where := stack.Back(0)
 		addr := contract.Address()
 		index := trieUtils.GetTreeKeyStorageSlot(addr[:], where)
-		usedGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index)
+		usedGas += evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(index)
 	}
 
 	return usedGas, nil
@@ -426,7 +426,7 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 		// Charge witness costs
 		for i := trieUtils.VersionLeafKey; i <= trieUtils.CodeSizeLeafKey; i++ {
 			index := trieUtils.GetTreeKeyAccountLeaf(address[:], byte(i))
-			gas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index)
+			gas += evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(index)
 		}
 	}
 

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -345,7 +345,7 @@ func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	cs := uint64(interpreter.evm.StateDB.GetCodeSize(slot.Bytes20()))
 	if interpreter.evm.accesses != nil {
 		index := trieUtils.GetTreeKeyCodeSize(slot.Bytes())
-		interpreter.evm.TxContext.Accesses.SetLeafValue(indx), uint256.NewInt(cs).Bytes())
+		interpreter.evm.TxContext.Accesses.SetLeafValue(index, uint256.NewInt(cs).Bytes())
 	}
 	slot.SetUint64(cs)
 	return nil, nil
@@ -400,7 +400,7 @@ func touchEachChunks(start, end uint64, code []byte, contract *Contract, evm *EV
 			end = uint64(len(code))
 		}
 		copy(value[1:], code[chunk*31:end])
-		evm.Accesses.SetLeafValues(index, value[:])
+		evm.Accesses.SetLeafValue(index, value[:])
 	}
 }
 
@@ -925,7 +925,7 @@ func opPush1(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 			copy(value[1:], scope.Contract.Code[chunk*31:endMin])
 			index := trieUtils.GetTreeKeyCodeChunk(scope.Contract.Address().Bytes(), uint256.NewInt(chunk))
 			interpreter.evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(index)
-			interpreter.evm.TxContext.Accesses.SetLeafValue(index, value)
+			interpreter.evm.TxContext.Accesses.SetLeafValue(index, value[:])
 		}
 	} else {
 		scope.Stack.push(integer.Clear())
@@ -962,8 +962,8 @@ func makePush(size uint64, pushByteSize int) executionFunc {
 		value[0] = byte(count)
 		copy(value[1:], scope.Contract.Code[chunk*31:endMin])
 		index := trieUtils.GetTreeKeyCodeChunk(scope.Contract.Address().Bytes(), uint256.NewInt(chunk))
-		interpreter.evm.TxContext.Accesses.TouchAddressAndChargeGas(index)
-		interpreter.evm.TxContext.Accesses.SetLeafValue(index, value)
+		interpreter.evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(index)
+		interpreter.evm.TxContext.Accesses.SetLeafValue(index, value[:])
 
 		// in the case of PUSH32, the end data might be two chunks away,
 		// so also get the middle chunk. There is a boundary condition
@@ -983,7 +983,7 @@ func makePush(size uint64, pushByteSize int) executionFunc {
 			copy(value[1:], scope.Contract.Code[chunk*31:end])
 			index := trieUtils.GetTreeKeyCodeChunk(scope.Contract.Address().Bytes(), uint256.NewInt(chunk))
 			interpreter.evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(index)
-			interpreter.evm.TxContext.Accesses.SetLeafValue(index, value)
+			interpreter.evm.TxContext.Accesses.SetLeafValue(index, value[:])
 
 		}
 

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -227,7 +227,8 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 				value[0] = byte(count)
 				copy(value[1:], contract.Code[chunk*31:end])
 			}
-			contract.Gas -= in.evm.TxContext.Accesses.TouchAddressAndChargeGas(index, value[:])
+			contract.Gas -= in.evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(index, value[:])
+			in.evm.TxContext.SetLeafValue(index, value[:])
 		}
 
 		if inWitness {

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -227,8 +227,8 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 				value[0] = byte(count)
 				copy(value[1:], contract.Code[chunk*31:end])
 			}
-			contract.Gas -= in.evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(index, value[:])
-			in.evm.TxContext.SetLeafValue(index, value[:])
+			contract.Gas -= in.evm.TxContext.Accesses.TouchAddressOnReadAndChargeGas(index)
+			in.evm.TxContext.Accesses.SetLeafValue(index, value[:])
 		}
 
 		if inWitness {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -157,9 +157,13 @@ const (
 	RefundQuotient        uint64 = 2
 	RefundQuotientEIP3529 uint64 = 5
 
-	// Verkle tree EIP: costs associated to witness accesses
-	WitnessBranchCost = uint64(1900)
-	WitnessChunkCost  = uint64(200)
+        // Verkle tree EIP: costs associated to witness accesses
+        WitnessBranchReadCost = uint64(1900)
+        WitnessChunkReadCost  = uint64(200)
+    WitnessBranchWriteCost = uint64(3000)
+    WitnessChunkWriteCost = uint64(500)
+    WitnessChunkFillCost = uint64(6200)
+
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations


### PR DESCRIPTION
This PR updates the witness gas charging scheme to differentiate between witness access events and write events.
Relevant spec doc: https://notes.ethereum.org/-fJSOrnYQl-mqoWKpaTIsQ

TODOs that can be addressed in future PR(s):
* Charging for filling a previously-empty leaf is omitted from this PR as it is currently unclear how to expose the db to the EVM in a non-hacky way.
~~* witness access events/costs are not handled for PUSH.  Because executed code is accounted for in the interpreter loop, I think the costs/witnesses would still be correct in most cases.  However, I can see issues with witnesses/costs being missed (e.g. `PUSH32` could advance the PC over a slot and cause the leaf for that code to not be charged/included).  To properly make this change, `PUSH` will have to be modified to be treated as a dynamically-priced opcode in Geth's EVM.~~ <- done in https://github.com/gballet/go-ethereum/pull/42