### PR TITLE
investigate the access witness issue

### DIFF
--- a/core/types/access_witness.go
+++ b/core/types/access_witness.go
@@ -68,8 +68,14 @@ func (aw *AccessWitness) SetLeafValue(addr []byte, value []byte) {
 	copy(stem[:], addr[:31])
 
 	if chunk, exists := aw.Chunks[common.BytesToHash(addr)]; exists && len(chunk.value) == 0 {
-		// overwrite nil
-		chunk.value = value
+		if len(value) < 32 && value != nil {
+			var aligned [32]byte
+			copy(aligned[:len(value)], value)
+			chunk.value = aligned[:]
+		} else {
+			// overwrite nil
+			chunk.value = value
+		}
 		aw.Chunks[common.BytesToHash(addr)] = chunk
 	} else if !exists {
 		panic(fmt.Sprintf("address not in access witness: %x", addr))


### PR DESCRIPTION
# Context

When creating the proof, the values that find themselves in the access witness are wrong, they correspond to a state later than that of the post state. For example, in `TestProcessStateless`,  a comparison of the first block's prestate with that of the access witness show:

```
key 6c99a3a0427cab63b7ab24f0683da88a1c5ed53f7b072b9e4efebd5dc412fd01 has value 0000000000000000000000000000000000000000000000000000000000000000, should be 
key a365db4f33df4f95bf2ae41da5a1bc3c804c3e511e7fddff4eabd000b5c0d602 has correct value 0000000000000000000000000000000000000000000000000000000000000000
key 78fdaed8ac3619d9b9520a66b57fdc16a1ed03b29ab8e9fb021c39bf8cefdd01 has value 0000000000000000000000000000000000000000000000000000000000000000, should be 
key 78fdaed8ac3619d9b9520a66b57fdc16a1ed03b29ab8e9fb021c39bf8cefdd02 has value 0000000000000000000000000000000000000000000000000000000000000000, should be 
key a365db4f33df4f95bf2ae41da5a1bc3c804c3e511e7fddff4eabd000b5c0d604 has value , should be 0000000000000000000000000000000000000000000000000000000000000000
key a365db4f33df4f95bf2ae41da5a1bc3c804c3e511e7fddff4eabd000b5c0d601 has value 0043fdd2679be00d000000000000000000000000000000000000000000000000, should be 000064a7b3b6e00d000000000000000000000000000000000000000000000000
key a365db4f33df4f95bf2ae41da5a1bc3c804c3e511e7fddff4eabd000b5c0d603 has value , should be c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
key 78fdaed8ac3619d9b9520a66b57fdc16a1ed03b29ab8e9fb021c39bf8cefdd03 has value 0000000000000000000000000000000000000000000000000000000000000000, should be 
key 78fdaed8ac3619d9b9520a66b57fdc16a1ed03b29ab8e9fb021c39bf8cefdd00 has value 0000000000000000000000000000000000000000000000000000000000000000, should be 
key 6c99a3a0427cab63b7ab24f0683da88a1c5ed53f7b072b9e4efebd5dc412fd04 has value 0000000000000000000000000000000000000000000000000000000000000000, should be 
key 6c99a3a0427cab63b7ab24f0683da88a1c5ed53f7b072b9e4efebd5dc412fd03 has value 0000000000000000000000000000000000000000000000000000000000000000, should be 
key 6c99a3a0427cab63b7ab24f0683da88a1c5ed53f7b072b9e4efebd5dc412fd02 has value 0000000000000000000000000000000000000000000000000000000000000000, should be 
key 78fdaed8ac3619d9b9520a66b57fdc16a1ed03b29ab8e9fb021c39bf8cefdd04 has value 0000000000000000000000000000000000000000000000000000000000000000, should be 
key 6c99a3a0427cab63b7ab24f0683da88a1c5ed53f7b072b9e4efebd5dc412fd00 has value 0000000000000000000000000000000000000000000000000000000000000000, should be 
key a365db4f33df4f95bf2ae41da5a1bc3c804c3e511e7fddff4eabd000b5c0d600 has correct value 0000000000000000000000000000000000000000000000000000000000000000
```

# Analysis

There are several bugs here:

 * some values are correct, but are not 32-byte aligned. This PR contains the fix for this;
 * some values are initially `nil`, but since `nil` isn't recognized as a value, it is replaced with `0000000000000000000000000000000000000000000000000000000000000000`
 * some values, namely the balances, are wrong, for example the pre-allocated account should have a balance of `1000000000000000000` (`000064a7b3b6e00d` in little endian hex form), but the first value that is inserted is `0043fdd2679be00d`, which is little-endian hex for `999969987500000000`. That is an incorrect value, which probably comes from the fact that this is the sender account and that the sending costs is charged before the account witness is created.