### PR TITLE
fix: redundant proof-of-absence stems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/fatih/color v1.7.0
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20220330063001-d9fddb499b7a
+	github.com/gballet/go-verkle v0.0.0-20220401072859-0ae88725b839
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.0
 	github.com/golang/protobuf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/gballet/go-verkle v0.0.0-20220309192943-d9f613553c79 h1:IGryvoVakS5AN
 github.com/gballet/go-verkle v0.0.0-20220309192943-d9f613553c79/go.mod h1:S2TbrZxLyGqCqwtl2IA09xxun6oretK6byC1lHY+sAk=
 github.com/gballet/go-verkle v0.0.0-20220330063001-d9fddb499b7a h1:WDnnkoIpO6lqoUydcAzsrYnXOaZyZCFBz3IIRZy5fZ0=
 github.com/gballet/go-verkle v0.0.0-20220330063001-d9fddb499b7a/go.mod h1:S2TbrZxLyGqCqwtl2IA09xxun6oretK6byC1lHY+sAk=
+github.com/gballet/go-verkle v0.0.0-20220401072859-0ae88725b839 h1:Dmwdz0Db5n3PwCu+xvrnyIohV7PMfsfaFFuUDULMJyU=
+github.com/gballet/go-verkle v0.0.0-20220401072859-0ae88725b839/go.mod h1:S2TbrZxLyGqCqwtl2IA09xxun6oretK6byC1lHY+sAk=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
works in conjunction with gballet/go-verkle/pull/201