### PR TITLE
fix for unit tests: do not call NewAccessWitness in NewEVMTxContext

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -672,9 +672,7 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 	}
 	if config.IsCancun(header.Number) {
 		coinbase := utils.GetTreeKeyBalance(header.Coinbase.Bytes())
-		if state.Witness() != nil {
-			state.Witness().TouchAddress(coinbase, state.GetBalance(header.Coinbase).Bytes())
-		}
+		state.Witness().TouchAddress(coinbase, state.GetBalance(header.Coinbase).Bytes())
 	}
 	state.AddBalance(header.Coinbase, reward)
 }

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -662,7 +662,9 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		r.Mul(r, blockReward)
 		r.Div(r, big8)
 		uncleCoinbase := utils.GetTreeKeyBalance(uncle.Coinbase.Bytes())
-		state.Witness().TouchAddress(uncleCoinbase, state.GetBalance(uncle.Coinbase).Bytes())
+		if state.Witness() != nil {
+			state.Witness().TouchAddress(uncleCoinbase, state.GetBalance(uncle.Coinbase).Bytes())
+		}
 		state.AddBalance(uncle.Coinbase, r)
 
 		r.Div(blockReward, big32)

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -668,7 +668,11 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		r.Div(blockReward, big32)
 		reward.Add(reward, r)
 	}
-	coinbase := utils.GetTreeKeyBalance(header.Coinbase.Bytes())
-	state.Witness().TouchAddress(coinbase, state.GetBalance(header.Coinbase).Bytes())
+	if config.IsCancun(header.Number) {
+		coinbase := utils.GetTreeKeyBalance(header.Coinbase.Bytes())
+		if state.Witness() != nil {
+			state.Witness().TouchAddress(coinbase, state.GetBalance(header.Coinbase).Bytes())
+		}
+	}
 	state.AddBalance(header.Coinbase, reward)
 }

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -661,8 +661,8 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		r.Sub(r, header.Number)
 		r.Mul(r, blockReward)
 		r.Div(r, big8)
-		uncleCoinbase := utils.GetTreeKeyBalance(uncle.Coinbase.Bytes())
 		if state.Witness() != nil {
+			uncleCoinbase := utils.GetTreeKeyBalance(uncle.Coinbase.Bytes())
 			state.Witness().TouchAddress(uncleCoinbase, state.GetBalance(uncle.Coinbase).Bytes())
 		}
 		state.AddBalance(uncle.Coinbase, r)

--- a/core/evm.go
+++ b/core/evm.go
@@ -69,7 +69,7 @@ func NewEVMTxContext(msg Message) vm.TxContext {
 	return vm.TxContext{
 		Origin:   msg.From(),
 		GasPrice: new(big.Int).Set(msg.GasPrice()),
-		Accesses: types.NewAccessWitness(),
+		//Accesses: types.NewAccessWitness(),
 	}
 }
 

