### PR TITLE
first batch of optimizations from the replay code

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -523,12 +523,9 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 			}
 
 			if obj.dirtyCode {
-				if chunks, err := trie.ChunkifyCode(obj.code); err == nil {
-					for i := 0; i < len(chunks); i += 32 {
-						s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i)/32)), chunks[i:i+32])
-					}
-				} else {
-					s.setError(err)
+				chunks := trie.ChunkifyCode(obj.code)
+				for i := 0; i < len(chunks); i += 32 {
+					s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i)/32)), chunks[i:i+32])
 				}
 			}
 		} else {
@@ -1019,12 +1016,10 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 			// Write any contract code associated with the state object
 			if obj.code != nil && obj.dirtyCode {
 				if s.trie.IsVerkle() {
-					if chunks, err := trie.ChunkifyCode(obj.code); err == nil {
+					if chunks := trie.ChunkifyCode(obj.code); err == nil {
 						for i := 0; i < len(chunks); i += 32 {
 							s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i)/32)), chunks[i:32+i])
 						}
-					} else {
-						s.setError(err)
 					}
 				}
 				rawdb.WriteCode(codeWriter, common.BytesToHash(obj.CodeHash()), obj.code)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -447,10 +447,7 @@ func touchEachChunksOnReadAndChargeGas(offset, size uint64, addrPoint *verkle.Po
 	} else {
 		endOffset = offset + size
 	}
