### PR TITLE
Refactor witness-accumulation in EVM

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -661,14 +661,20 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		r.Sub(r, header.Number)
 		r.Mul(r, blockReward)
 		r.Div(r, big8)
-		uncleCoinbase := utils.GetTreeKeyBalance(uncle.Coinbase.Bytes())
-		state.Witness().TouchAddress(uncleCoinbase, state.GetBalance(uncle.Coinbase).Bytes())
+
+		if state.Witness() != nil {
+			uncleCoinbase := utils.GetTreeKeyBalance(uncle.Coinbase.Bytes())
+			state.Witness().TouchAddress(uncleCoinbase, state.GetBalance(uncle.Coinbase).Bytes())
+		}
 		state.AddBalance(uncle.Coinbase, r)
 
 		r.Div(blockReward, big32)
 		reward.Add(reward, r)
 	}
 	coinbase := utils.GetTreeKeyBalance(header.Coinbase.Bytes())
-	state.Witness().TouchAddress(coinbase, state.GetBalance(header.Coinbase).Bytes())
+
+	if state.Witness() != nil {
+		state.Witness().TouchAddress(coinbase, state.GetBalance(header.Coinbase).Bytes())
+	}
 	state.AddBalance(header.Coinbase, reward)
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -128,7 +128,9 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
 	}
 
-	statedb.Witness().Merge(txContext.Accesses)
+	if config.IsCancun(blockNumber) {
+		statedb.Witness().Merge(txContext.Accesses)
+	}
 
 	// Set the receipt logs and create the bloom filter.
 	receipt.Logs = statedb.GetLogs(tx.Hash(), blockHash)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -304,26 +304,26 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	if st.gas < gas {
 		return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, gas)
 	}
