### PR TITLE
Write code to DB bucket keyed by code hash

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1032,9 +1032,8 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 					} else {
 						s.setError(err)
 					}
-				} else {
-					rawdb.WriteCode(codeWriter, common.BytesToHash(obj.CodeHash()), obj.code)
 				}
+				rawdb.WriteCode(codeWriter, common.BytesToHash(obj.CodeHash()), obj.code)
 				obj.dirtyCode = false
 			}
 		}


### PR DESCRIPTION
Unsure why this was removed with the verkle changes.  Does the contiguous code exist in another key?