### PR TITLE
no code size + hash for EoAs

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -685,8 +685,6 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		state.Witness().TouchAddressOnReadAndComputeGas(coinbase)
 		coinbase[31] = utils.NonceLeafKey // mark nonce
 		state.Witness().TouchAddressOnReadAndComputeGas(coinbase)
-		coinbase[31] = utils.CodeKeccakLeafKey // mark code keccak
-		state.Witness().TouchAddressOnReadAndComputeGas(coinbase)
 		balance := state.GetBalance(header.Coinbase)
 		coinbase[31] = utils.BalanceLeafKey
 		state.Witness().SetLeafValue(coinbase, balance.Bytes())

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -73,7 +73,7 @@ type Trie interface {
 	TryGet(key []byte) ([]byte, error)
 
 	// TryUpdateAccount abstract an account write in the trie.
-	TryUpdateAccount(key []byte, account *types.StateAccount) error
+	TryUpdateAccount(key []byte, account *types.StateAccount, code []byte) error
 
 	// TryUpdate associates key with value in the trie. If value has length zero, any
 	// existing value is deleted from the trie. The value bytes must not be modified

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -553,7 +553,7 @@ func (s *stateObject) CodeSize(db Database) int {
 	if bytes.Equal(s.CodeHash(), emptyCodeHash) {
 		if s.db.trie.IsVerkle() {
 			var sz [32]byte
-			s.db.witness.SetLeafValuesMessageCall(s.address.Bytes(), sz[:])
+			s.db.witness.SetLeafValuesMessageCall(s.address.Bytes(), sz[:], s.CodeHash())
 		}
 		return 0
 	}
@@ -564,7 +564,7 @@ func (s *stateObject) CodeSize(db Database) int {
 	if s.db.trie.IsVerkle() {
 		var sz [32]byte
 		binary.LittleEndian.PutUint64(sz[:8], uint64(size))
-		s.db.witness.SetLeafValuesMessageCall(s.address.Bytes(), sz[:])
+		s.db.witness.SetLeafValuesMessageCall(s.address.Bytes(), sz[:], s.CodeHash())
 	}
 	return size
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -512,7 +512,7 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 	// Encode the account and update the account trie
 	addr := obj.Address()
 
-	if err := s.trie.TryUpdateAccount(addr[:], &obj.data); err != nil {
+	if err := s.trie.TryUpdateAccount(addr[:], &obj.data, obj.code); err != nil {
 		s.setError(fmt.Errorf("updateStateObject (%x) error: %w", addr[:], err))
 	}
 	if s.trie.IsVerkle() {

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -394,10 +394,10 @@ func TestProcessVerkle(t *testing.T) {
 	defer blockchain.Stop()
 
 	code := common.FromHex(`6060604052600a8060106000396000f360606040526008565b00`)
-	txCost1 := params.WitnessBranchWriteCost*2 + params.WitnessBranchReadCost*2 + params.WitnessChunkWriteCost*3 + params.WitnessChunkReadCost*10 + params.TxGas
-	txCost2 := params.WitnessBranchWriteCost + params.WitnessBranchReadCost*2 + params.WitnessChunkWriteCost*2 + params.WitnessChunkReadCost*10 + params.TxGas
+	txCost1 := params.WitnessBranchWriteCost*2 + params.WitnessBranchReadCost*2 + params.WitnessChunkWriteCost*3 + params.WitnessChunkReadCost*7 + params.TxGas
+	txCost2 := params.WitnessBranchWriteCost + params.WitnessBranchReadCost*2 + params.WitnessChunkWriteCost*2 + params.WitnessChunkReadCost*6 + params.TxGas
 	intrinsic, _ := IntrinsicGas(code, nil, true, true, true)
-	contractCreationCost := intrinsic + 17339
+	contractCreationCost := intrinsic + params.WitnessBranchWriteCost + params.WitnessBranchReadCost*2 + params.WitnessBranchWriteCost*6 + 11739
 	blockGasUsagesExpected := []uint64{
 		txCost1*2 + txCost2,
 		txCost1*2 + txCost2 + contractCreationCost + codeWithExtCodeCopyGas,
@@ -440,7 +440,7 @@ func TestProcessVerkle(t *testing.T) {
 			t.Fatalf("expected block %d to be present in chain", i+1)
 		}
 		if b.GasUsed() != blockGasUsagesExpected[i] {
-			t.Fatalf("expected block txs to use %d, got %d\n", blockGasUsagesExpected[i], b.GasUsed())
+			t.Fatalf("expected block txs for block #%d to use %d, got %d\n", i+1, blockGasUsagesExpected[i], b.GasUsed())
 		}
 	}
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -203,7 +203,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	if !evm.StateDB.Exist(addr) {
 		if !isPrecompile && evm.chainRules.IsEIP158 && value.Sign() == 0 {
 			if evm.chainConfig.IsCancun(evm.Context.BlockNumber) {
-				// proof of absence
+				// prove the absence of the account until now
 				tryConsumeGas(&gas, evm.Accesses.TouchAndChargeProofOfAbsence(caller.Address().Bytes()))
 			}
 			// Calling a non existing account, don't do anything, but ping the tracer

--- a/light/trie.go
+++ b/light/trie.go
@@ -112,7 +112,7 @@ func (t *odrTrie) TryGet(key []byte) ([]byte, error) {
 	return res, err
 }
 
-func (t *odrTrie) TryUpdateAccount(key []byte, acc *types.StateAccount) error {
+func (t *odrTrie) TryUpdateAccount(key []byte, acc *types.StateAccount, _ []byte) error {
 	key = crypto.Keccak256(key)
 	value, err := rlp.EncodeToBytes(acc)
 	if err != nil {

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -89,7 +89,7 @@ func (t *SecureTrie) TryGetNode(path []byte) ([]byte, int, error) {
 
 // TryUpdateAccount account will abstract the write of an account to the
 // secure trie.
-func (t *SecureTrie) TryUpdateAccount(key []byte, acc *types.StateAccount) error {
+func (t *SecureTrie) TryUpdateAccount(key []byte, acc *types.StateAccount, _ []byte) error {
 	hk := t.hashKey(key)
 	data, err := rlp.EncodeToBytes(acc)
 	if err != nil {

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -290,7 +290,7 @@ func (t *Trie) Update(key, value []byte) {
 	}
 }
 
-func (t *Trie) TryUpdateAccount(key []byte, acc *types.StateAccount) error {
+func (t *Trie) TryUpdateAccount(key []byte, acc *types.StateAccount, _ []byte) error {
 	data, err := rlp.EncodeToBytes(acc)
 	if err != nil {
 		return fmt.Errorf("can't encode object at %x: %w", key[:], err)


### PR DESCRIPTION
This is done at the tree level, but also at the witness level, since values should not be added to the witness if they are not touched. 