-	if st.evm.TxContext.Accesses != nil {
+	if st.evm.Accesses != nil {
 		if msg.To() != nil {
 			toBalance := trieUtils.GetTreeKeyBalance(msg.To().Bytes())
 			pre := st.state.GetBalance(*msg.To())
-			gas += st.evm.TxContext.Accesses.TouchAddressAndChargeGas(toBalance, pre.Bytes())
+			gas += st.evm.Accesses.TouchAddressAndChargeGas(toBalance, pre.Bytes())
 
 			// NOTE: Nonce also needs to be charged, because it is needed for execution
 			// on the statless side.
 			var preTN [8]byte
 			fromNonce := trieUtils.GetTreeKeyNonce(msg.To().Bytes())
 			binary.BigEndian.PutUint64(preTN[:], st.state.GetNonce(*msg.To()))
-			gas += st.evm.TxContext.Accesses.TouchAddressAndChargeGas(fromNonce, preTN[:])
+			gas += st.evm.Accesses.TouchAddressAndChargeGas(fromNonce, preTN[:])
 		}
 		fromBalance := trieUtils.GetTreeKeyBalance(msg.From().Bytes())
 		preFB := st.state.GetBalance(msg.From()).Bytes()
 		fromNonce := trieUtils.GetTreeKeyNonce(msg.From().Bytes())
 		var preFN [8]byte
 		binary.BigEndian.PutUint64(preFN[:], st.state.GetNonce(msg.From()))
-		gas += st.evm.TxContext.Accesses.TouchAddressAndChargeGas(fromNonce, preFN[:])
-		gas += st.evm.TxContext.Accesses.TouchAddressAndChargeGas(fromBalance, preFB[:])
+		gas += st.evm.Accesses.TouchAddressAndChargeGas(fromNonce, preFN[:])
+		gas += st.evm.Accesses.TouchAddressAndChargeGas(fromBalance, preFB[:])
 	}
 	st.gas -= gas
 

--- a/core/vm/common.go
+++ b/core/vm/common.go
@@ -63,6 +63,18 @@ func getData(data []byte, start uint64, size uint64) []byte {
 	return common.RightPadBytes(data[start:end], int(size))
 }
 
+func getDataAndAdjustedBounds(data []byte, start uint64, size uint64) (codeCopyPadded []byte, actualStart uint64, sizeNonPadded uint64) {
+	length := uint64(len(data))
+	if start > length {
+		start = length
+	}
+	end := start + size
+	if end > length {
+		end = length
+	}
+	return common.RightPadBytes(data[start:end], int(size)), start, end
+}
+
 // toWordSize returns the ceiled word size required for memory expansion.
 func toWordSize(size uint64) uint64 {
 	if size > math.MaxUint64-31 {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -125,8 +125,6 @@ type EVM struct {
 	// available gas is calculated in gasCall* according to the 63/64 rule and later
 	// applied in opCall*.
 	callGasTemp uint64
-
-	accesses map[common.Hash]common.Hash
 }
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
@@ -232,15 +230,17 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		if len(code) == 0 {
 			ret, err = nil, nil // gas is unchanged
 		} else {
-			// Touch the account data
-			var data [32]byte
-			evm.Accesses.TouchAddress(utils.GetTreeKeyVersion(addr.Bytes()), data[:])
-			binary.BigEndian.PutUint64(data[:], evm.StateDB.GetNonce(addr))
-			evm.Accesses.TouchAddress(utils.GetTreeKeyNonce(addr[:]), data[:])
-			evm.Accesses.TouchAddress(utils.GetTreeKeyBalance(addr[:]), evm.StateDB.GetBalance(addr).Bytes())
-			binary.BigEndian.PutUint64(data[:], uint64(len(code)))
-			evm.Accesses.TouchAddress(utils.GetTreeKeyCodeSize(addr[:]), data[:])
-			evm.Accesses.TouchAddress(utils.GetTreeKeyCodeKeccak(addr[:]), evm.StateDB.GetCodeHash(addr).Bytes())
+			if evm.Accesses != nil {
+				// Touch the account data
+				var data [32]byte
+				evm.Accesses.TouchAddress(utils.GetTreeKeyVersion(addr.Bytes()), data[:])
+				binary.BigEndian.PutUint64(data[:], evm.StateDB.GetNonce(addr))
+				evm.Accesses.TouchAddress(utils.GetTreeKeyNonce(addr[:]), data[:])
+				evm.Accesses.TouchAddress(utils.GetTreeKeyBalance(addr[:]), evm.StateDB.GetBalance(addr).Bytes())
+				binary.BigEndian.PutUint64(data[:], uint64(len(code)))
+				evm.Accesses.TouchAddress(utils.GetTreeKeyCodeSize(addr[:]), data[:])
+				evm.Accesses.TouchAddress(utils.GetTreeKeyCodeKeccak(addr[:]), evm.StateDB.GetCodeHash(addr).Bytes())
+			}
 
 			addrCopy := addr
 			// If the account has no code, we can abort here

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -246,23 +246,13 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 			if evm.Accesses != nil {
 				// Touch the account data
 				var data [32]byte
-				if !tryConsumeGas(&gas, evm.Accesses.TouchAddressAndChargeGas(utils.GetTreeKeyVersion(addr.Bytes()), data[:])) {
-					return nil, 0, ErrOutOfGas
-				}
+				evm.Accesses.TouchAddress(utils.GetTreeKeyVersion(addr.Bytes()), data[:])
 				binary.BigEndian.PutUint64(data[:], evm.StateDB.GetNonce(addr))
-				if !tryConsumeGas(&gas, evm.Accesses.TouchAddressAndChargeGas(utils.GetTreeKeyNonce(addr[:]), data[:])) {
-					return nil, 0, ErrOutOfGas
-				}
-				if !tryConsumeGas(&gas, evm.Accesses.TouchAddressAndChargeGas(utils.GetTreeKeyBalance(addr[:]), evm.StateDB.GetBalance(addr).Bytes())) {
-					return nil, 0, ErrOutOfGas
-				}
+				evm.Accesses.TouchAddress(utils.GetTreeKeyNonce(addr[:]), data[:])
+				evm.Accesses.TouchAddress(utils.GetTreeKeyBalance(addr[:]), evm.StateDB.GetBalance(addr).Bytes())
 				binary.BigEndian.PutUint64(data[:], uint64(len(code)))
-				if !tryConsumeGas(&gas, evm.Accesses.TouchAddressAndChargeGas(utils.GetTreeKeyCodeSize(addr[:]), data[:])) {
-					return nil, 0, ErrOutOfGas
-				}
-				if !tryConsumeGas(&gas, evm.Accesses.TouchAddressAndChargeGas(utils.GetTreeKeyCodeKeccak(addr[:]), evm.StateDB.GetCodeHash(addr).Bytes())) {
-					return nil, 0, ErrOutOfGas
-				}
+				evm.Accesses.TouchAddress(utils.GetTreeKeyCodeSize(addr[:]), data[:])
+				evm.Accesses.TouchAddress(utils.GetTreeKeyCodeKeccak(addr[:]), evm.StateDB.GetCodeHash(addr).Bytes())
 			}
 
 			addrCopy := addr

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -110,7 +110,7 @@ func gasCodeCopy(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
 			uint64Length = 0xffffffffffffffff
 		}
 		_, offset, nonPaddedSize := getDataAndAdjustedBounds(contract.Code, uint64CodeOffset, uint64Length)
-		statelessGas = touchEachChunksAndChargeGas(offset, nonPaddedSize, contract.Address().Bytes()[:], contract, evm.Accesses)
+		statelessGas = touchEachChunksAndChargeGas(offset, nonPaddedSize, contract.Address().Bytes()[:], nil, evm.Accesses)
 	}
 	usedGas, err := gasCodeCopyStateful(evm, contract, stack, mem, memorySize)
 	return usedGas + statelessGas, err

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -22,8 +22,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/params"
-	trieUtils "github.com/ethereum/go-ethereum/trie/utils"
-	"github.com/holiman/uint256"
 )
 
 // memoryGasCost calculates the quadratic gas for memory expansion. It does so
@@ -88,102 +86,14 @@ func memoryCopierGas(stackpos int) gasFunc {
 	}
 }
 
-func gasExtCodeSize(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	usedGas := uint64(0)
-	slot := stack.Back(0)
-	if evm.accesses != nil {
-		index := trieUtils.GetTreeKeyCodeSize(slot.Bytes())
-		usedGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index, nil)
-	}
-
-	return usedGas, nil
-}
-
 var (
-	gasCallDataCopy        = memoryCopierGas(2)
-	gasCodeCopyStateful    = memoryCopierGas(2)
-	gasExtCodeCopyStateful = memoryCopierGas(3)
-	gasReturnDataCopy      = memoryCopierGas(2)
+	gasCallDataCopy   = memoryCopierGas(2)
+	gasCodeCopy       = memoryCopierGas(2)
+	gasExtCodeCopy    = memoryCopierGas(3)
+	gasReturnDataCopy = memoryCopierGas(2)
 )
 