-	chunks, err := trie.ChunkifyCode(code)
-	if err != nil {
-		panic(err)
-	}
+	chunks := trie.ChunkifyCode(code)
 
 	// endOffset - 1 since if the end offset is aligned on a chunk boundary,
 	// the last chunk should not be included.

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -183,7 +183,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 
 	// Evaluate one address per group of 256, 31-byte chunks
 	if in.evm.ChainConfig().IsCancun(in.evm.Context.BlockNumber) && !contract.IsDeployment {
-		chunks, err = trie.ChunkifyCode(contract.Code)
+		chunks = trie.ChunkifyCode(contract.Code)
 
 		totalEvals := len(contract.Code) / 31 / 256
 		if len(contract.Code)%(256*31) != 0 {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cespare/cp v0.1.0
 	github.com/cloudflare/cloudflare-go v0.14.0
 	github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f
-	github.com/crate-crypto/go-ipa v0.0.0-20220524122216-93013fc5e327
+	github.com/crate-crypto/go-ipa v0.0.0-20220916134416-c5abbdbdf644
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.8.0
 	github.com/docker/docker v1.6.2
@@ -23,7 +23,7 @@ require (
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20220722103930-acd34254ebff
+	github.com/gballet/go-verkle v0.0.0-20220902153445-097bd83b7732
 	github.com/go-stack/stack v1.8.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/golang/protobuf v1.5.2
@@ -61,7 +61,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
+	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/crate-crypto/go-ipa v0.0.0-20220523130400-f11357ae11c7 h1:6IrxszG5G+O
 github.com/crate-crypto/go-ipa v0.0.0-20220523130400-f11357ae11c7/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/crate-crypto/go-ipa v0.0.0-20220524122216-93013fc5e327 h1:E6A+t+Jx11nqwgQwUX41rM/BYa1fQOjRQqafNSBo0DE=
 github.com/crate-crypto/go-ipa v0.0.0-20220524122216-93013fc5e327/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
+github.com/crate-crypto/go-ipa v0.0.0-20220916134416-c5abbdbdf644 h1:1BOsVjUetPH2Lqv71Dh6uKLVj9WKdDr5KY57KZBbsWU=
+github.com/crate-crypto/go-ipa v0.0.0-20220916134416-c5abbdbdf644/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -142,6 +144,8 @@ github.com/gballet/go-verkle v0.0.0-20220721055241-e8766f8d3fc5 h1:xt1HMesV5NWex
 github.com/gballet/go-verkle v0.0.0-20220721055241-e8766f8d3fc5/go.mod h1:o/XfIXWi4/GqbQirfRm5uTbXMG5NpqxkxblnbZ+QM9I=
 github.com/gballet/go-verkle v0.0.0-20220722103930-acd34254ebff h1:s2sHJc8wheUHyLC/0BdmpaU/viPspno7s3R1wj6C/sg=
 github.com/gballet/go-verkle v0.0.0-20220722103930-acd34254ebff/go.mod h1:o/XfIXWi4/GqbQirfRm5uTbXMG5NpqxkxblnbZ+QM9I=
+github.com/gballet/go-verkle v0.0.0-20220902153445-097bd83b7732 h1:AB7YjNrzlVHsYz06zCULVV2zYCEft82P86dSmtwxKL0=
+github.com/gballet/go-verkle v0.0.0-20220902153445-097bd83b7732/go.mod h1:o/XfIXWi4/GqbQirfRm5uTbXMG5NpqxkxblnbZ+QM9I=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -573,6 +577,8 @@ golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d h1:/m5NbqQelATgoSPVC2Z23sR4k
 golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
+golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=

--- a/trie/verkle_test.go
+++ b/trie/verkle_test.go
@@ -93,10 +93,7 @@ func TestReproduceTree(t *testing.T) {
 
 func TestChunkifyCodeTestnet(t *testing.T) {
 	code, _ := hex.DecodeString("6080604052348015600f57600080fd5b506004361060285760003560e01c806381ca91d314602d575b600080fd5b60336047565b604051603e9190605a565b60405180910390f35b60005481565b6054816073565b82525050565b6000602082019050606d6000830184604d565b92915050565b600081905091905056fea264697066735822122000382db0489577c1646ea2147a05f92f13f32336a32f1f82c6fb10b63e19f04064736f6c63430008070033")
-	chunks, err := ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks := ChunkifyCode(code)
 	if len(chunks) != 32*(len(code)/31+1) {
 		t.Fatalf("invalid length %d != %d", len(chunks), 32*(len(code)/31+1))
 	}
@@ -116,10 +113,7 @@ func TestChunkifyCodeTestnet(t *testing.T) {
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
 
 	code, _ = hex.DecodeString("608060405234801561001057600080fd5b506004361061002b5760003560e01c8063f566852414610030575b600080fd5b61003861004e565b6040516100459190610146565b60405180910390f35b6000600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166381ca91d36040518163ffffffff1660e01b815260040160206040518083038186803b1580156100b857600080fd5b505afa1580156100cc573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906100f0919061010a565b905090565b60008151905061010481610170565b92915050565b6000602082840312156101205761011f61016b565b5b600061012e848285016100f5565b91505092915050565b61014081610161565b82525050565b600060208201905061015b6000830184610137565b92915050565b6000819050919050565b600080fd5b61017981610161565b811461018457600080fd5b5056fea2646970667358221220d8add45a339f741a94b4fe7f22e101b560dc8a5874cbd957a884d8c9239df86264736f6c63430008070033")
-	chunks, err = ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks = ChunkifyCode(code)
 	if len(chunks) != 32*((len(code)+30)/31) {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
@@ -138,10 +132,7 @@ func TestChunkifyCodeTestnet(t *testing.T) {
 	t.Logf("code=%x, chunks=%x\n", code, chunks)
 
 	code, _ = hex.DecodeString("6080604052348015600f57600080fd5b506004361060285760003560e01c8063ab5ed15014602d575b600080fd5b60336047565b604051603e9190605d565b60405180910390f35b60006001905090565b6057816076565b82525050565b6000602082019050607060008301846050565b92915050565b600081905091905056fea2646970667358221220163c79eab5630c3dbe22f7cc7692da08575198dda76698ae8ee2e3bfe62af3de64736f6c63430008070033")
-	chunks, err = ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks = ChunkifyCode(code)
 	if len(chunks) != 32*((len(code)+30)/31) {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
@@ -170,10 +161,7 @@ func TestChunkifyCodeSimple(t *testing.T) {
 		23, 24, 25, 26, 27, 28, 29, 30,
 	}
 	t.Logf("code=%x", code)
-	chunks, err := ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks := ChunkifyCode(code)
 	if len(chunks) != 96 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
@@ -194,10 +182,7 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 		3, PUSH32, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
 		17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
 	}
-	chunks, err := ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks := ChunkifyCode(code)
 	if len(chunks) != 32 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
@@ -210,10 +195,7 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		0, 0, 0, 0, 0, 0, 0, 0, 0, PUSH32,
 	}
-	chunks, err = ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks = ChunkifyCode(code)
 	if len(chunks) != 32 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
@@ -226,10 +208,7 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 		PUSH4, PUSH32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	}
-	chunks, err = ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks = ChunkifyCode(code)
 	if len(chunks) != 64 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}
@@ -245,10 +224,7 @@ func TestChunkifyCodeFuzz(t *testing.T) {
 		PUSH4, PUSH32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	}
-	chunks, err = ChunkifyCode(code)
-	if err != nil {
-		t.Fatal(err)
-	}
+	chunks = ChunkifyCode(code)
 	if len(chunks) != 64 {
 		t.Fatalf("invalid length %d", len(chunks))
 	}


### PR DESCRIPTION
#128 causes the testnet to fail, so I am slowly replaying all optimizations found in the replay branch, in order to figure out where the problem is.

This PR simplifies the signature of `ChunkifyCode` and uses `InsertStem` in order to update the account all at once. It also upgrades go-verkle to the latest commit before `ParseNode` returned `StatlessNodes` instead of `InternalNode`