### PR TITLE
fix: don't add PUSH1-data during contract deployment

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -934,7 +934,11 @@ func opPush1(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 			copy(value[1:], scope.Contract.Code[chunk*31:endMin])
 			index := trieUtils.GetTreeKeyCodeChunk(scope.Contract.Address().Bytes(), uint256.NewInt(chunk))
 			statelessGas := interpreter.evm.Accesses.TouchAddressOnReadAndComputeGas(index)
-			interpreter.evm.Accesses.SetLeafValue(index, value[:])
+			if scope.Contract.IsDeployment {
+				interpreter.evm.Accesses.SetLeafValue(index, nil)
+			} else {
+				interpreter.evm.Accesses.SetLeafValue(index, value[:])
+			}
 			scope.Contract.UseGas(statelessGas)
 		}
 	} else {

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -307,8 +307,13 @@ func deserializeVerkleProof(serialized []byte) (*verkle.Proof, []*verkle.Point, 
 
 // Copy the values here so as to avoid an import cycle
 const (
-	PUSH1  = 0x60
-	PUSH32 = 0x7f
+	PUSH1  = byte(0x60)
+	PUSH3  = byte(0x62)
+	PUSH4  = byte(0x63)
+	PUSH7  = byte(0x66)
+	PUSH21 = byte(0x74)
+	PUSH30 = byte(0x7d)
+	PUSH32 = byte(0x7f)
 )
 
 func ChunkifyCode(code []byte) ([][32]byte, error) {
@@ -348,7 +353,7 @@ func ChunkifyCode(code []byte) ([][32]byte, error) {
 		// it should be 0 unless a PUSHn overflows.
 		for ; codeOffset < end; codeOffset++ {
 			if code[codeOffset] >= PUSH1 && code[codeOffset] <= PUSH32 {
-				codeOffset += int(code[codeOffset]) - PUSH1 + 1
+				codeOffset += int(code[codeOffset] - PUSH1 + 1)
 				if codeOffset+1 >= 31*(i+1) {
 					codeOffset++
 					chunkOffset = codeOffset - 31*(i+1)

--- a/trie/verkle_test.go
+++ b/trie/verkle_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/gballet/go-verkle"
 )
 
@@ -155,13 +154,13 @@ func TestChunkifyCodeTestnet(t *testing.T) {
 
 func TestChunkifyCodeSimple(t *testing.T) {
 	code := []byte{
-		0, byte(vm.PUSH4), 1, 2, 3, 4, byte(vm.PUSH3), 58, 68, 12, byte(vm.PUSH21), 1, 2, 3, 4, 5, 6,
+		0, PUSH4, 1, 2, 3, 4, PUSH3, 58, 68, 12, PUSH21, 1, 2, 3, 4, 5, 6,
 		7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 		// Second 31 bytes
-		0, byte(vm.PUSH21), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-		byte(vm.PUSH7), 1, 2, 3, 4, 5, 6, 7,
+		0, PUSH21, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+		PUSH7, 1, 2, 3, 4, 5, 6, 7,
 		// Third 31 bytes
-		byte(vm.PUSH30), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+		PUSH30, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
 		23, 24, 25, 26, 27, 28, 29, 30,
 	}
 	t.Logf("code=%x", code)
@@ -218,7 +217,7 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
 
 	code = []byte{
-		byte(vm.PUSH4), PUSH32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		PUSH4, PUSH32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	}
 	chunks, err = ChunkifyCode(code)
@@ -237,7 +236,7 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
 
 	code = []byte{
-		byte(vm.PUSH4), PUSH32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		PUSH4, PUSH32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	}
 	chunks, err = ChunkifyCode(code)


### PR DESCRIPTION
The fix already exists in `makePush`, however `PUSH1` doesn't make use of `makePush`.