### PR TITLE
Message call witness gas charging

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -328,31 +328,33 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 			}
 
 			// Generate an associated verkle proof
-			if tr := statedb.GetTrie(); tr.IsVerkle() {
-				vtr := tr.(*trie.VerkleTrie)
-				// Generate the proof if we are using a verkle tree
-				// WORKAROUND: make sure all keys are resolved
-				// before building the proof. Ultimately, node
-				// resolution can be done with a prefetcher or
-				// from GetCommitmentsAlongPath.
+			/*
+				if tr := statedb.GetTrie(); tr.IsVerkle() {
+					vtr := tr.(*trie.VerkleTrie)
+					// Generate the proof if we are using a verkle tree
+					// WORKAROUND: make sure all keys are resolved
+					// before building the proof. Ultimately, node
+					// resolution can be done with a prefetcher or
+					// from GetCommitmentsAlongPath.
 
-				keys := statedb.Witness().Keys()
-				for _, key := range keys {
-					out, err := vtr.TryGet(key)
+					keys := statedb.Witness().Keys()
+					for _, key := range keys {
+						out, err := vtr.TryGet(key)
+						if err != nil {
+							panic(err)
+						}
+						if len(out) == 0 {
+							panic(fmt.Sprintf("%x should be present in the tree", key))
+						}
+					}
+					vtr.Hash()
+					_, err := vtr.ProveAndSerialize(keys, statedb.Witness().KeyVals())
+					//block.SetVerkleProof(p)
 					if err != nil {
 						panic(err)
 					}
-					if len(out) == 0 {
-						panic(fmt.Sprintf("%x should be present in the tree", key))
-					}
 				}
-				vtr.Hash()
-				_, err := vtr.ProveAndSerialize(keys, statedb.Witness().KeyVals())
-				//block.SetVerkleProof(p)
-				if err != nil {
-					panic(err)
-				}
-			}
+			*/
 			return block, b.receipts
 		}
 		return nil, nil

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
-	trieUtils "github.com/ethereum/go-ethereum/trie/utils"
 )
 
 var emptyCodeHash = crypto.Keccak256Hash(nil)
@@ -261,6 +260,19 @@ func (st *StateTransition) preCheck() error {
 	return st.buyGas()
 }
 
+// tryConsumeGas tries to subtract gas from gasPool, setting the result in gasPool
+// if subtracting more gas than remains in gasPool, set gasPool = 0 and return false
+// otherwise, do the subtraction setting the result in gasPool and return true
+func tryConsumeGas(gasPool *uint64, gas uint64) bool {
+	if *gasPool < gas {
+		*gasPool = 0
+		return false
+	}
+
+	*gasPool -= gas
+	return true
+}
+
 // TransitionDb will transition the state by applying the current message and
 // returning the evm execution result with following fields.
 //
@@ -304,26 +316,34 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	if st.gas < gas {
 		return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, gas)
 	}
