### PR TITLE
spec: don't create code keccak/size leaves for EoAs

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -73,7 +73,7 @@ type Trie interface {
 	TryGet(key []byte) ([]byte, error)
 
 	// TryUpdateAccount abstract an account write in the trie.
-	TryUpdateAccount(key []byte, account *types.StateAccount) error
+	TryUpdateAccount(key []byte, account *types.StateAccount, code []byte) error
 
 	// TryUpdate associates key with value in the trie. If value has length zero, any
 	// existing value is deleted from the trie. The value bytes must not be modified

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -521,16 +521,8 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 	// Encode the account and update the account trie
 	addr := obj.Address()
 
-	if err := s.trie.TryUpdateAccount(addr[:], &obj.data); err != nil {
+	if err := s.trie.TryUpdateAccount(addr[:], &obj.data, obj.code); err != nil {
 		s.setError(fmt.Errorf("updateStateObject (%x) error: %w", addr[:], err))
-	}
-	if s.trie.IsVerkle() {
-		cs := make([]byte, 32)
-		binary.LittleEndian.PutUint64(cs, uint64(len(obj.code)))
-		key := trieUtils.GetTreeKeyCodeSize(addr[:])
-		if err := s.trie.TryUpdate(key, cs); err != nil {
-			s.setError(fmt.Errorf("updateStateObject (%x) %x error: %w", addr[:], key, err))
-		}
 	}
 
 	// If state snapshotting is active, cache the data til commit. Note, this

--- a/light/trie.go
+++ b/light/trie.go
@@ -112,7 +112,7 @@ func (t *odrTrie) TryGet(key []byte) ([]byte, error) {
 	return res, err
 }
 
-func (t *odrTrie) TryUpdateAccount(key []byte, acc *types.StateAccount) error {
+func (t *odrTrie) TryUpdateAccount(key []byte, acc *types.StateAccount, _ []byte) error {
 	key = crypto.Keccak256(key)
 	value, err := rlp.EncodeToBytes(acc)
 	if err != nil {

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -89,7 +89,7 @@ func (t *SecureTrie) TryGetNode(path []byte) ([]byte, int, error) {
 
 // TryUpdateAccount account will abstract the write of an account to the
 // secure trie.
-func (t *SecureTrie) TryUpdateAccount(key []byte, acc *types.StateAccount) error {
+func (t *SecureTrie) TryUpdateAccount(key []byte, acc *types.StateAccount, _ []byte) error {
 	hk := t.hashKey(key)
 	data, err := rlp.EncodeToBytes(acc)
 	if err != nil {

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -113,7 +113,7 @@ func (t *VerkleTrie) TryGetAccount(key []byte) (*types.StateAccount, error) {
 
 var zero [32]byte
 
-func (t *VerkleTrie) TryUpdateAccount(key []byte, acc *types.StateAccount) error {
+func (t *VerkleTrie) TryUpdateAccount(key []byte, acc *types.StateAccount, code []byte) error {
 	var (
 		err            error
 		nonce, balance [32]byte
@@ -125,7 +125,12 @@ func (t *VerkleTrie) TryUpdateAccount(key []byte, acc *types.StateAccount) error
 	values[utils.VersionLeafKey] = zero[:]
 	values[utils.NonceLeafKey] = nonce[:]
 	values[utils.BalanceLeafKey] = balance[:]
+	if len(code) > 0 {
 	values[utils.CodeKeccakLeafKey] = acc.CodeHash[:]
+		cs := make([]byte, 32)
+		binary.LittleEndian.PutUint64(cs, uint64(len(code)))
+		values[utils.CodeSizeLeafKey] = cs
+	}
 
 	binary.LittleEndian.PutUint64(nonce[:], acc.Nonce)
 	bbytes := acc.Balance.Bytes()
@@ -141,7 +146,6 @@ func (t *VerkleTrie) TryUpdateAccount(key []byte, acc *types.StateAccount) error
 	}, true); err != nil {
 		return fmt.Errorf("TryUpdateAccount (%x) error: %v", key, err)
 	}
-	// TODO figure out if the code size needs to be updated, too
 
 	return nil
 }


### PR DESCRIPTION
This PR moves the code creation to `TryUpdateAccount` and alters the signature of that function to pass the required code.

This PR isn't merged yet, because code deletion is problematic: prior to the removal of `SELFDESTRUCT`, the code should be passed so that each chunk can be deleted. This requires modifying the signature of `TryDeleteAccount`, but it would then have to be reverted. It is probably fine to leave it as is, since this only concerns block replays, but the question remains at the abstraction level. I'll leave this PR in draft while I mull it over.