### PR TITLE
core/state: cache point evals in the StateDB

### DIFF
--- a/core/state/access_witness.go
+++ b/core/state/access_witness.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package types
+package state
 
 import (
 	"encoding/binary"
@@ -303,7 +303,7 @@ func (aw *AccessWitness) SetLeafValuesMessageCall(addr, codeSize []byte) {
 		data  [32]byte
 	)
 	// Only evaluate the polynomial once
-	versionkey := utils.GetTreeKeyVersion(addr[:])
+	versionkey := aw.GetTreeKeyVersionCached(addr[:])
 	copy(cskey[:], versionkey)
 	cskey[31] = utils.CodeSizeLeafKey
 	aw.SetLeafValue(versionkey, data[:])

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -105,7 +105,7 @@ type StateDB struct {
 	// Per-transaction access list
 	accessList *accessList
 
-	witness *types.AccessWitness
+	witness *AccessWitness
 
 	// Journal of state modifications. This is the backbone of
 	// Snapshot and RevertToSnapshot.
@@ -166,14 +166,14 @@ func (s *StateDB) Snaps() *snapshot.Tree {
 	return s.snaps
 }
 
-func (s *StateDB) Witness() *types.AccessWitness {
+func (s *StateDB) Witness() *AccessWitness {
 	if s.witness == nil {
-		s.witness = types.NewAccessWitness()
+		s.witness = NewAccessWitness()
 	}
 	return s.witness
 }
 
-func (s *StateDB) SetWitness(aw *types.AccessWitness) {
+func (s *StateDB) SetWitness(aw *AccessWitness) {
 	s.witness = aw
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	trieUtils "github.com/ethereum/go-ethereum/trie/utils"
+	"github.com/gballet/go-verkle"
 	"github.com/holiman/uint256"
 )
 
@@ -107,6 +108,10 @@ type StateDB struct {
 
 	witness *AccessWitness
 
+	// Caches all the points that correspond to an address,
+	// so they are not recalculated.
+	addrToPoint map[string]*verkle.Point
+
 	// Journal of state modifications. This is the backbone of
 	// Snapshot and RevertToSnapshot.
 	journal        *journal
@@ -151,6 +156,7 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 		journal:             newJournal(),
 		accessList:          newAccessList(),
 		hasher:              crypto.NewKeccakState(),
+		addrToPoint:         make(map[string]*verkle.Point),
 	}
 	if sdb.snaps != nil {
 		if sdb.snap = sdb.snaps.Snapshot(root); sdb.snap != nil {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -96,7 +96,7 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 	// Create a new context to be used in the EVM environment.
 	txContext := NewEVMTxContext(msg)
 	if config.IsCancun(blockNumber) {
-		txContext.Accesses = types.NewAccessWitness()
+		txContext.Accesses = state.NewAccessWitness()
 	}
 	evm.Reset(txContext, statedb)
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
@@ -86,7 +86,7 @@ type TxContext struct {
 	Origin   common.Address // Provides information for ORIGIN
 	GasPrice *big.Int       // Provides information for GASPRICE
 
-	Accesses *types.AccessWitness
+	Accesses *state.AccessWitness
 }
 
 // EVM is the Ethereum Virtual Machine base object and provides
@@ -130,7 +130,7 @@ type EVM struct {
 // only ever be used *once*.
 func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig *params.ChainConfig, config Config) *EVM {
 	if txCtx.Accesses == nil && chainConfig.IsCancun(blockCtx.BlockNumber) {
-		txCtx.Accesses = types.NewAccessWitness()
+		txCtx.Accesses = state.NewAccessWitness()
 	}
 	evm := &EVM{
 		Context:     blockCtx,
@@ -148,7 +148,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 // This is not threadsafe and should only be done very cautiously.
 func (evm *EVM) Reset(txCtx TxContext, statedb StateDB) {
 	if txCtx.Accesses == nil && evm.chainConfig.IsCancun(evm.Context.BlockNumber) {
-		txCtx.Accesses = types.NewAccessWitness()
+		txCtx.Accesses = state.NewAccessWitness()
 	}
 	evm.TxContext = txCtx
 	evm.StateDB = statedb

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
@@ -384,13 +385,13 @@ func opCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	return nil, nil
 }
 
-func touchEachChunksOnReadAndChargeGasWithAddress(offset, size uint64, address, code []byte, accesses *types.AccessWitness, deployment bool) uint64 {
+func touchEachChunksOnReadAndChargeGasWithAddress(offset, size uint64, address, code []byte, accesses *state.AccessWitness, deployment bool) uint64 {
 	addrPoint := trieUtils.EvaluateAddressPoint(address)
 	return touchEachChunksOnReadAndChargeGas(offset, size, addrPoint, code, accesses, deployment)
 }
 
 // touchChunkOnReadAndChargeGas is a helper function to touch every chunk in a code range and charge witness gas costs
-func touchChunkOnReadAndChargeGas(chunks [][32]byte, offset uint64, evals [][]byte, code []byte, accesses *types.AccessWitness, deployment bool) uint64 {
+func touchChunkOnReadAndChargeGas(chunks [][32]byte, offset uint64, evals [][]byte, code []byte, accesses *state.AccessWitness, deployment bool) uint64 {
 	// note that in the case where the executed code is outside the range of
 	// the contract code but touches the last leaf with contract code in it,
 	// we don't include the last leaf of code in the AccessWitness. The
@@ -428,7 +429,7 @@ func touchChunkOnReadAndChargeGas(chunks [][32]byte, offset uint64, evals [][]by
 }
 
 // touchEachChunksOnReadAndChargeGas is a helper function to touch every chunk in a code range and charge witness gas costs
-func touchEachChunksOnReadAndChargeGas(offset, size uint64, addrPoint *verkle.Point, code []byte, accesses *types.AccessWitness, deployment bool) uint64 {
+func touchEachChunksOnReadAndChargeGas(offset, size uint64, addrPoint *verkle.Point, code []byte, accesses *state.AccessWitness, deployment bool) uint64 {
 	// note that in the case where the copied code is outside the range of the
 	// contract code but touches the last leaf with contract code in it,
 	// we don't include the last leaf of code in the AccessWitness.  The

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -78,8 +79,8 @@ type StateDB interface {
 
 	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error
 
-	Witness() *types.AccessWitness
-	SetWitness(*types.AccessWitness)
+	Witness() *state.AccessWitness
+	SetWitness(*state.AccessWitness)
 }
 
 // CallContext provides a basic interface for the EVM calling conventions. The EVM

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20220721134315-4fab3328c635
+	github.com/gballet/go-verkle v0.0.0-20220722103930-acd34254ebff
 	github.com/go-stack/stack v1.8.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/golang/protobuf v1.5.2
@@ -61,7 +61,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
+	golang.org/x/sys v0.0.0-20220803195053-6e608f9ce704
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqG
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/gballet/go-verkle v0.0.0-20220721055241-e8766f8d3fc5 h1:xt1HMesV5NWexeQj4LgveEMbxKlkfZCCHbDCnmI4USE=
 github.com/gballet/go-verkle v0.0.0-20220721055241-e8766f8d3fc5/go.mod h1:o/XfIXWi4/GqbQirfRm5uTbXMG5NpqxkxblnbZ+QM9I=
+github.com/gballet/go-verkle v0.0.0-20220722103930-acd34254ebff h1:s2sHJc8wheUHyLC/0BdmpaU/viPspno7s3R1wj6C/sg=
+github.com/gballet/go-verkle v0.0.0-20220722103930-acd34254ebff/go.mod h1:o/XfIXWi4/GqbQirfRm5uTbXMG5NpqxkxblnbZ+QM9I=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -571,6 +573,8 @@ golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d h1:/m5NbqQelATgoSPVC2Z23sR4k
 golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220803195053-6e608f9ce704 h1:Y7NOhdqIOU8kYI7BxsgL38d0ot0raxvcW+EMQU2QrT4=
+golang.org/x/sys v0.0.0-20220803195053-6e608f9ce704/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=


### PR DESCRIPTION
This is an experiment to attempt to reduce the amount of pedersen commitment evaluations by caching them in the `StateDB` instead of having per-tx caches.

*TODO*

 * [ ] test it on condrieu
 * [ ] test it in a block-replay context
 * [ ] store everything in a LRU to make sure the cache doesn't OOM