### PR TITLE
fixes for the return type change in go-verkle

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -340,12 +340,19 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 			// building the proof. Ultimately, node
 			// resolution can be done with a prefetcher
 			// or from GetCommitmentsAlongPath.
+			kvs := statedb.Witness().KeyVals()
 			keys := statedb.Witness().Keys()
 			for _, key := range keys {
-				vtr.TryGet(key)
+				// XXX workaround - there is a problem in the witness creation
+				// so fix the witness creation as well.
+				v, err := vtr.TryGet(key)
+				if err != nil {
+					panic(err)
+				}
+				kvs[string(key)] = v
 			}
 			vtr.Hash()
-			p, k, err := vtr.ProveAndSerialize(keys, statedb.Witness().KeyVals())
+			p, k, err := vtr.ProveAndSerialize(keys, kvs)
 			block.SetVerkleProof(p, k)
 			if err != nil {
 				panic(err)

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/fatih/color v1.7.0
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20220128155149-95499dfcd74a
+	github.com/gballet/go-verkle v0.0.0-20220209120303-88a3fa537cf1
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.0
 	github.com/golang/protobuf v1.4.3
@@ -66,7 +66,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
+	golang.org/x/sys v0.0.0-20220207234003-57398862261d
 	golang.org/x/text v0.3.6
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,10 @@ github.com/gballet/go-verkle v0.0.0-20220127081734-1fca5295178c h1:EoP3VKIxU+29c
 github.com/gballet/go-verkle v0.0.0-20220127081734-1fca5295178c/go.mod h1:NhFaKv4U1IBG8QkKCsKh4xBMmdori0B0eZjdywcrktE=
 github.com/gballet/go-verkle v0.0.0-20220128155149-95499dfcd74a h1:0GpdT+zyEoa8OTBtJk5EdZm7nF4HXzU+blG3io0pm5A=
 github.com/gballet/go-verkle v0.0.0-20220128155149-95499dfcd74a/go.mod h1:NhFaKv4U1IBG8QkKCsKh4xBMmdori0B0eZjdywcrktE=
+github.com/gballet/go-verkle v0.0.0-20220208130546-d368c16aca2f h1:E/dsnBev33ojJlYjBVnh/uJ2tvFB5juYKyOP854fwTE=
+github.com/gballet/go-verkle v0.0.0-20220208130546-d368c16aca2f/go.mod h1:NhFaKv4U1IBG8QkKCsKh4xBMmdori0B0eZjdywcrktE=
+github.com/gballet/go-verkle v0.0.0-20220209120303-88a3fa537cf1 h1:mkoUQjsrx/6hH3b3/tCfNhe1IJyErvNqG5k4XxWpuNs=
+github.com/gballet/go-verkle v0.0.0-20220209120303-88a3fa537cf1/go.mod h1:NhFaKv4U1IBG8QkKCsKh4xBMmdori0B0eZjdywcrktE=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -567,6 +571,8 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+R
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220207234003-57398862261d h1:Bm7BNOQt2Qv7ZqysjeLjgCBanX+88Z/OtdvsrEv1Djc=
+golang.org/x/sys v0.0.0-20220207234003-57398862261d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1043,7 +1043,18 @@ func (w *worker) commit(uncles []*types.Header, interval func(), update bool, st
 	}
 	if tr := w.current.original.GetTrie(); tr.IsVerkle() {
 		vtr := tr.(*trie.VerkleTrie)
-		// Generate the proof if we are using a verkle tree
+		keys := s.Witness().Keys()
+		kvs := s.Witness().KeyVals()
+		for _, key := range keys {
+			// XXX workaround - there is a problem in the witness creation
+			// so fix the witness creation as well.
+			v, err := vtr.TryGet(key)
+			if err != nil {
+				panic(err)
+			}
+			kvs[string(key)] = v
+		}
+		vtr.Hash()
 		p, k, err := vtr.ProveAndSerialize(s.Witness().Keys(), s.Witness().KeyVals())
 		if err != nil {
 			return err

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/crate-crypto/go-ipa/bandersnatch/fr"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -105,9 +106,7 @@ func (trie *VerkleTrie) TryDelete(key []byte) error {
 // Hash returns the root hash of the trie. It does not write to the database and
 // can be used even if the trie doesn't have one.
 func (trie *VerkleTrie) Hash() common.Hash {
-	// TODO cache this value
-	rootC := trie.root.ComputeCommitment()
-	return rootC.Bytes()
+	return trie.root.ComputeCommitment().Bytes()
 }
 
 func nodeToDBKey(n verkle.VerkleNode) []byte {
@@ -269,7 +268,10 @@ func deserializeVerkleProof(serialized []byte) (*verkle.Proof, []*verkle.Point, 
 			// same thing with a yi
 			if !hasKey(seenComm, stem[:j]) {
 				addKey(seenComm, stem[:j])
-				yis = append(yis, node.ComputeCommitment())
+				var yi fr.Element
+				bytes := node.ComputeCommitment().Bytes()
+				yi.SetBytesLE(bytes[:])
+				yis = append(yis, &yi)
 			}
 		}
 

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -69,13 +69,16 @@ func (t *VerkleTrie) TryUpdateAccount(key []byte, acc *types.StateAccount) error
 		return fmt.Errorf("updateStateObject (%x) error: %v", key, err)
 	}
 	var nonce [32]byte
-	binary.LittleEndian.PutUint64(nonce[24:], acc.Nonce)
+	binary.LittleEndian.PutUint64(nonce[:], acc.Nonce)
 	if err = t.TryUpdate(utils.GetTreeKeyNonce(key), nonce[:]); err != nil {
 		return fmt.Errorf("updateStateObject (%x) error: %v", key, err)
 	}
 	var balance [32]byte
-	for i, b := range acc.Balance.Bytes() {
-		balance[31-i] = b
+	bbytes := acc.Balance.Bytes()
+	if len(bbytes) > 0 {
+		for i, b := range bbytes {
+			balance[len(bbytes)-i-1] = b
+		}
 	}
 	if err = t.TryUpdate(utils.GetTreeKeyBalance(key), balance[:]); err != nil {
 		return fmt.Errorf("updateStateObject (%x) error: %v", key, err)

--- a/trie/verkle_test.go
+++ b/trie/verkle_test.go
@@ -84,5 +84,5 @@ func TestReproduceTree(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("serialized: %x", p)
-	t.Logf("tree: %s", verkle.ToDot(root))
+	t.Logf("tree: %s\n%x\n", verkle.ToDot(root), root.ComputeCommitment().Bytes())
 }


### PR DESCRIPTION
These changes go along with https://github.com/gballet/go-verkle/pull/189 : the state root is a serialized point, not a serialized-point-turned-field-element.