### PR TITLE
core, trie: cache the code chunking in contract

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -523,12 +523,9 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 			}
 
 			if obj.dirtyCode {
-				if chunks, err := trie.ChunkifyCode(obj.code); err == nil {
-					for i := 0; i < len(chunks); i += 32 {
-						s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i)/32)), chunks[i:i+32])
-					}
-				} else {
-					s.setError(err)
+				chunks := trie.ChunkifyCode(obj.code)
+				for i := 0; i < len(chunks); i += 32 {
+					s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i)/32)), chunks[i:i+32])
 				}
 			}
 		} else {
@@ -1019,12 +1016,9 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 			// Write any contract code associated with the state object
 			if obj.code != nil && obj.dirtyCode {
 				if s.trie.IsVerkle() {
-					if chunks, err := trie.ChunkifyCode(obj.code); err == nil {
-						for i := 0; i < len(chunks); i += 32 {
-							s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i)/32)), chunks[i:32+i])
-						}
-					} else {
-						s.setError(err)
+					chunks := trie.ChunkifyCode(obj.code)
+					for i := 0; i < len(chunks); i += 32 {
+						s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i)/32)), chunks[i:32+i])
 					}
 				}
 				rawdb.WriteCode(codeWriter, common.BytesToHash(obj.CodeHash()), obj.code)

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -440,7 +440,7 @@ func TestProcessVerkle(t *testing.T) {
 			t.Fatalf("expected block %d to be present in chain", i+1)
 		}
 		if b.GasUsed() != blockGasUsagesExpected[i] {
-			t.Fatalf("expected block txs to use %d, got %d\n", blockGasUsagesExpected[i], b.GasUsed())
+			t.Fatalf("expected block txs to use %d, got %d in block %d\n", blockGasUsagesExpected[i], b.GasUsed(), i)
 		}
 	}
 }

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/gballet/go-verkle"
 	"github.com/holiman/uint256"