-	if st.evm.ChainConfig().IsCancun(st.evm.Context.BlockNumber) {
-		if msg.To() != nil {
-			toBalance := trieUtils.GetTreeKeyBalance(msg.To().Bytes())
-			pre := st.state.GetBalance(*msg.To())
-			gas += st.evm.Accesses.TouchAddressAndChargeGas(toBalance, pre.Bytes())
+	if st.evm.Accesses != nil {
+		var targetBalance, targetNonce, targetCodeSize, targetCodeKeccak, originBalance, originNonce []byte
 
-			// NOTE: Nonce also needs to be charged, because it is needed for execution
-			// on the statless side.
-			var preTN [8]byte
-			fromNonce := trieUtils.GetTreeKeyNonce(msg.To().Bytes())
-			binary.BigEndian.PutUint64(preTN[:], st.state.GetNonce(*msg.To()))
-			gas += st.evm.Accesses.TouchAddressAndChargeGas(fromNonce, preTN[:])
+		targetAddr := msg.To()
+		originAddr := msg.From()
+
+		statelessGasOrigin := st.evm.Accesses.TouchTxOriginAndChargeGas(originAddr.Bytes())
+		if !tryConsumeGas(&st.gas, statelessGasOrigin) {
+			return nil, fmt.Errorf("insufficient gas to cover witness access costs")
 		}
-		fromBalance := trieUtils.GetTreeKeyBalance(msg.From().Bytes())
-		preFB := st.state.GetBalance(msg.From()).Bytes()
-		fromNonce := trieUtils.GetTreeKeyNonce(msg.From().Bytes())
-		var preFN [8]byte
-		binary.BigEndian.PutUint64(preFN[:], st.state.GetNonce(msg.From()))
-		gas += st.evm.Accesses.TouchAddressAndChargeGas(fromNonce, preFN[:])
-		gas += st.evm.Accesses.TouchAddressAndChargeGas(fromBalance, preFB[:])
+		originBalance = st.evm.StateDB.GetBalanceLittleEndian(originAddr)
+		originNonce = st.evm.StateDB.GetNonceLittleEndian(originAddr)
+		st.evm.Accesses.SetTxTouchedLeaves(originAddr.Bytes(), originBalance, originNonce)
+
+		if msg.To() != nil {
+			statelessGasDest := st.evm.Accesses.TouchTxExistingAndChargeGas(targetAddr.Bytes())
+			if !tryConsumeGas(&st.gas, statelessGasDest) {
+				return nil, fmt.Errorf("insufficient gas to cover witness access costs")
+			}
+			targetBalance = st.evm.StateDB.GetBalanceLittleEndian(*targetAddr)
+			targetNonce = st.evm.StateDB.GetNonceLittleEndian(*targetAddr)
+			targetCodeKeccak = st.evm.StateDB.GetCodeHash(*targetAddr).Bytes()
+
+			codeSize := uint64(st.evm.StateDB.GetCodeSize(*targetAddr))
+			var codeSizeBytes [32]byte
+			binary.LittleEndian.PutUint64(codeSizeBytes[:8], codeSize)
+			st.evm.Accesses.SetTxExistingTouchedLeaves(targetAddr.Bytes(), targetBalance, targetNonce, targetCodeSize, targetCodeKeccak)
+		}
 	}
 	st.gas -= gas
 

--- a/core/types/access_witness.go
+++ b/core/types/access_witness.go
@@ -19,6 +19,7 @@ package types
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/trie/utils"
 )
 
 // AccessWitness lists the locations of the state that are being accessed
@@ -43,6 +44,125 @@ func NewAccessWitness() *AccessWitness {
 		Chunks:    make(map[common.Hash][]byte),
 		Undefined: make(map[common.Hash]struct{}),
 	}
+}
+
+// TODO TouchAndCharge + SetLeafValue* does redundant calls to GetTreeKey*
+
+func (aw *AccessWitness) TouchAndChargeProofOfAbsence(addr []byte) uint64 {
+	var gas uint64
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyVersion(addr[:]), nil)
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyBalance(addr[:]), nil)
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyCodeSize(addr[:]), nil)
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyCodeKeccak(addr[:]), nil)
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyNonce(addr[:]), nil)
+	return gas
+}
+
+func (aw *AccessWitness) TouchAndChargeMessageCall(addr []byte) uint64 {
+	var gas uint64
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyVersion(addr[:]), nil)
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyCodeSize(addr[:]), nil)
+	return gas
+}
+
+func (aw *AccessWitness) SetLeafValuesMessageCall(addr, codeSize []byte) {
+	var data [32]byte
+	aw.TouchAddress(utils.GetTreeKeyVersion(addr[:]), data[:])
+	aw.TouchAddress(utils.GetTreeKeyCodeSize(addr[:]), codeSize[:])
+}
+
+func (aw *AccessWitness) TouchAndChargeValueTransfer(callerAddr, targetAddr []byte) uint64 {
+	var gas uint64
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyBalance(callerAddr[:]), nil)
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyBalance(targetAddr[:]), nil)
+	return gas
+}
+
+func (aw *AccessWitness) SetLeafValuesValueTransfer(callerAddr, targetAddr, callerBalance, targetBalance []byte) {
+	aw.TouchAddress(utils.GetTreeKeyBalance(callerAddr[:]), callerBalance)
+	aw.TouchAddress(utils.GetTreeKeyBalance(targetAddr[:]), targetBalance)
+}
+
+// TouchAndChargeContractCreateInit charges access costs to initiate
+// a contract creation
+func (aw *AccessWitness) TouchAndChargeContractCreateInit(addr []byte) uint64 {
+	var gas uint64
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyVersion(addr[:]), nil)
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyNonce(addr[:]), nil)
+	return gas
+}
+
+func (aw *AccessWitness) SetLeafValuesContractCreateInit(addr, nonce []byte) {
+	var version [32]byte
+	aw.TouchAddress(utils.GetTreeKeyVersion(addr[:]), version[:])
+	aw.TouchAddress(utils.GetTreeKeyNonce(addr[:]), nonce)
+}
+
+// TouchAndChargeContractCreateCompleted charges access access costs after
+// the completion of a contract creation to populate the created account in
+// the tree
+func (aw *AccessWitness) TouchAndChargeContractCreateCompleted(addr []byte, withValue bool) uint64 {
+	var gas uint64
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyVersion(addr[:]), nil)
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyNonce(addr[:]), nil)
+	if withValue {
+		gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyBalance(addr[:]), nil)
+	}
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyCodeSize(addr[:]), nil)
+	gas += aw.TouchAddressAndChargeGas(utils.GetTreeKeyCodeKeccak(addr[:]), nil)
+	return gas
+}
+
+func (aw *AccessWitness) SetLeafValuesContractCreateCompleted(addr, codeSize, codeKeccak []byte) {
+	aw.TouchAddress(utils.GetTreeKeyCodeSize(addr[:]), codeSize)
+	aw.TouchAddress(utils.GetTreeKeyCodeKeccak(addr[:]), codeKeccak)
+}
+
+func (aw *AccessWitness) TouchTxAndChargeGas(originAddr, targetAddr []byte) uint64 {
+	var gasUsed uint64
+	var version [32]byte
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyVersion(originAddr[:]), version[:])
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyBalance(originAddr[:]), nil)
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyNonce(originAddr[:]), nil)
+
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyVersion(targetAddr[:]), version[:])
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyBalance(targetAddr[:]), nil)
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyNonce(targetAddr[:]), nil)
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyCodeSize(targetAddr[:]), nil)
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyCodeKeccak(targetAddr[:]), nil)
+	return gasUsed
+}
+
+func (aw *AccessWitness) TouchTxOriginAndChargeGas(originAddr []byte) uint64 {
+	var gasUsed uint64
+	var version [32]byte
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyVersion(originAddr[:]), version[:])
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyBalance(originAddr[:]), nil)
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyNonce(originAddr[:]), nil)
+	return gasUsed
+}
+
+func (aw *AccessWitness) TouchTxExistingAndChargeGas(targetAddr []byte) uint64 {
+	var gasUsed uint64
+	var version [32]byte
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyVersion(targetAddr[:]), version[:])
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyBalance(targetAddr[:]), nil)
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyNonce(targetAddr[:]), nil)
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyCodeSize(targetAddr[:]), nil)
+	gasUsed += aw.TouchAddressAndChargeGas(utils.GetTreeKeyCodeKeccak(targetAddr[:]), nil)
+	return gasUsed
+}
+
+func (aw *AccessWitness) SetTxTouchedLeaves(originAddr, originBalance, originNonce []byte) {
+	aw.TouchAddress(utils.GetTreeKeyBalance(originAddr[:]), originBalance)
+	aw.TouchAddress(utils.GetTreeKeyNonce(originAddr[:]), originNonce)
+}
+
+func (aw *AccessWitness) SetTxExistingTouchedLeaves(targetAddr, targetBalance, targetNonce, targetCodeSize, targetCodeHash []byte) {
+	aw.TouchAddress(utils.GetTreeKeyBalance(targetAddr[:]), targetBalance)
+	aw.TouchAddress(utils.GetTreeKeyNonce(targetAddr[:]), targetNonce)
+	aw.TouchAddress(utils.GetTreeKeyCodeSize(targetAddr[:]), targetCodeSize)
+	aw.TouchAddress(utils.GetTreeKeyCodeKeccak(targetAddr[:]), targetCodeHash)
 }
 
 // TouchAddress adds any missing addr to the witness and returns respectively

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -202,6 +202,10 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 
 	if !evm.StateDB.Exist(addr) {
 		if !isPrecompile && evm.chainRules.IsEIP158 && value.Sign() == 0 {
+			if evm.Accesses != nil {
+				// proof of absence
+				tryConsumeGas(&gas, evm.Accesses.TouchAndChargeProofOfAbsence(caller.Address().Bytes()))
+			}
 			// Calling a non existing account, don't do anything, but ping the tracer
 			if evm.Config.Debug {
 				if evm.depth == 0 {
@@ -214,7 +218,13 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 			}
 			return nil, gas, nil
 		}
+
 		evm.StateDB.CreateAccount(addr)
+	}
+	if evm.Accesses != nil && value.Sign() != 0 {
+		callerBalanceBefore := evm.StateDB.GetBalanceLittleEndian(caller.Address())
+		targetBalanceBefore := evm.StateDB.GetBalanceLittleEndian(addr)
+		evm.Accesses.SetLeafValuesValueTransfer(caller.Address().Bytes()[:], addr[:], callerBalanceBefore, targetBalanceBefore)
 	}
 	evm.Context.Transfer(evm.StateDB, caller.Address(), addr, value)
 
@@ -240,21 +250,16 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
 		code := evm.StateDB.GetCode(addr)
+		if evm.Accesses != nil {
+			codeSize := uint64(len(code))
+			var codeSizeBytes [32]byte
+			binary.LittleEndian.PutUint64(codeSizeBytes[:8], codeSize)
+			evm.Accesses.SetLeafValuesMessageCall(addr[:], codeSizeBytes[:])
+		}
+
 		if len(code) == 0 {
 			ret, err = nil, nil // gas is unchanged
 		} else {
-			if evm.chainConfig.IsCancun(evm.Context.BlockNumber) {
-				// Touch the account data
-				var data [32]byte
-				evm.Accesses.TouchAddress(utils.GetTreeKeyVersion(addr.Bytes()), data[:])
-				binary.BigEndian.PutUint64(data[:], evm.StateDB.GetNonce(addr))
-				evm.Accesses.TouchAddress(utils.GetTreeKeyNonce(addr[:]), data[:])
-				evm.Accesses.TouchAddress(utils.GetTreeKeyBalance(addr[:]), evm.StateDB.GetBalance(addr).Bytes())
-				binary.BigEndian.PutUint64(data[:], uint64(len(code)))
-				evm.Accesses.TouchAddress(utils.GetTreeKeyCodeSize(addr[:]), data[:])
-				evm.Accesses.TouchAddress(utils.GetTreeKeyCodeKeccak(addr[:]), evm.StateDB.GetCodeHash(addr).Bytes())
-			}
-
 			addrCopy := addr
 			// If the account has no code, we can abort here
 			// The depth-check is already done, and precompiles handled above
@@ -316,6 +321,12 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
 		ret, gas, err = RunPrecompiledContract(p, input, gas)
 	} else {
+		if evm.Accesses != nil {
+			codeSize := uint64(evm.StateDB.GetCodeSize(addr))
+			var codeSizeBytes [32]byte
+			binary.LittleEndian.PutUint64(codeSizeBytes[:8], codeSize)
+			evm.Accesses.SetLeafValuesMessageCall(addr.Bytes()[:], codeSizeBytes[:])
+		}
 		addrCopy := addr
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
@@ -360,6 +371,12 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
 		ret, gas, err = RunPrecompiledContract(p, input, gas)
 	} else {
+		if evm.Accesses != nil {
+			codeSize := uint64(evm.StateDB.GetCodeSize(addr))
+			var codeSizeBytes [32]byte
+			binary.LittleEndian.PutUint64(codeSizeBytes[:8], codeSize)
+			evm.Accesses.SetLeafValuesMessageCall(addr.Bytes()[:], codeSizeBytes[:])
+		}
 		addrCopy := addr
 		// Initialise a new contract and make initialise the delegate values
 		contract := NewContract(caller, AccountRef(caller.Address()), nil, gas).AsDelegate()
@@ -412,6 +429,12 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
 		ret, gas, err = RunPrecompiledContract(p, input, gas)
 	} else {
+		if evm.Accesses != nil {
+			codeSize := uint64(evm.StateDB.GetCodeSize(addr))
+			var codeSizeBytes [32]byte
+			binary.LittleEndian.PutUint64(codeSizeBytes[:8], codeSize)
+			evm.Accesses.SetLeafValuesMessageCall(addr.Bytes()[:], codeSizeBytes[:])
+		}
 		// At this point, we use a copy of address. If we don't, the go compiler will
 		// leak the 'contract' to the outer scope, and make allocation for 'contract'
 		// even if the actual execution ends on RunPrecompiled above.
@@ -449,6 +472,13 @@ func (c *codeAndHash) Hash() common.Hash {
 
 // create creates a new contract using code as deployment code.
 func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64, value *big.Int, address common.Address, typ OpCode) ([]byte, common.Address, uint64, error) {
+	var zeroVerkleLeaf [32]byte
+	var balanceBefore []byte
+
+	if evm.Accesses != nil {
+		evm.Accesses.SetLeafValuesContractCreateInit(address.Bytes()[:], zeroVerkleLeaf[:])
+	}
+
 	// Depth check execution. Fail if we're trying to execute above the
 	// limit.
 	if evm.depth > int(params.CallCreateDepth) {
@@ -478,6 +508,14 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	if evm.chainRules.IsEIP158 {
 		evm.StateDB.SetNonce(address, 1)
 	}
+	if evm.Accesses != nil {
+		// note: assumption is that the nonce, code size, code hash
+		// will be 0x0000...00 at the target account before it is created
+		// otherwise would imply contract creation collision which is
+		// impossible if self-destruct is removed
+		balanceBefore = evm.StateDB.GetBalanceLittleEndian(address)
+	}
+
 	evm.Context.Transfer(evm.StateDB, caller.Address(), address, value)
 
 	// Initialise a new contract and set the code that is to be used by the EVM.
@@ -532,6 +570,18 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		evm.StateDB.RevertToSnapshot(snapshot)
 		if err != ErrExecutionReverted {
 			contract.UseGas(contract.Gas)
+		}
+	}
+
+	if err == nil && evm.Accesses != nil {
+		if !contract.UseGas(evm.Accesses.TouchAndChargeContractCreateCompleted(address.Bytes()[:], value.Sign() != 0)) {
+			evm.StateDB.RevertToSnapshot(snapshot)
+			err = ErrOutOfGas
+		} else {
+			evm.Accesses.SetLeafValuesContractCreateCompleted(address.Bytes()[:], zeroVerkleLeaf[:], zeroVerkleLeaf[:])
+			if value.Sign() != 0 {
+				evm.Accesses.TouchAddress(utils.GetTreeKeyBalance(address.Bytes()[:]), balanceBefore)
+			}
 		}
 	}
 

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	trieUtils "github.com/ethereum/go-ethereum/trie/utils"
 )
@@ -350,13 +351,36 @@ func pureMemoryGascost(evm *EVM, contract *Contract, stack *Stack, mem *Memory, 
 }
 
 var (
-	gasReturn  = pureMemoryGascost
-	gasRevert  = pureMemoryGascost
-	gasMLoad   = pureMemoryGascost
-	gasMStore8 = pureMemoryGascost
-	gasMStore  = pureMemoryGascost
-	gasCreate  = pureMemoryGascost
+	gasReturn         = pureMemoryGascost
+	gasRevert         = pureMemoryGascost
+	gasMLoad          = pureMemoryGascost
+	gasMStore8        = pureMemoryGascost
+	gasMStore         = pureMemoryGascost
+	statefulGasCreate = pureMemoryGascost
 )
+
+func gasCreate(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	var gasUsed uint64
+	if gasUsed, err := statefulGasCreate(evm, contract, stack, mem, memorySize); err != nil {
+		return gasUsed, err
+	}
+
+	if evm.Accesses != nil {
+		var overflow bool
+		statelessGas := evm.Accesses.TouchAndChargeContractCreateInit(contract.Address().Bytes()[:])
+		if gasUsed, overflow = math.SafeAdd(gasUsed, statelessGas); overflow {
+			return 0, ErrGasUintOverflow
+		}
+		if stack.Back(0).Sign() != 0 {
+			valueTransferGas := evm.Accesses.TouchAddressAndChargeGas(contract.Address().Bytes()[:], nil)
+			if gasUsed, overflow = math.SafeAdd(gasUsed, valueTransferGas); overflow {
+				return 0, ErrGasUintOverflow
+			}
+		}
+	}
+
+	return gasUsed, nil
+}
 
 func gasCreate2(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	gas, err := memoryGasCost(mem, memorySize)
@@ -372,6 +396,19 @@ func gasCreate2(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memoryS
 	}
 	if gas, overflow = math.SafeAdd(gas, wordGas); overflow {
 		return 0, ErrGasUintOverflow
+	}
+	if evm.Accesses != nil {
+		var overflow bool
+		statelessGas := evm.Accesses.TouchAndChargeContractCreateInit(contract.Address().Bytes()[:])
+		if gas, overflow = math.SafeAdd(gas, statelessGas); overflow {
+			return 0, ErrGasUintOverflow
+		}
+		if stack.Back(0).Sign() != 0 {
+			valueTransferGas := evm.Accesses.TouchAddressAndChargeGas(contract.Address().Bytes()[:], nil)
+			if gas, overflow = math.SafeAdd(gas, valueTransferGas); overflow {
+				return 0, ErrGasUintOverflow
+			}
+		}
 	}
 	return gas, nil
 }
@@ -408,13 +445,6 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 		transfersValue = !stack.Back(2).IsZero()
 		address        = common.Address(stack.Back(1).Bytes20())
 	)
-	if evm.chainConfig.IsCancun(evm.Context.BlockNumber) {
-		// Charge witness costs
-		for i := trieUtils.VersionLeafKey; i <= trieUtils.CodeSizeLeafKey; i++ {
-			index := trieUtils.GetTreeKeyAccountLeaf(address[:], byte(i))
-			gas += evm.TxContext.Accesses.TouchAddressAndChargeGas(index, nil)
-		}
-	}
 
 	if evm.chainRules.IsEIP158 {
 		if transfersValue && evm.StateDB.Empty(address) {
@@ -442,6 +472,20 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
 		return 0, ErrGasUintOverflow
 	}
+	if evm.Accesses != nil {
+		if _, isPrecompile := evm.precompile(address); !isPrecompile {
+			gas, overflow = math.SafeAdd(gas, evm.Accesses.TouchAndChargeMessageCall(address.Bytes()[:]))
+			if overflow {
+				return 0, ErrGasUintOverflow
+			}
+		}
+		if transfersValue {
+			gas, overflow = math.SafeAdd(gas, evm.Accesses.TouchAndChargeValueTransfer(contract.Address().Bytes()[:], address.Bytes()[:]))
+			if overflow {
+				return 0, ErrGasUintOverflow
+			}
+		}
+	}
 
 	return gas, nil
 }
@@ -468,6 +512,15 @@ func gasCallCode(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
 	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
 		return 0, ErrGasUintOverflow
 	}
+	if evm.Accesses != nil {
+		address := common.Address(stack.Back(1).Bytes20())
+		if _, isPrecompile := evm.precompile(address); !isPrecompile {
+			gas, overflow = math.SafeAdd(gas, evm.Accesses.TouchAndChargeMessageCall(address.Bytes()))
+			if overflow {
+				return 0, ErrGasUintOverflow
+			}
+		}
+	}
 	return gas, nil
 }
 
