### PR TITLE
core: store the chunked code directly in the database

### DIFF
--- a/core/types/access_witness.go
+++ b/core/types/access_witness.go
@@ -336,9 +336,7 @@ func (aw *AccessWitness) TouchAndChargeContractCreateInit(addr []byte, createSen
 
 	gas += aw.TouchAddressOnWriteAndComputeGas(versionkey)
 	gas += aw.TouchAddressOnWriteAndComputeGas(noncekey[:])
-	if createSendsValue {
-		gas += aw.TouchAddressOnWriteAndComputeGas(balancekey[:])
-	}
+	gas += aw.TouchAddressOnWriteAndComputeGas(balancekey[:])
 	gas += aw.TouchAddressOnWriteAndComputeGas(ckkey[:])
 	return gas
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -525,6 +525,11 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 			err = ErrOutOfGas
 		} else {
 			evm.Accesses.SetLeafValuesContractCreateCompleted(address.Bytes()[:], zeroVerkleLeaf[:], zeroVerkleLeaf[:])
+
+			if !contract.UseGas(evm.StateDB.AddCodeChunksToWitness(address)) {
+				evm.StateDB.RevertToSnapshot(snapshot)
+				err = ErrOutOfGas
+			}
 		}
 	}
 

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -121,8 +121,10 @@ func gasCodeCopy(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
 		if overflow {
 			uint64Length = 0xffffffffffffffff
 		}
-		_, offset, nonPaddedSize := getDataAndAdjustedBounds(contract.Code, uint64CodeOffset, uint64Length)
-		statelessGas = touchEachChunksOnReadAndChargeGas(offset, nonPaddedSize, contract.AddressPoint(), nil, evm.Accesses, contract.IsDeployment)
+		if !contract.IsDeployment {
+			_, offset, nonPaddedSize := getDataAndAdjustedBounds(contract.Code, uint64CodeOffset, uint64Length)
+			statelessGas = touchEachChunksOnReadAndChargeGas(offset, nonPaddedSize, contract.AddressPoint(), nil, evm.Accesses, contract.IsDeployment)
+		}
 	}
 	usedGas, err := gasCodeCopyStateful(evm, contract, stack, mem, memorySize)
 	return usedGas + statelessGas, err

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -38,6 +38,7 @@ type StateDB interface {
 	GetCode(common.Address) []byte
 	SetCode(common.Address, []byte)
 	GetCodeSize(common.Address) int
+	AddCodeChunksToWitness(common.Address) uint64
 
 	AddRefund(uint64)
 	SubRefund(uint64)


### PR DESCRIPTION
This is the 3rd attempt at storing the code chunking into the database in order to speed-up verkle tree execution. Instead of creating two different code paths between chunked/not chunked, this approach simply assumes that the binary payload stored in the DB is already chunked code. So it is the responsibility of the contract-creation code to chunk it once and for all.

It introduces a few helper functions to help manage chunked code and make the conversion from "linear" to "chunked" space simpler:

 * A chunk iterator;
 * `AtPC`, a method to take a "linear space" program counter and return the byte in a chunked space;

Ideally, there should be a `Code` interface, that would be implemented by both `ChunkedCode` and `LinearCode`. I'll leave the verkle branch some time to mature before I propose this interface in the main repository.

### TODO

 * [ ] Add a test for `EXTCODECOPY`
 * [ ] Condrieu test
 * [ ] Conversion test