-func gasCodeCopy(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	var statelessGas uint64
-	if evm.accesses != nil {
-		var (
-			codeOffset = stack.Back(1)
-			length     = stack.Back(2)
-		)
-		uint64CodeOffset, overflow := codeOffset.Uint64WithOverflow()
-		if overflow {
-			uint64CodeOffset = 0xffffffffffffffff
-		}
-		uint64CodeEnd, overflow := new(uint256.Int).Add(codeOffset, length).Uint64WithOverflow()
-		if overflow {
-			uint64CodeEnd = 0xffffffffffffffff
-		}
-		addr := contract.Address()
-		chunk := uint64CodeOffset / 31
-		endChunk := uint64CodeEnd / 31
-		// XXX uint64 overflow in condition check
-		for ; chunk < endChunk; chunk++ {
-
-			// TODO make a version of GetTreeKeyCodeChunk without the bigint
-			index := trieUtils.GetTreeKeyCodeChunk(addr[:], uint256.NewInt(chunk))
-			statelessGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index, nil)
-		}
-
-	}
-	usedGas, err := gasCodeCopyStateful(evm, contract, stack, mem, memorySize)
-	return usedGas + statelessGas, err
-}
-
-func gasExtCodeCopy(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	var statelessGas uint64
-	if evm.accesses != nil {
-		var (
-			a          = stack.Back(0)
-			codeOffset = stack.Back(2)
-			length     = stack.Back(3)
-		)
-		uint64CodeOffset, overflow := codeOffset.Uint64WithOverflow()
-		if overflow {
-			uint64CodeOffset = 0xffffffffffffffff
-		}
-		uint64CodeEnd, overflow := new(uint256.Int).Add(codeOffset, length).Uint64WithOverflow()
-		if overflow {
-			uint64CodeEnd = 0xffffffffffffffff
-		}
-		addr := common.Address(a.Bytes20())
-		chunk := uint64CodeOffset / 31
-		endChunk := uint64CodeEnd / 31
-		// XXX uint64 overflow in condition check
-		for ; chunk < endChunk; chunk++ {
-			// TODO(@gballet) make a version of GetTreeKeyCodeChunk without the bigint
-			index := trieUtils.GetTreeKeyCodeChunk(addr[:], uint256.NewInt(chunk))
-			statelessGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index, nil)
-		}
-
-	}
-	usedGas, err := gasExtCodeCopyStateful(evm, contract, stack, mem, memorySize)
-	return usedGas + statelessGas, err
-}
-
-func gasSLoad(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	usedGas := uint64(0)
-
-	if evm.accesses != nil {
-		where := stack.Back(0)
-		addr := contract.Address()
-		index := trieUtils.GetTreeKeyStorageSlot(addr[:], where)
-		usedGas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index, nil)
-	}
-
-	return usedGas, nil
-}
-
 func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	// Apply the witness access costs, err is nil