@@ -484,6 +537,15 @@ func gasDelegateCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
 		return 0, ErrGasUintOverflow
 	}
+	if evm.Accesses != nil {
+		address := common.Address(stack.Back(1).Bytes20())
+		if _, isPrecompile := evm.precompile(address); !isPrecompile {
+			gas, overflow = math.SafeAdd(gas, evm.Accesses.TouchAndChargeMessageCall(address.Bytes()))
+			if overflow {
+				return 0, ErrGasUintOverflow
+			}
+		}
+	}
 	return gas, nil
 }
 
@@ -499,6 +561,15 @@ func gasStaticCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memo
 	var overflow bool
 	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
 		return 0, ErrGasUintOverflow
+	}
+	if evm.Accesses != nil {
+		address := common.Address(stack.Back(1).Bytes20())
+		if _, isPrecompile := evm.precompile(address); !isPrecompile {
+			gas, overflow = math.SafeAdd(gas, evm.Accesses.TouchAndChargeMessageCall(address.Bytes()))
+			if overflow {
+				return 0, ErrGasUintOverflow
+			}
+		}
 	}
 	return gas, nil
 }
@@ -518,6 +589,12 @@ func gasSelfdestruct(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 		} else if !evm.StateDB.Exist(address) {
 			gas += params.CreateBySelfdestructGas
 		}
