### PR TITLE
core: do not make AccessWitness capture initial values

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -671,7 +671,6 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		if config.IsCancun(header.Number) {
 			uncleCoinbase := utils.GetTreeKeyBalance(uncle.Coinbase.Bytes())
 			state.Witness().TouchAddressOnReadAndComputeGas(uncleCoinbase)
-			state.Witness().SetLeafValue(uncleCoinbase, state.GetBalance(uncle.Coinbase).Bytes())
 		}
 		state.AddBalance(uncle.Coinbase, r)
 
@@ -687,9 +686,6 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		state.Witness().TouchAddressOnReadAndComputeGas(coinbase)
 		coinbase[31] = utils.CodeKeccakLeafKey // mark code keccak
 		state.Witness().TouchAddressOnReadAndComputeGas(coinbase)
-		balance := state.GetBalance(header.Coinbase)
-		coinbase[31] = utils.BalanceLeafKey
-		state.Witness().SetLeafValue(coinbase, balance.Bytes())
 	}
 	state.AddBalance(header.Coinbase, reward)
 }

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -525,10 +525,6 @@ func (s *stateObject) Code(db Database) []byte {
 		return s.code
 	}
 	if bytes.Equal(s.CodeHash(), emptyCodeHash) {
-		if s.db.GetTrie().IsVerkle() {
-			// Mark the code size and code hash as empty
-			s.db.witness.SetObjectCodeTouchedLeaves(s.address.Bytes(), nil, nil)
-		}
 		return nil
 	}
 	code, err := db.ContractCode(s.addrHash, common.BytesToHash(s.CodeHash()))
@@ -553,8 +549,6 @@ func (s *stateObject) CodeSize(db Database) int {
 	}
 	if bytes.Equal(s.CodeHash(), emptyCodeHash) {
 		if s.db.trie.IsVerkle() {
-			var sz [32]byte
-			s.db.witness.SetLeafValuesMessageCall(s.address.Bytes(), sz[:])
 		}
 		return 0
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -272,20 +272,6 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 		value.SetBytes(content)
 	}
 
-	// Capture the initial value of the location in the verkle proof witness
-	if s.db.GetTrie().IsVerkle() {
-		if err != nil {
-			return common.Hash{}
-		}
-		loc := new(uint256.Int).SetBytes(key[:])
-		index := trieUtils.GetTreeKeyStorageSlotWithEvaluatedAddress(s.pointEval, loc)
-		if len(enc) > 0 {
-			s.db.Witness().SetLeafValue(index, value.Bytes())
-		} else {
-			s.db.Witness().SetLeafValue(index, nil)
-		}
-	}
-
 	s.originStorage[key] = value
 	return value
 }