-	accessGas, _ := gasSLoad(evm, contract, stack, mem, memorySize)
 	var (
 		y, x    = stack.Back(1), stack.Back(0)
 		current = evm.StateDB.GetState(contract.Address(), x.Bytes32())
@@ -199,15 +109,14 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 		// 3. From a non-zero to a non-zero                         (CHANGE)
 		switch {
 		case current == (common.Hash{}) && y.Sign() != 0: // 0 => non 0
-			return params.SstoreSetGas + accessGas, nil
+			return params.SstoreSetGas, nil
 		case current != (common.Hash{}) && y.Sign() == 0: // non 0 => 0
 			evm.StateDB.AddRefund(params.SstoreRefundGas)
-			return params.SstoreClearGas + accessGas, nil
+			return params.SstoreClearGas, nil
 		default: // non 0 => non 0 (or 0 => 0)
-			return params.SstoreResetGas + accessGas, nil
+			return params.SstoreResetGas, nil
 		}
 	}
-
 	// The new gas metering is based on net gas costs (EIP-1283):
 	//
 	// 1. If current value equals new value (this is a no-op), 200 gas is deducted.
@@ -422,14 +331,6 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 		transfersValue = !stack.Back(2).IsZero()
 		address        = common.Address(stack.Back(1).Bytes20())
 	)
