### PR TITLE
refactor: set witness account values in getStateObject()

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -343,14 +343,23 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 			kvs := statedb.Witness().KeyVals()
 			keys := statedb.Witness().Keys()
 			for _, key := range keys {
-				// XXX workaround - there is a problem in the witness creation
-				// so fix the witness creation as well.
-				v, err := vtr.TryGet(key)
+				_, err := vtr.TryGet(key)
 				if err != nil {
 					panic(err)
 				}
-				kvs[string(key)] = v
+				// Sanity check: ensure all flagged addresses have an associated
+				// value: keys is built from Chunks and kvs from InitialValue.
+				if _, exists := kvs[string(key)]; !exists {
+					panic(fmt.Sprintf("address not in access witness: %x", key))
+				}
 			}
+
+			// sanity check: ensure all values correspond to a flagged key by
+			// comparing the lengths of both structures: they should be equal
+			if len(kvs) != len(keys) {
+				panic("keys without a value in witness")
+			}
+
 			vtr.Hash()
 			p, k, err := vtr.ProveAndSerialize(keys, kvs)
 			block.SetVerkleProof(p, k)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -347,6 +347,7 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 				if err != nil {
 					panic(err)
 				}
+
 				// Sanity check: ensure all flagged addresses have an associated
 				// value: keys is built from Chunks and kvs from InitialValue.
 				if _, exists := kvs[string(key)]; !exists {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -18,6 +18,7 @@ package state
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"math/big"
@@ -520,6 +521,11 @@ func (s *stateObject) CodeSize(db Database) int {
 	size, err := db.ContractCodeSize(s.addrHash, common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.setError(fmt.Errorf("can't load code size %x: %v", s.CodeHash(), err))
+	}
+	if s.db.trie.IsVerkle() {
+		var sz [32]byte
+		binary.LittleEndian.PutUint64(sz[:8], uint64(size))
+		s.db.witness.SetLeafValuesMessageCall(s.addrHash[:], sz[:])
 	}
 	return size
 }

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -103,6 +103,24 @@ func (s *stateObject) empty() bool {
 
 // newObject creates a state object.
 func newObject(db *StateDB, address common.Address, data types.StateAccount) *stateObject {
+	if db.trie.IsVerkle() {
+		var nonce, balance, version []byte
+
+		// preserve nil as a balance value, it means it's not in the tree
+		// use is as a heuristic for the nonce being null as well
+		if data.Balance != nil {
+			nonce = make([]byte, 32)
+			balance = make([]byte, 32)
+			version = make([]byte, 32)
+			for i, b := range data.Balance.Bytes() {
+				balance[len(data.Balance.Bytes())-1-i] = b
+			}
+
+			binary.LittleEndian.PutUint64(nonce[:8], data.Nonce)
+		}
+		db.witness.SetGetObjectTouchedLeaves(address.Bytes(), version, balance[:], nonce[:], data.CodeHash)
+	}
+
 	if data.Balance == nil {
 		data.Balance = new(big.Int)
 	}
@@ -498,11 +516,21 @@ func (s *stateObject) Code(db Database) []byte {
 		return s.code
 	}
 	if bytes.Equal(s.CodeHash(), emptyCodeHash) {
+		if s.db.GetTrie().IsVerkle() {
+			// Mark the code size and code hash as empty
+			s.db.witness.SetObjectCodeTouchedLeaves(s.address.Bytes(), nil, nil)
+		}
 		return nil
 	}
 	code, err := db.ContractCode(s.addrHash, common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.setError(fmt.Errorf("can't load code hash %x: %v", s.CodeHash(), err))
+	}
+	if s.db.GetTrie().IsVerkle() {
+		// XXX move this to the function
+		var cs [32]byte
+		binary.LittleEndian.PutUint64(cs[:8], uint64(len(code)))
+		s.db.witness.SetObjectCodeTouchedLeaves(s.address.Bytes(), cs[:], s.CodeHash())
 	}
 	s.code = code
 	return code
@@ -516,6 +544,10 @@ func (s *stateObject) CodeSize(db Database) int {
 		return len(s.code)
 	}
 	if bytes.Equal(s.CodeHash(), emptyCodeHash) {
+		if s.db.trie.IsVerkle() {
+			var sz [32]byte
+			s.db.witness.SetLeafValuesMessageCall(s.address.Bytes(), sz[:])
+		}
 		return 0
 	}
 	size, err := db.ContractCodeSize(s.addrHash, common.BytesToHash(s.CodeHash()))
@@ -525,7 +557,7 @@ func (s *stateObject) CodeSize(db Database) int {
 	if s.db.trie.IsVerkle() {
 		var sz [32]byte
 		binary.LittleEndian.PutUint64(sz[:8], uint64(size))
-		s.db.witness.SetLeafValuesMessageCall(s.addrHash[:], sz[:])
+		s.db.witness.SetLeafValuesMessageCall(s.address.Bytes(), sz[:])
 	}
 	return size
 }
@@ -566,8 +598,23 @@ func (s *stateObject) Balance() *big.Int {
 	return s.data.Balance
 }
 
+func (s *stateObject) BalanceLE() []byte {
+	var out [32]byte
+	for i, b := range s.data.Balance.Bytes() {
+		out[len(s.data.Balance.Bytes())-1-i] = b
+	}
+
+	return out[:]
+}
+
 func (s *stateObject) Nonce() uint64 {
 	return s.data.Nonce
+}
+
+func (s *stateObject) NonceLE() []byte {
+	var out [32]byte
+	binary.LittleEndian.PutUint64(out[:8], s.data.Nonce)
+	return out[:]
 }
 
 // Never called, but must be present to allow stateObject to be used

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -527,7 +527,6 @@ func (s *stateObject) Code(db Database) []byte {
 		s.setError(fmt.Errorf("can't load code hash %x: %v", s.CodeHash(), err))
 	}
 	if s.db.GetTrie().IsVerkle() {
-		// XXX move this to the function
 		var cs [32]byte
 		binary.LittleEndian.PutUint64(cs[:8], uint64(len(code)))
 		s.db.witness.SetObjectCodeTouchedLeaves(s.address.Bytes(), cs[:], s.CodeHash())

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -607,13 +607,6 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 			}
 		}
 
-		// NOTE: Do not touch the addresses here, kick the can down the
-		// road. That is because I don't want to change the interface
-		// to getDeletedStateObject at this stage, as the PR would then
-		// have a huge footprint.
-		// The alternative is to make accesses available via the state
-		// db instead of the evm. This requires a significant rewrite,
-		// that isn't currently warranted.
 	}
 	// If snapshot unavailable or reading from it failed, load from the database
 	if s.snap == nil || err != nil {

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -386,7 +386,7 @@ func TestProcessStateless(t *testing.T) {
 	blockGasUsedExpected := txCost1*2 + txCost2
 	chain, _ := GenerateVerkleChain(gspec.Config, genesis, ethash.NewFaker(), db, 2, func(i int, gen *BlockGen) {
 		// TODO need to check that the tx cost provided is the exact amount used (no remaining left-over)
-		tx, _ := types.SignTx(types.NewTransaction(uint64(i)*3, common.Address{1, 2, 3}, big.NewInt(999), txCost1, big.NewInt(875000000), nil), signer, testKey)
+		tx, _ := types.SignTx(types.NewTransaction(uint64(i)*3, common.Address{byte(i), 2, 3}, big.NewInt(999), txCost1, big.NewInt(875000000), nil), signer, testKey)
 		gen.AddTx(tx)
 		tx, _ = types.SignTx(types.NewTransaction(uint64(i)*3+1, common.Address{}, big.NewInt(999), txCost1, big.NewInt(875000000), nil), signer, testKey)
 		gen.AddTx(tx)

--- a/core/types/access_witness.go
+++ b/core/types/access_witness.go
@@ -68,8 +68,14 @@ func (aw *AccessWitness) SetLeafValue(addr []byte, value []byte) {
 	copy(stem[:], addr[:31])
 
 	if chunk, exists := aw.Chunks[common.BytesToHash(addr)]; exists && len(chunk.value) == 0 {
-		// overwrite nil
-		chunk.value = value
+		if len(value) < 32 && value != nil {
+			var aligned [32]byte
+			copy(aligned[:len(value)], value)
+			chunk.value = aligned[:]
+		} else {
+			// overwrite nil
+			chunk.value = value
+		}
 		aw.Chunks[common.BytesToHash(addr)] = chunk
 	} else if !exists {
 		panic(fmt.Sprintf("address not in access witness: %x", addr))

--- a/core/types/access_witness.go
+++ b/core/types/access_witness.go
@@ -261,11 +261,6 @@ func (aw *AccessWitness) TouchAndChargeValueTransfer(callerAddr, targetAddr []by
 	return gas
 }
 
-func (aw *AccessWitness) SetLeafValuesValueTransfer(callerAddr, targetAddr, callerBalance, targetBalance []byte) {
-	aw.SetLeafValue(utils.GetTreeKeyBalance(callerAddr[:]), callerBalance)
-	aw.SetLeafValue(utils.GetTreeKeyBalance(targetAddr[:]), targetBalance)
-}
-
 // TouchAndChargeContractCreateInit charges access costs to initiate
 // a contract creation
 func (aw *AccessWitness) TouchAndChargeContractCreateInit(addr []byte, createSendsValue bool) uint64 {
@@ -276,15 +271,6 @@ func (aw *AccessWitness) TouchAndChargeContractCreateInit(addr []byte, createSen
 		gas += aw.TouchAddressOnWriteAndComputeGas(utils.GetTreeKeyBalance(addr[:]))
 	}
 	return gas
-}
-
-func (aw *AccessWitness) SetLeafValuesContractCreateInit(addr, nonce, value []byte) {
-	var version [32]byte
-	aw.SetLeafValue(utils.GetTreeKeyVersion(addr[:]), version[:])
-	aw.SetLeafValue(utils.GetTreeKeyNonce(addr[:]), nonce)
-	if value != nil {
-		aw.SetLeafValue(utils.GetTreeKeyBalance(addr[:]), value)
-	}
 }
 
 // TouchAndChargeContractCreateCompleted charges access access costs after

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -17,7 +17,6 @@
 package vm
 
 import (
-	"encoding/binary"
 	"math/big"
 	"sync/atomic"
 	"time"
@@ -222,11 +221,6 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		}
 		evm.StateDB.CreateAccount(addr)
 	}
-	if evm.chainConfig.IsCancun(evm.Context.BlockNumber) && value.Sign() != 0 {
-		callerBalanceBefore := evm.StateDB.GetBalanceLittleEndian(caller.Address())
-		targetBalanceBefore := evm.StateDB.GetBalanceLittleEndian(addr)
-		evm.Accesses.SetLeafValuesValueTransfer(caller.Address().Bytes()[:], addr[:], callerBalanceBefore, targetBalanceBefore)
-	}
 	evm.Context.Transfer(evm.StateDB, caller.Address(), addr, value)
 
 	// Capture the tracer start/end events in debug mode
@@ -251,12 +245,6 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
 		code := evm.StateDB.GetCode(addr)
-		if evm.chainConfig.IsCancun(evm.Context.BlockNumber) {
-			codeSize := uint64(len(code))
-			var codeSizeBytes [32]byte
-			binary.LittleEndian.PutUint64(codeSizeBytes[:8], codeSize)
-			evm.Accesses.SetLeafValuesMessageCall(addr[:], codeSizeBytes[:])
-		}
 
 		if len(code) == 0 {
 			ret, err = nil, nil // gas is unchanged
@@ -322,12 +310,6 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
 		ret, gas, err = RunPrecompiledContract(p, input, gas)
 	} else {
-		if evm.chainConfig.IsCancun(evm.Context.BlockNumber) {
-			codeSize := uint64(evm.StateDB.GetCodeSize(addr))
-			var codeSizeBytes [32]byte
-			binary.LittleEndian.PutUint64(codeSizeBytes[:8], codeSize)
-			evm.Accesses.SetLeafValuesMessageCall(addr.Bytes()[:], codeSizeBytes[:])
-		}
 		addrCopy := addr
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
@@ -372,12 +354,6 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
 		ret, gas, err = RunPrecompiledContract(p, input, gas)
 	} else {
-		if evm.chainConfig.IsCancun(evm.Context.BlockNumber) {
-			codeSize := uint64(evm.StateDB.GetCodeSize(addr))
-			var codeSizeBytes [32]byte
-			binary.LittleEndian.PutUint64(codeSizeBytes[:8], codeSize)
-			evm.Accesses.SetLeafValuesMessageCall(addr.Bytes()[:], codeSizeBytes[:])
-		}
 		addrCopy := addr
 		// Initialise a new contract and make initialise the delegate values
 		contract := NewContract(caller, AccountRef(caller.Address()), nil, gas).AsDelegate()
@@ -430,12 +406,6 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
 		ret, gas, err = RunPrecompiledContract(p, input, gas)
 	} else {
-		if evm.chainConfig.IsCancun(evm.Context.BlockNumber) {
-			codeSize := uint64(evm.StateDB.GetCodeSize(addr))
-			var codeSizeBytes [32]byte
-			binary.LittleEndian.PutUint64(codeSizeBytes[:8], codeSize)
-			evm.Accesses.SetLeafValuesMessageCall(addr.Bytes()[:], codeSizeBytes[:])
-		}
 		// At this point, we use a copy of address. If we don't, the go compiler will
 		// leak the 'contract' to the outer scope, and make allocation for 'contract'
 		// even if the actual execution ends on RunPrecompiled above.
@@ -474,23 +444,6 @@ func (c *codeAndHash) Hash() common.Hash {
 // create creates a new contract using code as deployment code.
 func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64, value *big.Int, address common.Address, typ OpCode) ([]byte, common.Address, uint64, error) {
 	var zeroVerkleLeaf [32]byte
-	var balance []byte
-
-	if evm.chainConfig.IsCancun(evm.Context.BlockNumber) {
-		// note: assumption is that the nonce, code size, code hash
-		// will be 0x0000...00 at the target account before it is created
-		// otherwise would imply contract creation collision which is
-		// impossible if self-destruct is removed
-		if evm.StateDB.GetBalance(address).Sign() != 0 {
-			balance = evm.StateDB.GetBalanceLittleEndian(address)
-		}
-
-		if value.Sign() != 0 {
-			evm.Accesses.SetLeafValuesContractCreateInit(address.Bytes()[:], zeroVerkleLeaf[:], nil)
-		} else {
-			evm.Accesses.SetLeafValuesContractCreateInit(address.Bytes()[:], zeroVerkleLeaf[:], balance)
-		}
-	}
 
 	// Depth check execution. Fail if we're trying to execute above the
 	// limit.

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -347,7 +347,6 @@ func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	if interpreter.evm.chainConfig.IsCancun(interpreter.evm.Context.BlockNumber) {
 		index := trieUtils.GetTreeKeyCodeSize(slot.Bytes())
 		statelessGas := interpreter.evm.Accesses.TouchAddressOnReadAndComputeGas(index)
-		interpreter.evm.Accesses.SetLeafValue(index, uint256.NewInt(cs).Bytes())
 		scope.Contract.UseGas(statelessGas)
 	}
 	slot.SetUint64(cs)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -397,7 +397,6 @@ func touchEachChunksOnReadAndChargeGas(offset, size uint64, address []byte, code
 		startOffset         uint64
 		endOffset           uint64
 		numLeaves           uint64
-		index               [32]byte
 	)
 	// startLeafOffset, endLeafOffset is the evm code offset of the first byte in the first leaf touched
 	// and the evm code offset of the last byte in the last leaf touched
@@ -409,25 +408,12 @@ func touchEachChunksOnReadAndChargeGas(offset, size uint64, address []byte, code
 	}
 	endLeafOffset = endOffset + (endOffset % 31)
 	numLeaves = (endLeafOffset - startLeafOffset) / 31
-	chunkOffset := new(uint256.Int)
-	treeIndex := new(uint256.Int)
 
 	for i := 0; i < int(numLeaves); i++ {
-		chunkOffset.Add(trieUtils.CodeOffset, uint256.NewInt(uint64(i)))
-		treeIndex.Div(chunkOffset, trieUtils.VerkleNodeWidth)
-		var subIndex byte
-		subIndexMod := chunkOffset.Mod(chunkOffset, trieUtils.VerkleNodeWidth).Bytes()
-		if len(subIndexMod) == 0 {
-			subIndex = 0
-		} else {
-			subIndex = subIndexMod[0]
-		}
-		treeKey := trieUtils.GetTreeKey(address, treeIndex, subIndex)
-		copy(index[0:31], treeKey)
-		index[31] = subIndex
+		index := trieUtils.GetTreeKeyCodeChunk(address, uint256.NewInt(uint64(i)))
 
 		// TODO safe-add here to catch overflow
-		statelessGasCharged += accesses.TouchAddressOnReadAndComputeGas(index[:])
+		statelessGasCharged += accesses.TouchAddressOnReadAndComputeGas(index)
 		var value []byte
 		if code != nil && len(code) > 0 {
 			// the offset into the leaf that the first PUSH occurs

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/fatih/color v1.7.0
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20220209120303-88a3fa537cf1
+	github.com/gballet/go-verkle v0.0.0-20220217102726-664ad58b43cd
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.0
 	github.com/golang/protobuf v1.4.3
@@ -66,7 +66,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20220207234003-57398862261d
+	golang.org/x/sys v0.0.0-20220209214540-3681064d5158
 	golang.org/x/text v0.3.6
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/gballet/go-verkle v0.0.0-20220208130546-d368c16aca2f h1:E/dsnBev33ojJ
 github.com/gballet/go-verkle v0.0.0-20220208130546-d368c16aca2f/go.mod h1:NhFaKv4U1IBG8QkKCsKh4xBMmdori0B0eZjdywcrktE=
 github.com/gballet/go-verkle v0.0.0-20220209120303-88a3fa537cf1 h1:mkoUQjsrx/6hH3b3/tCfNhe1IJyErvNqG5k4XxWpuNs=
 github.com/gballet/go-verkle v0.0.0-20220209120303-88a3fa537cf1/go.mod h1:NhFaKv4U1IBG8QkKCsKh4xBMmdori0B0eZjdywcrktE=
+github.com/gballet/go-verkle v0.0.0-20220217102726-664ad58b43cd h1:kvZpVdKgiVfxi+8Wvlm9FknyA4b+T5bp3ajZEMlp6N0=
+github.com/gballet/go-verkle v0.0.0-20220217102726-664ad58b43cd/go.mod h1:NhFaKv4U1IBG8QkKCsKh4xBMmdori0B0eZjdywcrktE=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -573,6 +575,8 @@ golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220207234003-57398862261d h1:Bm7BNOQt2Qv7ZqysjeLjgCBanX+88Z/OtdvsrEv1Djc=
 golang.org/x/sys v0.0.0-20220207234003-57398862261d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220209214540-3681064d5158 h1:rm+CHSpPEEW2IsXUib1ThaHIjuBVZjxNgSKmBLFfD4c=
+golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -36,7 +36,7 @@ var (
 	HeaderStorageOffset = uint256.NewInt(64)
 	CodeOffset          = uint256.NewInt(128)
 	MainStorageOffset   = new(uint256.Int).Lsh(uint256.NewInt(256), 31)
-	VerkleNodeWidth     = uint256.NewInt(8)
+	VerkleNodeWidth     = uint256.NewInt(256)
 	codeStorageDelta    = uint256.NewInt(0).Sub(CodeOffset, HeaderStorageOffset)
 )
 


### PR DESCRIPTION
The values provided in the witness were wrong, as some were already overwritten compared to what they were in the pre-state.

To ensure that the initial value is loaded, catch them at the time they are first loaded from disk, by setting them in `getStateObject` instead of the evm.

TODO:
 * [x] cleanup
 * [x] remove superfluous calls to `SetLeafValue` in `evm.go`
 * [x] check contract creation is still working
 * [x] found an issue with missing keys: they contain 0s instead of `nil`s