@@ -555,11 +541,6 @@ func (s *stateObject) CodeSize(db Database) int {
 	size, err := db.ContractCodeSize(s.addrHash, common.BytesToHash(s.CodeHash()))
 	if err != nil {
 		s.setError(fmt.Errorf("can't load code size %x: %v", s.CodeHash(), err))
-	}
-	if s.db.trie.IsVerkle() {
-		var sz [32]byte
-		binary.LittleEndian.PutUint64(sz[:8], uint64(size))
-		s.db.witness.SetLeafValuesMessageCall(s.address.Bytes(), sz[:])
 	}
 	return size
 }

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -373,10 +373,11 @@ func TestProcessVerkle(t *testing.T) {
 		signer     = types.LatestSigner(config)
 		testKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		db         = rawdb.NewMemoryDatabase()
+		coinbase   = common.HexToAddress("0x71562b71999873DB5b286dF957af199Ec94617F7")
 		gspec      = &Genesis{
 			Config: config,
 			Alloc: GenesisAlloc{
-				common.HexToAddress("0x71562b71999873DB5b286dF957af199Ec94617F7"): GenesisAccount{
+				coinbase: GenesisAccount{
 					Balance: big.NewInt(1000000000000000000), // 1 ether
 					Nonce:   0,
 				},

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -398,7 +398,7 @@ func TestProcessVerkle(t *testing.T) {
 		txCost1*2 + txCost2,
 		txCost1*2 + txCost2 + contractCreationCost + codeWithExtCodeCopyGas,
 	}
-	chain, _ := GenerateVerkleChain(gspec.Config, genesis, ethash.NewFaker(), db, 2, func(i int, gen *BlockGen) {
+	chain, _, proofs, keyvals := GenerateVerkleChain(gspec.Config, genesis, ethash.NewFaker(), db, 2, func(i int, gen *BlockGen) {
 		// TODO need to check that the tx cost provided is the exact amount used (no remaining left-over)
 		tx, _ := types.SignTx(types.NewTransaction(uint64(i)*3, common.Address{byte(i), 2, 3}, big.NewInt(999), txCost1, big.NewInt(875000000), nil), signer, testKey)
 		gen.AddTx(tx)
@@ -424,8 +424,13 @@ func TestProcessVerkle(t *testing.T) {
 	//rlp.Encode(&buf, chain[1])
 	//f.Write(buf.Bytes())
 	//fmt.Printf("root= %x\n", chain[0].Root())
+	// check the proof for the last block
+	err := trie.DeserializeAndVerifyVerkleProof(proofs[1], chain[0].Root().Bytes(), keyvals[1])
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := blockchain.InsertChain(chain)
+	_, err = blockchain.InsertChain(chain)
 	if err != nil {
 		t.Fatalf("block imported with error: %v", err)
 	}
@@ -436,7 +441,7 @@ func TestProcessVerkle(t *testing.T) {
 			t.Fatalf("expected block %d to be present in chain", i+1)
 		}
 		if b.GasUsed() != blockGasUsagesExpected[i] {
-			t.Fatalf("expected block txs to use %d, got %d\n", blockGasUsagesExpected[i], b.GasUsed())
+			t.Fatalf("expected block #%d txs to use %d, got %d\n", i+1, blockGasUsagesExpected[i], b.GasUsed())
 		}
 	}
 }

--- a/core/types/access_witness.go
+++ b/core/types/access_witness.go
@@ -71,23 +71,6 @@ func NewAccessWitness() *AccessWitness {
 	}
 }
 
-func (aw *AccessWitness) SetLeafValue(addr []byte, value []byte) {
-	var stem [31]byte
-	copy(stem[:], addr[:31])
-
-	// Sanity check: ensure that the location has been declared
-	if _, exist := aw.InitialValue[string(addr)]; !exist {
-		if len(value) == 32 || len(value) == 0 {
-			aw.InitialValue[string(addr)] = value
-		} else {
-			var aligned [32]byte
-			copy(aligned[:len(value)], value)
-
-			aw.InitialValue[string(addr)] = aligned[:]
-		}
-	}
-}
-
 func (aw *AccessWitness) HasCodeChunk(addr []byte, chunknr uint64) bool {
 	if locs, ok := aw.CodeLocations[string(addr)]; ok {
 		if _, ok = locs[chunknr]; ok {
@@ -326,19 +309,6 @@ func (aw *AccessWitness) TouchAndChargeMessageCall(addr []byte) uint64 {
 	return gas
 }
 
-func (aw *AccessWitness) SetLeafValuesMessageCall(addr, codeSize []byte) {
-	var (
-		cskey [32]byte
-		data  [32]byte
-	)
-	// Only evaluate the polynomial once
-	versionkey := utils.GetTreeKeyVersion(addr[:])
-	copy(cskey[:], versionkey)
-	cskey[31] = utils.CodeSizeLeafKey
-	aw.SetLeafValue(versionkey, data[:])
-	aw.SetLeafValue(cskey[:], codeSize[:])
-}
-
 func (aw *AccessWitness) TouchAndChargeValueTransfer(callerAddr, targetAddr []byte) uint64 {
 	var gas uint64
 	gas += aw.TouchAddressOnWriteAndComputeGas(utils.GetTreeKeyBalance(callerAddr[:]))
@@ -400,17 +370,6 @@ func (aw *AccessWitness) TouchAndChargeContractCreateCompleted(addr []byte, with
 	return gas
 }
 
-func (aw *AccessWitness) SetLeafValuesContractCreateCompleted(addr, codeSize, codeKeccak []byte) {
-	var ckkey [32]byte
-	cskey := aw.GetTreeKeyVersionCached(addr[:])
-	cskey[31] = utils.CodeSizeLeafKey
-	copy(ckkey[:], cskey)
-	ckkey[31] = utils.CodeKeccakLeafKey
-
-	aw.SetLeafValue(cskey, codeSize)
-	aw.SetLeafValue(ckkey[:], codeKeccak)
-}
-
 func (aw *AccessWitness) TouchTxOriginAndComputeGas(originAddr []byte) uint64 {
 	var (
 		balancekey, cskey, ckkey, noncekey [32]byte
@@ -462,75 +421,4 @@ func (aw *AccessWitness) TouchTxExistingAndComputeGas(targetAddr []byte, sendsVa
 		gas += aw.TouchAddressOnWriteAndComputeGas(balancekey[:])
 	}
 	return gas
-}
-
-func (aw *AccessWitness) SetTxOriginTouchedLeaves(originAddr, originBalance, originNonce []byte, codeSize int) {
-	var (
-		balancekey, cskey, noncekey [32]byte
-		version                     [32]byte
-	)
-
-	// Only evaluate the polynomial once
-	versionkey := aw.GetTreeKeyVersionCached(originAddr[:])
-	copy(balancekey[:], versionkey)
-	balancekey[31] = utils.BalanceLeafKey
-	copy(noncekey[:], versionkey)
-	noncekey[31] = utils.NonceLeafKey
-	copy(cskey[:], versionkey)
-	cskey[31] = utils.CodeSizeLeafKey
-
-	aw.SetLeafValue(versionkey, version[:])
-	aw.SetLeafValue(balancekey[:], originBalance)
-	aw.SetLeafValue(noncekey[:], originNonce)
-}
-
-func (aw *AccessWitness) SetTxExistingTouchedLeaves(targetAddr, targetBalance, targetNonce, targetCodeSize, targetCodeHash []byte) {
-	var (
-		balancekey, cskey, ckkey, noncekey [32]byte
-		version                            [32]byte
-	)
-
-	// Only evaluate the polynomial once
-	versionkey := aw.GetTreeKeyVersionCached(targetAddr[:])
-	copy(balancekey[:], versionkey)
-	balancekey[31] = utils.BalanceLeafKey
-	copy(noncekey[:], versionkey)
-	noncekey[31] = utils.NonceLeafKey
-	copy(cskey[:], versionkey)
-	cskey[31] = utils.CodeSizeLeafKey
-	copy(ckkey[:], versionkey)
-	ckkey[31] = utils.CodeKeccakLeafKey
-
-	aw.SetLeafValue(versionkey, version[:])
-	aw.SetLeafValue(balancekey[:], targetBalance)
-	aw.SetLeafValue(noncekey[:], targetNonce)
-	aw.SetLeafValue(cskey[:], targetCodeSize)
-	aw.SetLeafValue(ckkey[:], targetCodeHash)
-}
-
-func (aw *AccessWitness) SetGetObjectTouchedLeaves(targetAddr, version, targetBalance, targetNonce, targetCodeHash []byte) {
-	var balancekey, ckkey, noncekey [32]byte
-	versionkey := aw.GetTreeKeyVersionCached(targetAddr[:])
-	copy(balancekey[:], versionkey)
-	balancekey[31] = utils.BalanceLeafKey
-	copy(noncekey[:], versionkey)
-	noncekey[31] = utils.NonceLeafKey
-	copy(ckkey[:], versionkey)
-	ckkey[31] = utils.CodeKeccakLeafKey
-
-	aw.SetLeafValue(versionkey, version[:])
-	aw.SetLeafValue(balancekey[:], targetBalance)
-	aw.SetLeafValue(noncekey[:], targetNonce)
-	aw.SetLeafValue(ckkey[:], targetCodeHash)
-}
-
-func (aw *AccessWitness) SetObjectCodeTouchedLeaves(addr, cs, ch []byte) {
-	var ckkey [32]byte
-	cskey := aw.GetTreeKeyVersionCached(addr[:])
-	cskey[31] = utils.CodeSizeLeafKey
-	copy(ckkey[:], cskey)
-	ckkey[31] = utils.CodeKeccakLeafKey
-
-	aw.SetLeafValue(cskey, cs)
-	aw.SetLeafValue(ckkey[:], ch)
 }

--- a/core/types/access_witness.go
+++ b/core/types/access_witness.go
@@ -17,8 +17,6 @@
 package types
 
 import (
-	"encoding/binary"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie/utils"
@@ -431,8 +429,6 @@ func (aw *AccessWitness) TouchTxOriginAndComputeGas(originAddr []byte) uint64 {
 	ckkey[31] = utils.CodeKeccakLeafKey
 
 	gas += aw.TouchAddressOnReadAndComputeGas(versionkey)
-	gas += aw.TouchAddressOnReadAndComputeGas(cskey[:])
-	gas += aw.TouchAddressOnReadAndComputeGas(ckkey[:])
 	gas += aw.TouchAddressOnWriteAndComputeGas(noncekey[:])
 	gas += aw.TouchAddressOnWriteAndComputeGas(balancekey[:])
 
@@ -486,9 +482,6 @@ func (aw *AccessWitness) SetTxOriginTouchedLeaves(originAddr, originBalance, ori
 	aw.SetLeafValue(versionkey, version[:])
 	aw.SetLeafValue(balancekey[:], originBalance)
 	aw.SetLeafValue(noncekey[:], originNonce)
-	var cs [32]byte
-	binary.LittleEndian.PutUint64(cs[:8], uint64(codeSize))
-	aw.SetLeafValue(cskey[:], cs[:])
 }
 
 func (aw *AccessWitness) SetTxExistingTouchedLeaves(targetAddr, targetBalance, targetNonce, targetCodeSize, targetCodeHash []byte) {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -434,8 +434,6 @@ func (c *codeAndHash) Hash() common.Hash {
 
 // create creates a new contract using code as deployment code.
 func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64, value *big.Int, address common.Address, typ OpCode) ([]byte, common.Address, uint64, error) {
-	var zeroVerkleLeaf [32]byte
-
 	// Depth check execution. Fail if we're trying to execute above the
 	// limit.
 	if evm.depth > int(params.CallCreateDepth) {
@@ -523,8 +521,6 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		if !contract.UseGas(evm.Accesses.TouchAndChargeContractCreateCompleted(address.Bytes()[:], value.Sign() != 0)) {
 			evm.StateDB.RevertToSnapshot(snapshot)
 			err = ErrOutOfGas
-		} else {
-			evm.Accesses.SetLeafValuesContractCreateCompleted(address.Bytes()[:], zeroVerkleLeaf[:], zeroVerkleLeaf[:])
 		}
 	}
 

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -413,16 +413,6 @@ func touchChunkOnReadAndChargeGas(chunks trie.ChunkedCode, offset uint64, evals 
 		panic("overflow when adding gas")
 	}
 
-	if len(code) > 0 {
-		if deployment {
-			accesses.SetLeafValue(index[:], nil)
-		} else {
-			if uint64(len(chunks)) >= (chunknr+1)*32 {
-				accesses.SetLeafValue(index[:], chunks[chunknr*32:(chunknr+1)*32])
-			}
-		}
-	}
-
 	return statelessGasCharged
 }
 
@@ -458,13 +448,6 @@ func touchEachChunksOnReadAndChargeGas(offset, size uint64, contract *Contract, 
 			statelessGasCharged, overflow = math.SafeAdd(statelessGasCharged, accesses.TouchAddressOnReadAndComputeGas(index))
 			if overflow {
 				panic("overflow when adding gas")
-			}
-			if len(code) > 0 {
-				if deployment {
-					accesses.SetLeafValue(index[:], nil)
-				} else {
-					accesses.SetLeafValue(index[:], contract.Chunks[32*i:(i+1)*32])
-				}
 			}
 
 			accesses.SetCachedCodeChunk(contract.Address().Bytes(), i)


### PR DESCRIPTION
The complexity associated with getting `AccessWitness` to keep track of initial values is the cause of many maintenance headaches, as well as being ultimately broken since the proof creation ends up calling `Get` on the pre-state tree anyway.

In order to reduce the final complexity, this PR is a cleanup that removes all `SetLeafValues` and generates the proof at the end of the block execution, so that it can easily be deactivated.

TODO 

 * [x] Remove all `SetLeafValues`
 * [x] Check why the gas cost changes in `TestProcessVerkle` and fix that