### PR TITLE
temp fix: little endian pedersen_hash

### DIFF
--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -70,7 +70,17 @@ func GetTreeKey(address []byte, treeIndex *uint256.Int, subIndex byte) []byte {
 
 	cfg, _ := verkle.GetConfig()
 	ret := cfg.CommitToPoly(poly[:], 0)
-	retb := ret.Bytes()
+
+	// The output of Byte() is big engian for banderwagon. This
+	// introduces an inbalance in the tree, because hashes are
+	// elements of a 253-bit field. This means more than half the
+	// tree would be empty. To avoid this problem, use a little
+	// endian commitment and chop the MSB.
+	var retb [32]byte
+	retb = ret.Bytes()
+	for i := 0; i < 16; i++ {
+		retb[31-i], retb[i] = retb[i], retb[31-i]
+	}
 	retb[31] = subIndex
 	return retb[:]
 

--- a/trie/verkle_test.go
+++ b/trie/verkle_test.go
@@ -386,7 +386,7 @@ func TestReproduceCondrieuPoAStemConflictWithAnotherStem(t *testing.T) {
 
 func TestGetTreeKeys(t *testing.T) {
 	addr := common.Hex2Bytes("71562b71999873DB5b286dF957af199Ec94617f7")
-	target := common.Hex2Bytes("0e19316be898a50719b7c321005583ddab6398f4e568d8efafb0619609700f00")
+	target := common.Hex2Bytes("e00f70099661b0afefd868e5f49863abdd83550021c3b71907a598e86b311900")
 	key := utils.GetTreeKeyVersion(addr)
 	t.Logf("key=%x", key)
 	t.Logf("actualKey=%x", target)


### PR DESCRIPTION
The endianness of `pedersen_hash` has changed when switching to Banderwagon. This is a problem because Pedersen hashes are field elements of width 253 bits. Using the top 31 bytes in big endian mode means that only 115 subtrees are used out of 256, thus making the tree unbalanced.

Until Banderwagon is switched to little endian, this change will swap the endianness of the pedersen hash output to take the 31 least significant bytes when calculating a tree address.