### PR TITLE
fix: add commitments to nodes loaded from the DB

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -231,7 +231,7 @@ func (db *VerkleDB) OpenTrie(root common.Hash) (Trie, error) {
 		return nil, err
 	}
 
-	r, err := verkle.ParseNode(payload, 0)
+	r, err := verkle.ParseNode(payload, 0, root[:])
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/fatih/color v1.7.0
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20220401072859-0ae88725b839
+	github.com/gballet/go-verkle v0.0.0-20220404153453-8feceddf771f
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.0
 	github.com/golang/protobuf v1.4.3
@@ -66,7 +66,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f
+	golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb
 	golang.org/x/text v0.3.6
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,8 @@ github.com/gballet/go-verkle v0.0.0-20220330063001-d9fddb499b7a h1:WDnnkoIpO6lqo
 github.com/gballet/go-verkle v0.0.0-20220330063001-d9fddb499b7a/go.mod h1:S2TbrZxLyGqCqwtl2IA09xxun6oretK6byC1lHY+sAk=
 github.com/gballet/go-verkle v0.0.0-20220401072859-0ae88725b839 h1:Dmwdz0Db5n3PwCu+xvrnyIohV7PMfsfaFFuUDULMJyU=
 github.com/gballet/go-verkle v0.0.0-20220401072859-0ae88725b839/go.mod h1:S2TbrZxLyGqCqwtl2IA09xxun6oretK6byC1lHY+sAk=
+github.com/gballet/go-verkle v0.0.0-20220404153453-8feceddf771f h1:IYcgobnDr8q19efp7YcJlD6+Q9+mvJOMIK1I7OyZABE=
+github.com/gballet/go-verkle v0.0.0-20220404153453-8feceddf771f/go.mod h1:S2TbrZxLyGqCqwtl2IA09xxun6oretK6byC1lHY+sAk=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -596,6 +598,8 @@ golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 h1:y/woIyUBFbpQGKS0u1aHF/40W
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f h1:rlezHXNlxYWvBCzNses9Dlc7nGFaNMJeqLolcmQSSZY=
 golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb h1:PVGECzEo9Y3uOidtkHGdd347NjLtITfJFO9BxFpmRoo=
+golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/trie/verkle_iterator.go
+++ b/trie/verkle_iterator.go
@@ -104,7 +104,7 @@ func (it *verkleNodeIterator) Next(descend bool) bool {
 		if err != nil {
 			panic(err)
 		}
-		it.current, err = verkle.ParseNode(data, byte(len(it.stack)-1))
+		it.current, err = verkle.ParseNode(data, byte(len(it.stack)-1), nodeToDBKey(node))
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Depends on gballet/go-verkle#202

When loading a tree from the db, the commitments were not assigned to the nodes.