+	}
+
+	if evm.Accesses != nil {
+		// TODO turn this into a panic (when we are sure this method
+		// will never execute when verkle is enabled)
+		log.Warn("verkle witness accumulation not supported for selfdestruct")
 	}
 
 	if !evm.StateDB.HasSuicided(contract.Address()) {

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -19,6 +19,7 @@ package vm
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	trieUtils "github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/holiman/uint256"
@@ -667,6 +668,13 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 		input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
 		gas          = scope.Contract.Gas
 	)
+	if interpreter.evm.Accesses != nil {
+		contractAddress := crypto.CreateAddress(scope.Contract.Address(), interpreter.evm.StateDB.GetNonce(scope.Contract.Address()))
+		statelessGas := interpreter.evm.Accesses.TouchAndChargeContractCreateInit(contractAddress.Bytes()[:])
+		if !tryConsumeGas(&gas, statelessGas) {
+			return nil, ErrExecutionReverted
+		}
+	}
 	if interpreter.evm.chainRules.IsEIP150 {
 		gas -= gas / 64
 	}
@@ -674,6 +682,7 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	stackvalue := size
 
 	scope.Contract.UseGas(gas)
+
 	//TODO: use uint256.Int instead of converting with toBig()
 	var bigVal = big0
 	if !value.IsZero() {
@@ -709,6 +718,14 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 		input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
 		gas          = scope.Contract.Gas
 	)
