### PR TITLE
core, trie: flatten all chunks into a single linear buffer

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
-	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -88,12 +87,7 @@ func (ga *GenesisAlloc) flush(db ethdb.Database, cfg *params.ChainConfig) (commo
 	if cfg != nil {
 		trieCfg = &trie.Config{UseVerkle: cfg.IsCancun(big.NewInt(int64(0)))}
 	}
-	triedb := state.NewDatabaseWithConfig(db, trieCfg)
-	snaps, err := snapshot.New(db, triedb.TrieDB(), 1, common.Hash{}, false, true, false, true)
-	if err != nil {
-		return common.Hash{}, err
-	}
-	statedb, err := state.New(common.Hash{}, triedb, snaps)
+	statedb, err := state.New(common.Hash{}, state.NewDatabaseWithConfig(db, trieCfg), nil)
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -121,7 +121,7 @@ func newObject(db *StateDB, address common.Address, data types.StateAccount) *st
 
 			binary.LittleEndian.PutUint64(nonce[:8], data.Nonce)
 		}
-		db.Witness().SetGetObjectTouchedLeaves(address.Bytes(), version, balance[:], nonce[:], data.CodeHash)
+		db.witness.SetGetObjectTouchedLeaves(address.Bytes(), version, balance[:], nonce[:], data.CodeHash)
 	}
 
 	if data.Balance == nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -152,6 +152,15 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 		accessList:          newAccessList(),
 		hasher:              crypto.NewKeccakState(),
 	}