@@ -57,6 +58,7 @@ type Contract struct {
 	analysis  bitvec                 // Locally cached result of JUMPDEST analysis
 
 	Code     []byte
+	Chunks   trie.ChunkedCode
 	CodeHash common.Hash
 	CodeAddr *common.Address
 	Input    []byte

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -89,10 +89,10 @@ func memoryCopierGas(stackpos int) gasFunc {
 }
 
 var (
-	gasCallDataCopy        = memoryCopierGas(2)
-	gasCodeCopyStateful    = memoryCopierGas(2)
-	gasExtCodeCopyStateful = memoryCopierGas(3)
-	gasReturnDataCopy      = memoryCopierGas(2)
+	gasCallDataCopy   = memoryCopierGas(2)
+	gasCodeCopy       = memoryCopierGas(2)
+	gasExtCodeCopy    = memoryCopierGas(3)
+	gasReturnDataCopy = memoryCopierGas(2)
 )
 
 func gasExtCodeSize(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
@@ -104,56 +104,6 @@ func gasExtCodeSize(evm *EVM, contract *Contract, stack *Stack, mem *Memory, mem
 	}
 
 	return usedGas, nil
-}
-
-func gasCodeCopy(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	var statelessGas uint64
-	if evm.chainConfig.IsCancun(evm.Context.BlockNumber) {
-		var (
-			codeOffset = stack.Back(1)
-			length     = stack.Back(2)
-		)
-		uint64CodeOffset, overflow := codeOffset.Uint64WithOverflow()
-		if overflow {
-			uint64CodeOffset = 0xffffffffffffffff
-		}
-		uint64Length, overflow := length.Uint64WithOverflow()
-		if overflow {
-			uint64Length = 0xffffffffffffffff
-		}
-		_, offset, nonPaddedSize := getDataAndAdjustedBounds(contract.Code, uint64CodeOffset, uint64Length)
-		statelessGas = touchEachChunksOnReadAndChargeGas(offset, nonPaddedSize, contract, nil, evm.Accesses, contract.IsDeployment)
-	}
-	usedGas, err := gasCodeCopyStateful(evm, contract, stack, mem, memorySize)
-	return usedGas + statelessGas, err
-}
-
-func gasExtCodeCopy(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	var statelessGas uint64
-	if evm.chainConfig.IsCancun(evm.Context.BlockNumber) {
-		var (
-			codeOffset = stack.Back(2)
-			length     = stack.Back(3)
-		)
-		uint64CodeOffset, overflow := codeOffset.Uint64WithOverflow()
-		if overflow {
-			uint64CodeOffset = 0xffffffffffffffff
-		}
-		uint64Length, overflow := length.Uint64WithOverflow()
-		if overflow {
-			uint64Length = 0xffffffffffffffff
-		}
-		othercontract := &Contract{}
-		// note:  we must charge witness costs for the specified range regardless of whether it
-		// is in-bounds of the actual target account code.  This is because we must charge the cost
-		// before hitting the db to be able to now what the actual code size is.  This is different
-		// behavior from CODECOPY which only charges witness access costs for the part of the range
-		// which overlaps in the account code.  TODO: clarify this is desired behavior and amend the
-		// spec.
-		statelessGas = touchEachChunksOnReadAndChargeGasWithAddress(uint64CodeOffset, uint64Length, othercontract, nil, evm.Accesses, contract.IsDeployment)
-	}
-	usedGas, err := gasExtCodeCopyStateful(evm, contract, stack, mem, memorySize)
-	return usedGas + statelessGas, err
 }
 
 func gasSLoad(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
 	trieUtils "github.com/ethereum/go-ethereum/trie/utils"
-	"github.com/gballet/go-verkle"
 	"github.com/holiman/uint256"
 	"golang.org/x/crypto/sha3"
 )
@@ -378,15 +377,14 @@ func opCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 
 	paddedCodeCopy, copyOffset, nonPaddedCopyLength := getDataAndAdjustedBounds(scope.Contract.Code, uint64CodeOffset, length.Uint64())
 	if interpreter.evm.chainConfig.IsCancun(interpreter.evm.Context.BlockNumber) {
-		touchEachChunksOnReadAndChargeGas(copyOffset, nonPaddedCopyLength, scope.Contract.AddressPoint(), scope.Contract.Code, interpreter.evm.Accesses, scope.Contract.IsDeployment)
+		touchEachChunksOnReadAndChargeGas(copyOffset, nonPaddedCopyLength, scope.Contract, scope.Contract.Code, interpreter.evm.Accesses, scope.Contract.IsDeployment)
 	}
 	scope.Memory.Set(memOffset.Uint64(), uint64(len(paddedCodeCopy)), paddedCodeCopy)
 	return nil, nil
 }
 
