### PR TITLE
miner: embed verkle proof in sealing block

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1046,7 +1046,6 @@ func (w *worker) commit(uncles []*types.Header, interval func(), update bool, st
 		if err != nil {
 			return err
 		}
-		//w.current.header.VerkleProof = p
 		block.SetVerkleProof(p)
 	}
 	if w.isRunning() && !w.merger.TDDReached() {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1043,10 +1043,11 @@ func (w *worker) commit(uncles []*types.Header, interval func(), update bool, st
 		vtr := tr.(*trie.VerkleTrie)
 		// Generate the proof if we are using a verkle tree
 		p, err := vtr.ProveAndSerialize(s.Witness().Keys(), s.Witness().KeyVals())
-		w.current.header.VerkleProof = p
 		if err != nil {
 			return err
 		}
+		//w.current.header.VerkleProof = p
+		block.SetVerkleProof(p)
 	}
 	if w.isRunning() && !w.merger.TDDReached() {
 		if interval != nil {


### PR DESCRIPTION
### Justification that this is working/correct:
Get the RLP of a block: `curl -H 'Content-type: application/json' -X POST --data '{"jsonrpc":"2.0","method":"debug_getBlockRlp","params":[1],"id":83}' localhost:8545`

Example program to decode a returned block's RLP:
```
const verkleBlockRlp = "..."

let {rlp} = require('ethereumjs-util')
const b = Buffer.from(verkleBlockRlp, 'hex')

console.log(rlp.decode(b))
```

Output before this change:
```
[ [ <Buffer 72 93 56 f6 1c 03 c0 97 5c 73 bf e7 55 c3 e0 80 70 83 55 77 c7 9f fe c0 fe 17 4c 81 ba 25 35 b5>,
    <Buffer 1d cc 4d e8 de c7 5d 7a ab 85 b5 67 b6 cc d4 1a d3 12 45 1b 94 8a 74 13 f0 a1 42 fd 40 d4 93 47>,
    <Buffer a8 ea 39 1e ac d8 6a b3 26 84 35 79 06 0e 42 00 7a 5f a9 3b>,
    <Buffer 0f 14 23 c8 31 98 43 77 25 87 92 29 2e 72 53 ff ce 9c c5 98 50 82 67 95 b2 b8 00 95 e1 db db 23>,
    <Buffer 56 e8 1f 17 1b cc 55 a6 ff 83 45 e6 92 c0 f8 6e 5b 48 e0 1b 99 6c ad c0 01 62 2f b5 e3 63 b4 21>,
    <Buffer 56 e8 1f 17 1b cc 55 a6 ff 83 45 e6 92 c0 f8 6e 5b 48 e0 1b 99 6c ad c0 01 62 2f b5 e3 63 b4 21>,
    <Buffer 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ... >,
    <Buffer 02 00 00>,
    <Buffer 01>,
    <Buffer 2f fb d2>,
    <Buffer >,
    <Buffer 61 a6 ac 19>,
    <Buffer 64 61 6f 2d 68 61 72 64 2d 66 6f 72 6b>,
    <Buffer c2 80 66 79 1f ad 66 f8 df f8 f4 da 93 73 c7 6c 9b 37 ee fb 94 e8 b9 9d ff ce 1c 8b 46 1a 0e ec>,
    <Buffer 7a d1 b6 d8 2f 00 5f 94>,
    <Buffer 34 27 70 c0> ],
  [],
  [] ]
```

Output after this change:
```
[ [ <Buffer 72 93 56 f6 1c 03 c0 97 5c 73 bf e7 55 c3 e0 80 70 83 55 77 c7 9f fe c0 fe 17 4c 81 ba 25 35 b5>,
    <Buffer 1d cc 4d e8 de c7 5d 7a ab 85 b5 67 b6 cc d4 1a d3 12 45 1b 94 8a 74 13 f0 a1 42 fd 40 d4 93 47>,
    <Buffer a8 ea 39 1e ac d8 6a b3 26 84 35 79 06 0e 42 00 7a 5f a9 3b>,
    <Buffer 0f 14 23 c8 31 98 43 77 25 87 92 29 2e 72 53 ff ce 9c c5 98 50 82 67 95 b2 b8 00 95 e1 db db 23>,
    <Buffer 56 e8 1f 17 1b cc 55 a6 ff 83 45 e6 92 c0 f8 6e 5b 48 e0 1b 99 6c ad c0 01 62 2f b5 e3 63 b4 21>,
    <Buffer 56 e8 1f 17 1b cc 55 a6 ff 83 45 e6 92 c0 f8 6e 5b 48 e0 1b 99 6c ad c0 01 62 2f b5 e3 63 b4 21>,
    <Buffer 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ... >,
    <Buffer 02 00 00>,
    <Buffer 01>,
    <Buffer 2f fb d2>,
    <Buffer >,
    <Buffer 61 a6 a9 7f>,
    <Buffer 64 61 6f 2d 68 61 72 64 2d 66 6f 72 6b>,
    <Buffer 31 a3 37 96 0c 9c 58 85 5e da 5d 6d f1 f8 52 48 b9 ff 82 4f ca 27 b5 d5 ec 8d 32 f8 52 01 69 16>,
    <Buffer 6f 42 fd 91 52 40 3b 32>,
    <Buffer 34 27 70 c0>,
    <Buffer f9 06 a3 f9 05 3a f9 04 eb f9 02 60 f8 4a e4 88 d8 ac 67 3b a0 09 74 17 88 f2 5a ba 78 2a 03 46 8b 88 92 c6 6f 58 58 21 72 73 88 3b 1e 3d a8 79 09 02 ... > ],
  [],
  [] ]
```