### PR TITLE
spec: don't add the trailing pushdata for a final PUSHn

### DIFF
--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -322,7 +322,6 @@ func ChunkifyCode(code []byte) ([][32]byte, error) {
 	}
 	chunks := make([][32]byte, chunkCount)
 	for i := range chunks {
-
 		// number of bytes to copy, 31 unless
 		// the end of the code has been reached.
 		end := 31 * (i + 1)
@@ -356,17 +355,6 @@ func ChunkifyCode(code []byte) ([][32]byte, error) {
 					break
 				}
 			}
-		}
-	}
-
-	// if PUSHDATA went past the code end, add 0-filled chunks with
-	// the correct offset.
-	if chunkOffset > 0 {
-
-		if chunkOffset > 31 {
-			chunks = append(chunks, [32]byte{31}, [32]byte{1})
-		} else {
-			chunks = append(chunks, [32]byte{byte(chunkOffset)})
 		}
 	}
 

--- a/trie/verkle_test.go
+++ b/trie/verkle_test.go
@@ -193,14 +193,11 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(chunks) != 2 {
+	if len(chunks) != 1 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
 	if chunks[0][0] != 0 {
 		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0][0])
-	}
-	if chunks[1][0] != 3 {
-		t.Fatalf("invalid offset in second chunk %d != 3, chunk=%x", chunks[1][0], chunks[1])
 	}
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
 
@@ -212,17 +209,11 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(chunks) != 3 {
+	if len(chunks) != 1 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
 	if chunks[0][0] != 0 {
 		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0][0])
-	}
-	if chunks[1][0] != 31 {
-		t.Fatalf("invalid offset in second chunk %d != 31, chunk=%x", chunks[1][0], chunks[1])
-	}
-	if chunks[2][0] != 1 {
-		t.Fatalf("invalid offset in third chunk %d != 1, chunk=%x", chunks[2][0], chunks[1])
 	}
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
 


### PR DESCRIPTION
In eth1, the code is implicitly suffixed with infinitely-many 0 bytes. This means that, for example, if:
 * the last instruction in the code is a `PUSHn`,
 * the push's immediate overflows the length of the suffix-less code,
 * the push immediate also overflows the 31-byte chunk that the push instruction is in,

the question then arises whether or not to add one or more 0-filled chunks to the witness.

Before this PR, the code assumed that these extra chunks should be added. The spec, however, clearly states that they should not. This makes sense, because extra chunks translate into a bigger witness - and ultimately extra gas costs - when the client can easily determine that the code is truncated based on the codesize provided in the account header.