-func touchEachChunksOnReadAndChargeGasWithAddress(offset, size uint64, address, code []byte, accesses *types.AccessWitness, deployment bool) uint64 {
-	addrPoint := trieUtils.EvaluateAddressPoint(address)
-	return touchEachChunksOnReadAndChargeGas(offset, size, addrPoint, code, accesses, deployment)
+func touchEachChunksOnReadAndChargeGasWithAddress(offset, size uint64, contract *Contract, code []byte, accesses *types.AccessWitness, deployment bool) uint64 {
+	return touchEachChunksOnReadAndChargeGas(offset, size, contract, code, accesses, deployment)
 }
 
 // touchChunkOnReadAndChargeGas is a helper function to touch every chunk in a code range and charge witness gas costs
@@ -428,7 +426,7 @@ func touchChunkOnReadAndChargeGas(chunks trie.ChunkedCode, offset uint64, evals 
 }
 
 // touchEachChunksOnReadAndChargeGas is a helper function to touch every chunk in a code range and charge witness gas costs
-func touchEachChunksOnReadAndChargeGas(offset, size uint64, addrPoint *verkle.Point, code []byte, accesses *types.AccessWitness, deployment bool) uint64 {
+func touchEachChunksOnReadAndChargeGas(offset, size uint64, contract *Contract, code []byte, accesses *types.AccessWitness, deployment bool) uint64 {
 	// note that in the case where the copied code is outside the range of the
 	// contract code but touches the last leaf with contract code in it,
 	// we don't include the last leaf of code in the AccessWitness.  The
@@ -447,15 +445,11 @@ func touchEachChunksOnReadAndChargeGas(offset, size uint64, addrPoint *verkle.Po
 	} else {
 		endOffset = offset + size
 	}
-	chunks, err := trie.ChunkifyCode(code)
-	if err != nil {
-		panic(err)
-	}
 
 	// endOffset - 1 since if the end offset is aligned on a chunk boundary,
 	// the last chunk should not be included.
 	for i := offset / 31; i <= (endOffset-1)/31; i++ {
-		index := trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(addrPoint, uint256.NewInt(i))
+		index := trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(contract.AddressPoint(), uint256.NewInt(i))
 
 		var overflow bool
 		statelessGasCharged, overflow = math.SafeAdd(statelessGasCharged, accesses.TouchAddressOnReadAndComputeGas(index))
@@ -467,7 +461,7 @@ func touchEachChunksOnReadAndChargeGas(offset, size uint64, addrPoint *verkle.Po
 			if deployment {
 				accesses.SetLeafValue(index[:], nil)
 			} else {
-				accesses.SetLeafValue(index[:], chunks[32*i:(i+1)*32])
+				accesses.SetLeafValue(index[:], contract.Chunks[32*i:(i+1)*32])
 			}
 		}
 	}
@@ -490,8 +484,12 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	addr := common.Address(a.Bytes20())
 	if interpreter.evm.chainConfig.IsCancun(interpreter.evm.Context.BlockNumber) {
 		code := interpreter.evm.StateDB.GetCode(addr)
+		contract := &Contract{
+			Code:   code,
+			Chunks: trie.ChunkifyCode(code),
+		}
 		paddedCodeCopy, copyOffset, nonPaddedCopyLength := getDataAndAdjustedBounds(code, uint64CodeOffset, length.Uint64())
-		touchEachChunksOnReadAndChargeGasWithAddress(copyOffset, nonPaddedCopyLength, addr[:], code, interpreter.evm.Accesses, false)
+		touchEachChunksOnReadAndChargeGasWithAddress(copyOffset, nonPaddedCopyLength, contract, code, interpreter.evm.Accesses, false)
 		scope.Memory.Set(memOffset.Uint64(), length.Uint64(), paddedCodeCopy)
 	} else {
 		codeCopy := getData(interpreter.evm.StateDB.GetCode(addr), uint64CodeOffset, length.Uint64())
@@ -1009,7 +1007,7 @@ func opPush1(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 		if interpreter.evm.chainConfig.IsCancun(interpreter.evm.Context.BlockNumber) && *pc%31 == 0 {
 			// touch next chunk if PUSH1 is at the boundary. if so, *pc has
 			// advanced past this boundary.
-			statelessGas := touchEachChunksOnReadAndChargeGas(*pc+1, uint64(1), scope.Contract.AddressPoint(), scope.Contract.Code, interpreter.evm.Accesses, scope.Contract.IsDeployment)
+			statelessGas := touchEachChunksOnReadAndChargeGas(*pc+1, uint64(1), scope.Contract, scope.Contract.Code, interpreter.evm.Accesses, scope.Contract.IsDeployment)
 			scope.Contract.UseGas(statelessGas)
 		}
 	} else {
@@ -1034,7 +1032,7 @@ func makePush(size uint64, pushByteSize int) executionFunc {
 		}
 
 		if interpreter.evm.chainConfig.IsCancun(interpreter.evm.Context.BlockNumber) {
-			statelessGas := touchEachChunksOnReadAndChargeGas(uint64(startMin), uint64(pushByteSize), scope.Contract.AddressPoint(), scope.Contract.Code, interpreter.evm.Accesses, scope.Contract.IsDeployment)
+			statelessGas := touchEachChunksOnReadAndChargeGas(uint64(startMin), uint64(pushByteSize), scope.Contract, scope.Contract.Code, interpreter.evm.Accesses, scope.Contract.IsDeployment)
 			scope.Contract.UseGas(statelessGas)
 		}
 

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -377,7 +377,7 @@ func opCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 
 	paddedCodeCopy, copyOffset, nonPaddedCopyLength := getDataAndAdjustedBounds(scope.Contract.Code, uint64CodeOffset, length.Uint64())
 	if interpreter.evm.chainConfig.IsCancun(interpreter.evm.Context.BlockNumber) {
-		touchEachChunksOnReadAndChargeGas(copyOffset, nonPaddedCopyLength, scope.Contract, scope.Contract.Code, interpreter.evm.Accesses, scope.Contract.IsDeployment)
+		scope.Contract.UseGas(touchEachChunksOnReadAndChargeGas(copyOffset, nonPaddedCopyLength, scope.Contract, scope.Contract.Code, interpreter.evm.Accesses, scope.Contract.IsDeployment))
 	}
 	scope.Memory.Set(memOffset.Uint64(), uint64(len(paddedCodeCopy)), paddedCodeCopy)
 	return nil, nil

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -492,6 +492,7 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 		contract := &Contract{
 			Code:   code,
 			Chunks: trie.ChunkifyCode(code),
+			self:   AccountRef(addr),
 		}
 		paddedCodeCopy, copyOffset, nonPaddedCopyLength := getDataAndAdjustedBounds(code, uint64CodeOffset, length.Uint64())
 		touchEachChunksOnReadAndChargeGasWithAddress(copyOffset, nonPaddedCopyLength, contract, code, interpreter.evm.Accesses, false)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -158,7 +158,6 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		logged  bool   // deferred EVMLogger should ignore already logged steps
 		res     []byte // result of the opcode execution function
 
-		chunks     trie.ChunkedCode
 		chunkEvals [][]byte
 	)
 	// Don't move this deferred function, it's placed before the capturestate-deferred method,
@@ -183,7 +182,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 
 	// Evaluate one address per group of 256, 31-byte chunks
 	if in.evm.ChainConfig().IsCancun(in.evm.Context.BlockNumber) && !contract.IsDeployment {
-		chunks, err = trie.ChunkifyCode(contract.Code)
+		contract.Chunks = trie.ChunkifyCode(contract.Code)
 
 		totalEvals := len(contract.Code) / 31 / 256
 		if len(contract.Code)%(256*31) != 0 {
@@ -206,10 +205,10 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			logged, pcCopy, gasCopy = false, pc, contract.Gas
 		}
 
-		if chunks != nil {
+		if contract.Chunks != nil {
 			// if the PC ends up in a new "chunk" of verkleized code, charge the
 			// associated costs.
-			contract.Gas -= touchChunkOnReadAndChargeGas(chunks, pc, chunkEvals, contract.Code, in.evm.TxContext.Accesses, contract.IsDeployment)
+			contract.Gas -= touchChunkOnReadAndChargeGas(contract.Chunks, pc, chunkEvals, contract.Code, in.evm.TxContext.Accesses, contract.IsDeployment)
 		}
 
 		// Get the operation from the jump table and validate the stack to ensure there are

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -284,7 +284,7 @@ const (
 )
 
 // ChunkifyCode generates the chunked version of an array representing EVM bytecode
-func ChunkifyCode(code []byte) (ChunkedCode, error) {
+func ChunkifyCode(code []byte) ChunkedCode {
 	var (
 		chunkOffset = 0 // offset in the chunk
 		chunkCount  = len(code) / 31
@@ -331,5 +331,5 @@ func ChunkifyCode(code []byte) (ChunkedCode, error) {
 		}
 	}
 
-	return chunks, nil
+	return chunks
 }

--- a/trie/verkle_test.go
+++ b/trie/verkle_test.go
@@ -93,10 +93,7 @@ func TestReproduceTree(t *testing.T) {
 
 func TestChunkifyCodeTestnet(t *testing.T) {
 	code, _ := hex.DecodeString("6080604052348015600f57600080fd5b506004361060285760003560e01c806381ca91d314602d575b600080fd5b60336047565b604051603e9190605a565b60405180910390f35b60005481565b6054816073565b82525050565b6000602082019050606d6000830184604d565b92915050565b600081905091905056fea264697066735822122000382db0489577c1646ea2147a05f92f13f32336a32f1f82c6fb10b63e19f04064736f6c63430008070033")
-	chunks, err := ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks := ChunkifyCode(code)
 	if len(chunks) != 32*(len(code)/31+1) {
 		t.Fatalf("invalid length %d != %d", len(chunks), 32*(len(code)/31+1))
 	}
@@ -116,10 +113,7 @@ func TestChunkifyCodeTestnet(t *testing.T) {
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
 
 	code, _ = hex.DecodeString("608060405234801561001057600080fd5b506004361061002b5760003560e01c8063f566852414610030575b600080fd5b61003861004e565b6040516100459190610146565b60405180910390f35b6000600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166381ca91d36040518163ffffffff1660e01b815260040160206040518083038186803b1580156100b857600080fd5b505afa1580156100cc573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906100f0919061010a565b905090565b60008151905061010481610170565b92915050565b6000602082840312156101205761011f61016b565b5b600061012e848285016100f5565b91505092915050565b61014081610161565b82525050565b600060208201905061015b6000830184610137565b92915050565b6000819050919050565b600080fd5b61017981610161565b811461018457600080fd5b5056fea2646970667358221220d8add45a339f741a94b4fe7f22e101b560dc8a5874cbd957a884d8c9239df86264736f6c63430008070033")
-	chunks, err = ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks = ChunkifyCode(code)
 	if len(chunks) != 32*((len(code)+30)/31) {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
@@ -138,10 +132,7 @@ func TestChunkifyCodeTestnet(t *testing.T) {
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
 
 	code, _ = hex.DecodeString("6080604052348015600f57600080fd5b506004361060285760003560e01c8063ab5ed15014602d575b600080fd5b60336047565b604051603e9190605d565b60405180910390f35b60006001905090565b6057816076565b82525050565b6000602082019050607060008301846050565b92915050565b600081905091905056fea2646970667358221220163c79eab5630c3dbe22f7cc7692da08575198dda76698ae8ee2e3bfe62af3de64736f6c63430008070033")
-	chunks, err = ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks = ChunkifyCode(code)
 	if len(chunks) != 32*((len(code)+30)/31) {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
@@ -170,10 +161,7 @@ func TestChunkifyCodeSimple(t *testing.T) {
 		23, 24, 25, 26, 27, 28, 29, 30,
 	}
 	t.Logf("code=%x", code)
-	chunks, err := ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks := ChunkifyCode(code)
 	if len(chunks) != 96 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
@@ -194,10 +182,7 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 		3, PUSH32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
 		17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
 	}
-	chunks, err := ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks := ChunkifyCode(code)
 	if len(chunks) != 32 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
@@ -210,10 +195,7 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		0, 0, 0, 0, 0, 0, 0, 0, 0, PUSH32,
 	}
-	chunks, err = ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks = ChunkifyCode(code)
 	if len(chunks) != 32 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
@@ -226,10 +208,7 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 		PUSH4, PUSH32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	}
-	chunks, err = ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks = ChunkifyCode(code)
 	if len(chunks) != 64 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
@@ -245,10 +224,7 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 		PUSH4, PUSH32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	}
-	chunks, err = ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks = ChunkifyCode(code)
 	if len(chunks) != 64 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}


### PR DESCRIPTION
Since `ChunkifyCode` and `touchEachChunksOnReadAndChargeGas` are dominating the execution time, this PR attempts to cache the values as much as possible, in order to reduce the amount of time these functions are called.