### PR TITLE
sanity check: verify the produced proofs

### DIFF
--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -181,10 +181,16 @@ func (trie *VerkleTrie) IsVerkle() bool {
 }
 
 func (trie *VerkleTrie) ProveAndSerialize(keys [][]byte, kv map[string][]byte) ([]byte, []verkle.KeyValuePair, error) {
-	proof, _, _, _ := verkle.MakeVerkleMultiProof(trie.root, keys, kv)
+	proof, cis, zis, yis := verkle.MakeVerkleMultiProof(trie.root, keys, kv)
 	p, kvps, err := verkle.SerializeProof(proof)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	/* Sanity check during development */
+	cfg, _ := verkle.GetConfig()
+	if !verkle.VerifyVerkleProof(proof, cis, zis, yis, cfg) {
+		return nil, nil, fmt.Errorf("could not self-verify proof")
 	}
 
 	return p, kvps, nil


### PR DESCRIPTION
The root has 5 children, the proof is generated from two deserialized children, path 103 and 159.

|path|commitment|
|-|-|
|20|0x535aa6ab050d53e9d941385a0a2c75b5082898d3717ef29d8d1a0bfdf0898d84|
|25|0xd15ef2aee51ff497cf21c6dc739b094a726ea69455d117769c101521a55c8cda|
|103|0x554b0f50a5557420b2292200a40e7c48cda9141f20d9677dc7e6ba18da16013c|
|103, 2|0x0845795c1cf09242bdcd9f60334f1220dd8a14c50a86a7eb226807710e66acd4|
|159|0xd86d3edbaa61f21c64b8559d14701e42d5d94a1f5feec220c87b52e40b373b48|
|159, 2|0x7bf7caeeda98f7d12a9879f842e6900e5f7d7240f317ee22c59e4b49f4f40c19|
|197|0xab9b3340c35f9293e8c8bf9095df35d141af7c0159255e981f48840cf0145f01|

This picture shows the structure of the stateless tree producing the proof that can not be checked by `rust-verkle`.

![image](https://user-images.githubusercontent.com/3272758/162757452-b4ff3fab-d217-4047-9aee-55f6855eeecd.png)

I was initially thinking the commitments were not up-to-date, but calling `VerifyProof` on synced blocks does successfully validate the proofs produced.