### PR TITLE
core/state: don't delete an account from the trie if it becomes empty when verkle mode is enabled

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -550,16 +550,12 @@ func (s *StateDB) deleteStateObject(obj *stateObject) {
 	}
 
 	// Delete the account from the trie
+	// Post-verkle, the only case where this can occur is a static call
+	// to a non-existent account which creates an empty stateObject
 	if !s.trie.IsVerkle() {
 		addr := obj.Address()
 		if err := s.trie.TryDelete(addr[:]); err != nil {
 			s.setError(fmt.Errorf("deleteStateObject (%x) error: %v", addr[:], err))
-		}
-	} else {
-		for i := byte(0); i <= 255; i++ {
-			if err := s.trie.TryDelete(trieUtils.GetTreeKeyAccountLeaf(obj.Address().Bytes(), i)); err != nil {
-				s.setError(fmt.Errorf("deleteStateObject (%x) error: %v", obj.Address(), err))
-			}
 		}
 	}
 }


### PR DESCRIPTION
Leaving this one on draft for now as I need to think about what this could potentially break.  The only situation I can think of where we can get an empty `stateObject` is possibly upon the failure of a `CREATE`, but in this case it _should_ only exist as a `stateObject` and not in the trie yet.