-	if evm.accesses != nil {
-		// Charge witness costs
-		for i := trieUtils.VersionLeafKey; i <= trieUtils.CodeSizeLeafKey; i++ {
-			index := trieUtils.GetTreeKeyAccountLeaf(address[:], byte(i))
-			gas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index, nil)
-		}
-	}
-
 	if evm.chainRules.IsEIP158 {
 		if transfersValue && evm.StateDB.Empty(address) {
 			gas += params.CallNewAccountGas

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -139,6 +139,8 @@ func gasSLoad(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySiz
 }
 
 func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	// Apply the witness access costs, err is nil
+	accessGas, _ := gasSLoad(evm, contract, stack, mem, memorySize)
 	var (
 		y, x    = stack.Back(1), stack.Back(0)
 		current = evm.StateDB.GetState(contract.Address(), x.Bytes32())
@@ -154,12 +156,12 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 		// 3. From a non-zero to a non-zero                         (CHANGE)
 		switch {
 		case current == (common.Hash{}) && y.Sign() != 0: // 0 => non 0
-			return params.SstoreSetGas, nil
+			return params.SstoreSetGas + accessGas, nil
 		case current != (common.Hash{}) && y.Sign() == 0: // non 0 => 0
 			evm.StateDB.AddRefund(params.SstoreRefundGas)
-			return params.SstoreClearGas, nil
+			return params.SstoreClearGas + accessGas, nil
 		default: // non 0 => non 0 (or 0 => 0)
-			return params.SstoreResetGas, nil
+			return params.SstoreResetGas + accessGas, nil
 		}
 	}
 	// The new gas metering is based on net gas costs (EIP-1283):

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -402,6 +402,22 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
 		return 0, ErrGasUintOverflow
 	}
+
+	sourceAddrBytes := contract.Address().Bytes()
+        if evm.Accesses != nil {
+                // touch the balance
+                index := trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.BalanceLeafKey)
+                gas += evm.Accesses.TouchAddressAndChargeGas(index, nil)
+                // touch the nonce
+                index = trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.BalanceLeafKey)
+                gas += evm.Accesses.TouchAddressAndChargeGas(index, nil)
+                // touch the code hash
+                index = trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.CodeKeccakLeafKey)
+                gas += evm.Accesses.TouchAddressAndChargeGas(index, nil)
+                // touch the code size
+                index = trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.CodeSizeLeafKey)
+		gas += evm.Accesses.TouchAddressAndChargeGas(index, nil)
+        }
 	return gas, nil
 }
 

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -403,21 +403,6 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 		return 0, ErrGasUintOverflow
 	}
 
-	sourceAddrBytes := contract.Address().Bytes()
-        if evm.Accesses != nil {
-                // touch the balance
-                index := trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.BalanceLeafKey)
-                gas += evm.Accesses.TouchAddressAndChargeGas(index, nil)
-                // touch the nonce
-                index = trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.BalanceLeafKey)
-                gas += evm.Accesses.TouchAddressAndChargeGas(index, nil)
-                // touch the code hash
-                index = trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.CodeKeccakLeafKey)
-                gas += evm.Accesses.TouchAddressAndChargeGas(index, nil)
-                // touch the code size
-                index = trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.CodeSizeLeafKey)
-		gas += evm.Accesses.TouchAddressAndChargeGas(index, nil)
-        }
 	return gas, nil
 }
 

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -148,7 +148,7 @@ func gasExtCodeCopy(evm *EVM, contract *Contract, stack *Stack, mem *Memory, mem
 		// behavior from CODECOPY which only charges witness access costs for the part of the range
 		// which overlaps in the account code.  TODO: clarify this is desired behavior and amend the
 		// spec.
-		statelessGas = touchEachChunksAndChargeGas(offset, nonPaddedSize, nil, nil, evm.Accesses)
+		statelessGas = touchEachChunksAndChargeGas(uint64CodeOffset, uint64Length, nil, nil, evm.Accesses)
 	}
 	usedGas, err := gasExtCodeCopyStateful(evm, contract, stack, mem, memorySize)
 	return usedGas + statelessGas, err

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -88,10 +88,10 @@ func memoryCopierGas(stackpos int) gasFunc {
 }
 
 var (
-	gasCallDataCopy   = memoryCopierGas(2)
-	gasCodeCopyStateful       = memoryCopierGas(2)
-	gasExtCodeCopyStateful    = memoryCopierGas(3)
-	gasReturnDataCopy = memoryCopierGas(2)
+	gasCallDataCopy        = memoryCopierGas(2)
+	gasCodeCopyStateful    = memoryCopierGas(2)
+	gasExtCodeCopyStateful = memoryCopierGas(3)
+	gasReturnDataCopy      = memoryCopierGas(2)
 )
 
 func gasCodeCopy(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -375,8 +375,7 @@ func opCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 
 	paddedCodeCopy, copyOffset, nonPaddedCopyLength := getDataAndAdjustedBounds(scope.Contract.Code, uint64CodeOffset, length.Uint64())
 	if interpreter.evm.Accesses != nil {
-		statelessGas := touchEachChunksAndChargeGas(copyOffset, nonPaddedCopyLength, scope.Contract.Address().Bytes()[:], scope.Contract, interpreter.evm.Accesses)
-		scope.Contract.UseGas(statelessGas)
+		touchEachChunksAndChargeGas(copyOffset, nonPaddedCopyLength, scope.Contract.Address().Bytes()[:], scope.Contract, interpreter.evm.Accesses)
 	}
 	scope.Memory.Set(memOffset.Uint64(), uint64(len(paddedCodeCopy)), paddedCodeCopy)
 	return nil, nil
@@ -602,8 +601,7 @@ func opSload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 
 	if interpreter.evm.Accesses != nil {
 		index := trieUtils.GetTreeKeyStorageSlot(scope.Contract.Address().Bytes(), loc)
-		statelessGas := interpreter.evm.Accesses.TouchAddressAndChargeGas(index, val.Bytes())
-		scope.Contract.UseGas(statelessGas)
+		interpreter.evm.Accesses.TouchAddressAndChargeGas(index, val.Bytes())
 	}
 	return nil, nil
 }

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -766,8 +766,6 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 		bigVal = value.ToBig()
 	}
 
