### PR TITLE
Properly handle contract constructor bytecode with respect to AccessWitness

### DIFF
--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -58,6 +58,9 @@ type Contract struct {
 	CodeAddr *common.Address
 	Input    []byte
 
+	// is the execution frame represented by this object a contract deployment 
+	IsDeployment bool
+
 	Gas   uint64
 	value *big.Int
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -260,6 +260,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 			// The depth-check is already done, and precompiles handled above
 			contract := NewContract(caller, AccountRef(addrCopy), value, gas)
 			contract.SetCallCode(&addrCopy, evm.StateDB.GetCodeHash(addrCopy), code)
+			contract.IsDeployment = true
 			ret, err = evm.interpreter.Run(contract, input, false)
 			gas = contract.Gas
 		}
@@ -483,6 +484,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	// The contract is a scoped environment for this execution context only.
 	contract := NewContract(caller, AccountRef(address), value, gas)
 	contract.SetCodeOptionalHash(&address, codeAndHash)
+	contract.IsDeployment = true
 
 	if evm.Config.NoRecursion && evm.depth > 0 {
 		return nil, address, gas, nil

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -191,7 +191,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			logged, pcCopy, gasCopy = false, pc, contract.Gas
 		}
 
-		if in.evm.TxContext.Accesses != nil {
+		if in.evm.TxContext.Accesses != nil && !contract.IsDeployment {
 			// if the PC ends up in a new "page" of verkleized code, charge the
 			// associated witness costs.
 			contract.Gas -= touchEachChunksAndChargeGas(pc, 1, contract.Address().Bytes()[:], contract, in.evm.TxContext.Accesses)


### PR DESCRIPTION
Don't charge witness access costs for the executing bytecode or attempt include it in the proof.

Honestly, I think the functionality of querying to see if the current executing call frame is a constructor or on-chain code shouldn't go in the `AcessWitness`, but rather the `EVM`.  But I put it in the `AccessWitness` to avoid coupling a feature only needed by the `AccessWitness` with the `EVM` code.