+	if interpreter.evm.Accesses != nil {
+		codeAndHash := &codeAndHash{code: input}
+		contractAddress := crypto.CreateAddress2(scope.Contract.Address(), salt.Bytes32(), codeAndHash.Hash().Bytes())
+		statelessGas := interpreter.evm.Accesses.TouchAndChargeContractCreateInit(contractAddress.Bytes()[:])
+		if !tryConsumeGas(&gas, statelessGas) {
+			return nil, ErrExecutionReverted
+		}
+	}
 
 	// Apply EIP150
 	gas -= gas / 64

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -47,6 +47,9 @@ type StateDB interface {
 	GetState(common.Address, common.Hash) common.Hash
 	SetState(common.Address, common.Hash, common.Hash)
 
+	GetBalanceLittleEndian(address common.Address) []byte
+	GetNonceLittleEndian(address common.Address) []byte
+
 	Suicide(common.Address) bool
 	HasSuicided(common.Address) bool
 

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -79,7 +79,6 @@ func (t *VerkleTrie) TryUpdateAccount(key []byte, acc *types.StateAccount) error
 	if err = t.TryUpdate(utils.GetTreeKeyCodeKeccak(key), acc.CodeHash); err != nil {
 		return fmt.Errorf("updateStateObject (%x) error: %v", key, err)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Based on top of https://github.com/gballet/go-ethereum/pull/42

Adds part of the logic for witness gas charging from https://notes.ethereum.org/-fJSOrnYQl-mqoWKpaTIsQ .  Note that this treats all events as access events unlike the spec.  The purpose of this PR is to put in place the logic necessary to charge witness gas costs for message calling (`CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`, `SELFDESTRUCT`, `CREATE`, `CREATE2`).

Once this PR is done and approved, I will rebase https://github.com/gballet/go-ethereum/pull/37 and change the individual `Touch*` calls to either `TouchOnReadAndChargeGas` or `TouchOnWriteAndChargeGas`.