+	if tr.IsVerkle() {
+		sdb.witness = types.NewAccessWitness()
+		if sdb.snaps == nil {
+			sdb.snaps, err = snapshot.New(db.TrieDB().DiskDB(), db.TrieDB(), 1, root, false, true, false, true)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
 	if sdb.snaps != nil {
 		if sdb.snap = sdb.snaps.Snapshot(root); sdb.snap != nil {
 			sdb.snapDestructs = make(map[common.Hash]struct{})

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -524,8 +524,8 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 
 			if obj.dirtyCode {
 				if chunks, err := trie.ChunkifyCode(obj.code); err == nil {
-					for i := range chunks {
-						s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i))), chunks[32*i:(i+1)*32])
+					for i := 0; i < len(chunks); i += 32 {
+						s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i)/32)), chunks[i:i+32])
 					}
 				} else {
 					s.setError(err)
@@ -1020,8 +1020,8 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 			if obj.code != nil && obj.dirtyCode {
 				if s.trie.IsVerkle() {
 					if chunks, err := trie.ChunkifyCode(obj.code); err == nil {
-						for i := range chunks {
-							s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i))), chunks[i*32:32*(1+i)])
+						for i := 0; i < len(chunks); i += 32 {
+							s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i)/32)), chunks[i:32+i])
 						}
 					} else {
 						s.setError(err)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -516,7 +516,7 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 			if obj.dirtyCode {
 				if chunks, err := trie.ChunkifyCode(obj.code); err == nil {
 					for i := range chunks {
-						s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i))), chunks[i][:])
+						s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i))), chunks[32*i:(i+1)*32])
 					}
 				} else {
 					s.setError(err)
@@ -1012,7 +1012,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 				if s.trie.IsVerkle() {
 					if chunks, err := trie.ChunkifyCode(obj.code); err == nil {
 						for i := range chunks {
-							s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i))), chunks[i][:])
+							s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i))), chunks[i*32:32*(1+i)])
 						}
 					} else {
 						s.setError(err)

--- a/core/types/gen_account_rlp.go
+++ b/core/types/gen_account_rlp.go
@@ -5,8 +5,11 @@
 
 package types
 
-import "github.com/ethereum/go-ethereum/rlp"
-import "io"
+import (
+	"io"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
 
 func (obj *StateAccount) EncodeRLP(_w io.Writer) error {
 	w := rlp.NewEncoderBuffer(_w)

--- a/core/types/gen_header_rlp.go
+++ b/core/types/gen_header_rlp.go
@@ -5,10 +5,13 @@
 
 package types
 
-import "github.com/ethereum/go-ethereum/common"
-import "github.com/ethereum/go-ethereum/rlp"
-import "github.com/gballet/go-verkle"
-import "io"
+import (
+	"io"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/gballet/go-verkle"
+)
 
 func (obj *Header) EncodeRLP(_w io.Writer) error {
 	w := rlp.NewEncoderBuffer(_w)

--- a/core/types/gen_log_rlp.go
+++ b/core/types/gen_log_rlp.go
@@ -5,8 +5,11 @@
 
 package types
 
-import "github.com/ethereum/go-ethereum/rlp"
-import "io"
+import (
+	"io"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
 
 func (obj *rlpLog) EncodeRLP(_w io.Writer) error {
 	w := rlp.NewEncoderBuffer(_w)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -390,7 +390,7 @@ func touchEachChunksOnReadAndChargeGasWithAddress(offset, size uint64, address, 
 }
 
 // touchChunkOnReadAndChargeGas is a helper function to touch every chunk in a code range and charge witness gas costs
-func touchChunkOnReadAndChargeGas(chunks [][32]byte, offset uint64, evals [][]byte, code []byte, accesses *types.AccessWitness, deployment bool) uint64 {
+func touchChunkOnReadAndChargeGas(chunks trie.ChunkedCode, offset uint64, evals [][]byte, code []byte, accesses *types.AccessWitness, deployment bool) uint64 {
 	// note that in the case where the executed code is outside the range of
 	// the contract code but touches the last leaf with contract code in it,
 	// we don't include the last leaf of code in the AccessWitness. The
@@ -420,7 +420,7 @@ func touchChunkOnReadAndChargeGas(chunks [][32]byte, offset uint64, evals [][]by
 		if deployment {
 			accesses.SetLeafValue(index[:], nil)
 		} else {
-			accesses.SetLeafValue(index[:], chunks[chunknr][:])
+			accesses.SetLeafValue(index[:], chunks[chunknr*32:(chunknr+1)*32])
 		}
 	}
 
@@ -467,7 +467,7 @@ func touchEachChunksOnReadAndChargeGas(offset, size uint64, addrPoint *verkle.Po
 			if deployment {
 				accesses.SetLeafValue(index[:], nil)
 			} else {
-				accesses.SetLeafValue(index[:], chunks[i][:])
+				accesses.SetLeafValue(index[:], chunks[32*i:(i+1)*32])
 			}
 		}
 	}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -158,7 +158,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		logged  bool   // deferred EVMLogger should ignore already logged steps
 		res     []byte // result of the opcode execution function
 
-		chunks     [][32]byte
+		chunks     trie.ChunkedCode
 		chunkEvals [][]byte
 	)
 	// Don't move this deferred function, it's placed before the capturestate-deferred method,

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20220721134315-4fab3328c635
+	github.com/gballet/go-verkle v0.0.0-20220722103930-acd34254ebff
 	github.com/go-stack/stack v1.8.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqG
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/gballet/go-verkle v0.0.0-20220721055241-e8766f8d3fc5 h1:xt1HMesV5NWexeQj4LgveEMbxKlkfZCCHbDCnmI4USE=
 github.com/gballet/go-verkle v0.0.0-20220721055241-e8766f8d3fc5/go.mod h1:o/XfIXWi4/GqbQirfRm5uTbXMG5NpqxkxblnbZ+QM9I=
+github.com/gballet/go-verkle v0.0.0-20220722103930-acd34254ebff h1:s2sHJc8wheUHyLC/0BdmpaU/viPspno7s3R1wj6C/sg=
+github.com/gballet/go-verkle v0.0.0-20220722103930-acd34254ebff/go.mod h1:o/XfIXWi4/GqbQirfRm5uTbXMG5NpqxkxblnbZ+QM9I=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1152,6 +1152,9 @@ func (w *worker) commit(env *environment, interval func(), update bool, start ti
 		}
 
 		preTrie, err := env.state.Database().OpenTrie(env.preRoot)
+		if err != nil {
+			return err
+		}
 		if vtr, ok := preTrie.(*trie.VerkleTrie); ok {
 			keys := env.state.Witness().Keys()
 			kvs := env.state.Witness().KeyVals()

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -195,6 +195,7 @@ func (b *testWorkerBackend) newRandomUncle() *types.Block {
 	return blocks[0]
 }
 
+//nolint:unused
 func (b *testWorkerBackend) newRandomVerkleUncle() *types.Block {
 	var parent *types.Block
 	cur := b.chain.CurrentBlock()

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -268,6 +268,10 @@ func deserializeVerkleProof(serialized []byte, rootC *verkle.Point, keyvals []ve
 	return proof, pe.Cis, pe.Zis, pe.Yis, nil
 }
 
+// ChunkedCode represents a sequence of 32-bytes chunks of code (31 bytes of which
+// are actual code, and 1 byte is the pushdata offset).
+type ChunkedCode []byte
+
 // Copy the values here so as to avoid an import cycle
 const (
 	PUSH1  = byte(0x60)
@@ -279,7 +283,8 @@ const (
 	PUSH32 = byte(0x7f)
 )
 
-func ChunkifyCode(code []byte) ([][32]byte, error) {
+// ChunkifyCode generates the chunked version of an array representing EVM bytecode
+func ChunkifyCode(code []byte) (ChunkedCode, error) {
 	var (
 		chunkOffset = 0 // offset in the chunk
 		chunkCount  = len(code) / 31
@@ -288,7 +293,7 @@ func ChunkifyCode(code []byte) ([][32]byte, error) {
 	if len(code)%31 != 0 {
 		chunkCount++
 	}
-	chunks := make([][32]byte, chunkCount)
+	chunks := make([]byte, chunkCount*32)
 	for i := range chunks {
 		// number of bytes to copy, 31 unless
 		// the end of the code has been reached.
@@ -298,18 +303,18 @@ func ChunkifyCode(code []byte) ([][32]byte, error) {
 		}
 
 		// Copy the code itself
-		copy(chunks[i][1:], code[31*i:end])
+		copy(chunks[i*32+1:], code[31*i:end])
 
 		// chunk offset = taken from the
 		// last chunk.
 		if chunkOffset > 31 {
 			// skip offset calculation if push
 			// data covers the whole chunk
-			chunks[i][0] = 31
+			chunks[i*32] = 31
 			chunkOffset = 1
 			continue
 		}
-		chunks[i][0] = byte(chunkOffset)
+		chunks[32*i] = byte(chunkOffset)
 		chunkOffset = 0
 
 		// Check each instruction and update the offset

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -294,7 +294,7 @@ func ChunkifyCode(code []byte) (ChunkedCode, error) {
 		chunkCount++
 	}
 	chunks := make([]byte, chunkCount*32)
-	for i := range chunks {
+	for i := 0; i < chunkCount; i++ {
 		// number of bytes to copy, 31 unless
 		// the end of the code has been reached.
 		end := 31 * (i + 1)

--- a/trie/verkle_test.go
+++ b/trie/verkle_test.go
@@ -97,15 +97,16 @@ func TestChunkifyCodeTestnet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(chunks) != (len(code)+30)/31 {
-		t.Fatalf("invalid length %d", len(chunks))
+	if len(chunks) != 32*(len(code)/31+1) {
+		t.Fatalf("invalid length %d != %d", len(chunks), 32*(len(code)/31+1))
 	}
-	if chunks[0][0] != 0 {
-		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0][0])
+	if chunks[0] != 0 {
+		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0])
 	}
 	t.Logf("%x\n", chunks[0])
-	for i, chunk := range chunks[1:] {
-		if chunk[0] != 0 && i != 4 {
+	for i := 32; i < len(chunks); i += 32 {
+		chunk := chunks[i : 32+i]
+		if chunk[0] != 0 && i != 5*32 {
 			t.Fatalf("invalid offset in chunk #%d %d != 0", i+1, chunk[0])
 		}
 		if i == 4 && chunk[0] != 12 {
@@ -119,17 +120,19 @@ func TestChunkifyCodeTestnet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(chunks) != (len(code)+30)/31 {
+	if len(chunks) != 32*((len(code)+30)/31) {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
-	if chunks[0][0] != 0 {
-		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0][0])
+	if chunks[0] != 0 {
+		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0])
 	}
 	t.Logf("%x\n", chunks[0])
 	expected := []byte{0, 1, 0, 13, 0, 0, 1, 0, 0, 0, 0, 0, 0, 3}
-	for i, chunk := range chunks[1:] {
-		if chunk[0] != expected[i] {
-			t.Fatalf("invalid offset in chunk #%d %d != %d", i+1, chunk[0], expected[i])
+	for i := 32; i < len(chunks); i += 32 {
+		chunk := chunks[i : 32+i]
+		t.Log(i, i/32, chunk[0])
+		if chunk[0] != expected[i/32-1] {
+			t.Fatalf("invalid offset in chunk #%d %d != %d", i/32-1, chunk[0], expected[i/32-1])
 		}
 	}
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
@@ -139,16 +142,17 @@ func TestChunkifyCodeTestnet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(chunks) != (len(code)+30)/31 {
+	if len(chunks) != 32*((len(code)+30)/31) {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
-	if chunks[0][0] != 0 {
-		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0][0])
+	if chunks[0] != 0 {
+		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0])
 	}
 	expected = []byte{0, 0, 0, 0, 13}
-	for i, chunk := range chunks[1:] {
-		if chunk[0] != expected[i] {
-			t.Fatalf("invalid offset in chunk #%d %d != %d", i+1, chunk[0], expected[i])
+	for i := 32; i < len(chunks); i += 32 {
+		chunk := chunks[i : 32+i]
+		if chunk[0] != expected[i/32-1] {
+			t.Fatalf("invalid offset in chunk #%d %d != %d", i/32-1, chunk[0], expected[i/32-1])
 		}
 	}
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
@@ -170,17 +174,17 @@ func TestChunkifyCodeSimple(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(chunks) != 3 {
+	if len(chunks) != 96 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
-	if chunks[0][0] != 0 {
-		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0][0])
+	if chunks[0] != 0 {
+		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0])
 	}
-	if chunks[1][0] != 1 {
-		t.Fatalf("invalid offset in second chunk %d != 1, chunk=%x", chunks[1][0], chunks[1])
+	if chunks[32] != 1 {
+		t.Fatalf("invalid offset in second chunk %d != 1, chunk=%x", chunks[32], chunks[32:64])
 	}
-	if chunks[2][0] != 0 {
-		t.Fatalf("invalid offset in third chunk %d != 0", chunks[2][0])
+	if chunks[64] != 0 {
+		t.Fatalf("invalid offset in third chunk %d != 0", chunks[64])
 	}
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
 }
@@ -194,11 +198,11 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(chunks) != 1 {
+	if len(chunks) != 32 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
-	if chunks[0][0] != 0 {
-		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0][0])
+	if chunks[0] != 0 {
+		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0])
 	}
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
 
@@ -210,11 +214,11 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(chunks) != 1 {
+	if len(chunks) != 32 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
-	if chunks[0][0] != 0 {
-		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0][0])
+	if chunks[0] != 0 {
+		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0])
 	}
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
 
@@ -226,14 +230,14 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(chunks) != 2 {
+	if len(chunks) != 64 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
-	if chunks[0][0] != 0 {
-		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0][0])
+	if chunks[0] != 0 {
+		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0])
 	}
-	if chunks[1][0] != 0 {
-		t.Fatalf("invalid offset in second chunk %d != 0, chunk=%x", chunks[1][0], chunks[1])
+	if chunks[32] != 0 {
+		t.Fatalf("invalid offset in second chunk %d != 0, chunk=%x", chunks[32], chunks[32:64])
 	}
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
 
@@ -245,14 +249,14 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(chunks) != 2 {
+	if len(chunks) != 64 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
-	if chunks[0][0] != 0 {
-		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0][0])
+	if chunks[0] != 0 {
+		t.Fatalf("invalid offset in first chunk %d != 0", chunks[0])
 	}
-	if chunks[1][0] != 0 {
-		t.Fatalf("invalid offset in second chunk %d != 0, chunk=%x", chunks[1][0], chunks[1])
+	if chunks[32] != 0 {
+		t.Fatalf("invalid offset in second chunk %d != 0, chunk=%x", chunks[32], chunks[32:64])
 	}
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
 }


### PR DESCRIPTION
Flatten all code chunks into a single buffer.

This represents yet another approach to integrate code chunking in geth: instead of hacking the interface to pass the chunks along with the code, just return the chunked code in its place. This will have an impact on the tracking of the program counter by the interpreter loop, but it should be less invasive than a full interface change.