--- a/core/evm.go
+++ b/core/evm.go
@@ -69,7 +69,6 @@ func NewEVMTxContext(msg Message) vm.TxContext {
 	return vm.TxContext{
 		Origin:   msg.From(),
 		GasPrice: new(big.Int).Set(msg.GasPrice()),
-		//Accesses: types.NewAccessWitness(),
 	}
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -182,7 +182,7 @@ func (s *StateDB) StartPrefetcher(namespace string) {
 		s.prefetcher.close()
 		s.prefetcher = nil
 	}
-	if s.snap != nil {
+	if s.snap != nil && !s.trie.IsVerkle() {
 		s.prefetcher = newTriePrefetcher(s.db, s.originalRoot, namespace)
 	}
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -713,7 +713,9 @@ func (s *StateDB) Copy() *StateDB {
 		preimages:           make(map[common.Hash][]byte, len(s.preimages)),
 		journal:             newJournal(),
 		hasher:              crypto.NewKeccakState(),
-		witness:             s.witness.Copy(),
+	}
+	if s.witness != nil {
+		state.witness = s.witness.Copy()
 	}
 	// Copy the dirty states, logs, and preimages
 	for addr := range s.journal.dirties {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -149,11 +149,13 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 		accessList:          newAccessList(),
 		hasher:              crypto.NewKeccakState(),
 	}
-	if sdb.snaps == nil && tr.IsVerkle() {
+	if tr.IsVerkle() {
 		sdb.witness = types.NewAccessWitness()
-		sdb.snaps, err = snapshot.New(db.TrieDB().DiskDB(), db.TrieDB(), 1, root, false, true, false, true)
-		if err != nil {
-			return nil, err
+		if sdb.snaps == nil {
+			sdb.snaps, err = snapshot.New(db.TrieDB().DiskDB(), db.TrieDB(), 1, root, false, true, false, true)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	if sdb.snaps != nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -148,9 +148,9 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 		journal:             newJournal(),
 		accessList:          newAccessList(),
 		hasher:              crypto.NewKeccakState(),
-		witness:             types.NewAccessWitness(),
 	}
 	if sdb.snaps == nil && tr.IsVerkle() {
+		sdb.witness = types.NewAccessWitness()
 		sdb.snaps, err = snapshot.New(db.TrieDB().DiskDB(), db.TrieDB(), 1, root, false, true, false, true)
 		if err != nil {
 			return nil, err

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -95,6 +95,9 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM) (*types.Receipt, error) {
 	// Create a new context to be used in the EVM environment.
 	txContext := NewEVMTxContext(msg)
+	if config.IsCancun(blockNumber) {
+		txContext.Accesses = types.NewAccessWitness()
+	}
 	evm.Reset(txContext, statedb)
 
 	// Apply the transaction to the current state (included in the env).

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -128,7 +128,9 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
 	}
 
-	statedb.Witness().Merge(txContext.Accesses)
+	if txContext.Accesses != nil {
+		statedb.Witness().Merge(txContext.Accesses)
+	}
 
 	// Set the receipt logs and create the bloom filter.
 	receipt.Logs = statedb.GetLogs(tx.Hash(), blockHash)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -441,12 +441,10 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 		uint64CodeEnd = 0xffffffffffffffff
 	}
 	addr := common.Address(a.Bytes20())
-	if interpreter.evm.accesses != nil {
-		copyCodeFromAccesses(addr, uint64CodeOffset, uint64CodeEnd, memOffset.Uint64(), interpreter, scope)
-	} else {
-		codeCopy := getData(interpreter.evm.StateDB.GetCode(addr), uint64CodeOffset, length.Uint64())
-		scope.Memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
+	codeCopy := getData(interpreter.evm.StateDB.GetCode(addr), uint64CodeOffset, length.Uint64())
+	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
 
+	if interpreter.evm.chainConfig.IsCancun(interpreter.evm.Context.BlockNumber) {
 		touchEachChunks(uint64CodeOffset, uint64CodeEnd, codeCopy, scope.Contract, interpreter.evm)
 	}
 

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -259,10 +259,7 @@ func testGenerateBlockAndImport(t *testing.T, isClique bool) {
 			if _, err := chain.InsertChain([]*types.Block{block}); err != nil {
 				t.Fatalf("failed to insert new mined block %d: %v", block.NumberU64(), err)
 			}
-		// TODO(gballet) the timeout had to be increased from 3s to 7s with verkle
-		// trees, presumably because calculating an address is orders of magnitude
-		// slower with perdersen_hash not using the multi-exponentiation.
-		case <-time.After(5 * time.Second): // Worker needs 1s to include new changes.
+		case <-time.After(3 * time.Second): // Worker needs 1s to include new changes.
 			t.Fatalf("timeout")
 		}
 	}


### PR DESCRIPTION
Ensure that the tests pass if I deactivate witnesses in general tests. This includes part of the recommended fix for #47.

:warning: :skull_and_crossbones:  this doesn't change the fact that calculating an address is very slow with the proposed "pedersen hash" scheme.