-
-
 	ret, returnGas, err := interpreter.evm.Call(scope.Contract, toAddr, args, gas, bigVal)
 
 	if err != nil {

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -346,9 +346,9 @@ func opReturnDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	slot := scope.Stack.peek()
 	cs := uint64(interpreter.evm.StateDB.GetCodeSize(slot.Bytes20()))
-	if interpreter.evm.TxContext.Accesses != nil {
+	if interpreter.evm.Accesses != nil {
 		index := trieUtils.GetTreeKeyCodeSize(slot.Bytes())
-		statelessGas := interpreter.evm.TxContext.Accesses.TouchAddressAndChargeGas(index, uint256.NewInt(cs).Bytes())
+		statelessGas := interpreter.evm.Accesses.TouchAddressAndChargeGas(index, uint256.NewInt(cs).Bytes())
 		scope.Contract.UseGas(statelessGas)
 	}
 	slot.SetUint64(cs)
@@ -374,7 +374,7 @@ func opCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	}
 
 	paddedCodeCopy, copyOffset, nonPaddedCopyLength := getDataAndAdjustedBounds(scope.Contract.Code, uint64CodeOffset, length.Uint64())
-	if interpreter.evm.TxContext.Accesses != nil {
+	if interpreter.evm.Accesses != nil {
 		statelessGas := touchEachChunksAndChargeGas(copyOffset, nonPaddedCopyLength, scope.Contract.Address().Bytes()[:], scope.Contract, interpreter.evm.Accesses)
 		scope.Contract.UseGas(statelessGas)
 	}
@@ -461,7 +461,7 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 		uint64CodeOffset = 0xffffffffffffffff
 	}
 	addr := common.Address(a.Bytes20())
-	if interpreter.evm.TxContext.Accesses != nil {
+	if interpreter.evm.Accesses != nil {
 		panic("extcodecopy not implemented for verkle")
 	} else {
 		codeCopy := getData(interpreter.evm.StateDB.GetCode(addr), uint64CodeOffset, length.Uint64())
@@ -595,9 +595,9 @@ func opSload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	val := interpreter.evm.StateDB.GetState(scope.Contract.Address(), hash)
 	loc.SetBytes(val.Bytes())
 
-	if interpreter.evm.TxContext.Accesses != nil {
+	if interpreter.evm.Accesses != nil {
 		index := trieUtils.GetTreeKeyStorageSlot(scope.Contract.Address().Bytes(), loc)
-		statelessGas := interpreter.evm.TxContext.Accesses.TouchAddressAndChargeGas(index, val.Bytes())
+		statelessGas := interpreter.evm.Accesses.TouchAddressAndChargeGas(index, val.Bytes())
 		scope.Contract.UseGas(statelessGas)
 	}
 	return nil, nil
@@ -989,7 +989,7 @@ func opPush1(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 			}
 			copy(value[1:], scope.Contract.Code[chunk*31:endMin])
 			index := trieUtils.GetTreeKeyCodeChunk(scope.Contract.Address().Bytes(), uint256.NewInt(chunk))
-			statelessGas := interpreter.evm.TxContext.Accesses.TouchAddressAndChargeGas(index, nil)
+			statelessGas := interpreter.evm.Accesses.TouchAddressAndChargeGas(index, nil)
 			scope.Contract.UseGas(statelessGas)
 		}
 	} else {
@@ -1013,8 +1013,8 @@ func makePush(size uint64, pushByteSize int) executionFunc {
 			endMin = startMin + pushByteSize
 		}
 
-		if interpreter.evm.TxContext.Accesses != nil {
-			statelessGas := touchEachChunksAndChargeGas(uint64(startMin), uint64(pushByteSize), scope.Contract.Address().Bytes()[:], scope.Contract, interpreter.evm.TxContext.Accesses)
+		if interpreter.evm.Accesses != nil {
+			statelessGas := touchEachChunksAndChargeGas(uint64(startMin), uint64(pushByteSize), scope.Contract.Address().Bytes()[:], scope.Contract, interpreter.evm.Accesses)
 			scope.Contract.UseGas(statelessGas)
 		}
 

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -403,7 +403,7 @@ func touchEachChunksAndChargeGas(offset, size uint64, address []byte, contract *
 	}
 	var code []byte
 	if contract != nil {
-		code := contract.Code[:]
+		code = contract.Code[:]
 	}
 	numLeaves := (end - start) / 31
 	index := make([]byte, 32, 32)
@@ -763,31 +763,23 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
                 // touch the balance
                 index := trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.BalanceLeafKey)
                 balanceBytes := padBigInt(interpreter.evm.StateDB.GetBalance(scope.Contract.Address()))
-                if !scope.Contract.UseGas(interpreter.evm.Accesses.TouchAddressAndChargeGas(index, balanceBytes[:])) {
-			return nil, ErrOutOfGas
-		}
+                interpreter.evm.Accesses.TouchAddress(index, balanceBytes[:])
                 // touch the nonce
                 index = trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.BalanceLeafKey)
                 nonceBytes := [32]byte{}
                 nonce := interpreter.evm.StateDB.GetNonce(scope.Contract.Address())
 		binary.BigEndian.PutUint64(nonceBytes[24:32], nonce)
-                if !scope.Contract.UseGas(interpreter.evm.Accesses.TouchAddressAndChargeGas(index, nonceBytes[:])) {
-			return nil, ErrOutOfGas
-		}
+                interpreter.evm.Accesses.TouchAddress(index, nonceBytes[:])
                 // touch the code hash
                 index = trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.CodeKeccakLeafKey)
                 codeHash := interpreter.evm.StateDB.GetCodeHash(scope.Contract.Address())
-                if !scope.Contract.UseGas(interpreter.evm.Accesses.TouchAddressAndChargeGas(index, codeHash[:])) {
-			return nil, ErrOutOfGas
-		}
+                interpreter.evm.Accesses.TouchAddress(index, codeHash[:])
                 // set the code size
                 index = trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.CodeSizeLeafKey)
                 codeSize := uint64(interpreter.evm.StateDB.GetCodeSize(scope.Contract.Address()))
                 codeSizeLeafBytes := [32]byte{}
 		binary.BigEndian.PutUint64(codeSizeLeafBytes[24:32], codeSize)
-		if !scope.Contract.UseGas(interpreter.evm.Accesses.TouchAddressAndChargeGas(index, codeSizeLeafBytes[:])) {
-			return nil, ErrOutOfGas
-		}
+		interpreter.evm.Accesses.TouchAddress(index, codeSizeLeafBytes[:])
         }
 
 	var bigVal = big0

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -757,29 +757,6 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
 	sourceAddrBytes := scope.Contract.Address().Bytes()
 
-        if interpreter.evm.Accesses != nil {
-                // touch the balance
-                index := trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.BalanceLeafKey)
-                balanceBytes := padBigInt(interpreter.evm.StateDB.GetBalance(scope.Contract.Address()))
-                interpreter.evm.Accesses.TouchAddress(index, balanceBytes[:])
-                // touch the nonce
-                index = trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.BalanceLeafKey)
-                nonceBytes := [32]byte{}
-                nonce := interpreter.evm.StateDB.GetNonce(scope.Contract.Address())
-		binary.BigEndian.PutUint64(nonceBytes[24:32], nonce)
-                interpreter.evm.Accesses.TouchAddress(index, nonceBytes[:])
-                // touch the code hash
-                index = trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.CodeKeccakLeafKey)
-                codeHash := interpreter.evm.StateDB.GetCodeHash(scope.Contract.Address())
-                interpreter.evm.Accesses.TouchAddress(index, codeHash[:])
-                // set the code size
-                index = trieUtils.GetTreeKeyAccountLeaf(sourceAddrBytes, trieUtils.CodeSizeLeafKey)
-                codeSize := uint64(interpreter.evm.StateDB.GetCodeSize(scope.Contract.Address()))
-                codeSizeLeafBytes := [32]byte{}
-		binary.BigEndian.PutUint64(codeSizeLeafBytes[24:32], codeSize)
-		interpreter.evm.Accesses.TouchAddress(index, codeSizeLeafBytes[:])
-        }
-
 	var bigVal = big0
 	//TODO: use uint256.Int instead of converting with toBig()
 	// By using big0 here, we save an alloc for the most common case (non-ether-transferring contract calls),

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -19,6 +19,7 @@ package vm
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	trieUtils "github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/holiman/uint256"

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -433,6 +433,7 @@ func newFrontierInstructionSet() JumpTable {
 		EXTCODESIZE: {
 			execute:     opExtCodeSize,
 			constantGas: params.ExtcodeSizeGasFrontier,
+			dynamicGas:  gasExtCodeSize,
 			minStack:    minStack(1, 1),
 			maxStack:    maxStack(1, 1),
 		},
@@ -513,6 +514,7 @@ func newFrontierInstructionSet() JumpTable {
 		SLOAD: {
 			execute:     opSload,
 			constantGas: params.SloadGasFrontier,
+			dynamicGas:  gasSLoad,
 			minStack:    minStack(1, 1),
 			maxStack:    maxStack(1, 1),
 		},

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -433,7 +433,6 @@ func newFrontierInstructionSet() JumpTable {
 		EXTCODESIZE: {
 			execute:     opExtCodeSize,
 			constantGas: params.ExtcodeSizeGasFrontier,
-			dynamicGas:  gasExtCodeSize,
 			minStack:    minStack(1, 1),
 			maxStack:    maxStack(1, 1),
 		},
@@ -514,7 +513,6 @@ func newFrontierInstructionSet() JumpTable {
 		SLOAD: {
 			execute:     opSload,
 			constantGas: params.SloadGasFrontier,
-			dynamicGas:  gasSLoad,
 			minStack:    minStack(1, 1),
 			maxStack:    maxStack(1, 1),
 		},


### PR DESCRIPTION
Moves witness accumulation logic that involves touching a range of EVM code that can span multiple tree leaves into its own method.

There's some other unrelated changes packaged in with this one:
* charge witness gas costs for `PUSH`
* ~~move all witness gas charging out of `gas_table.go` and into `instructions.go`~~
* adds missing checks elsewhere to only build witnesses when verkle is enabled.