### PR TITLE
fix: storage offset in non-header group + reuse of value buffer

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -510,8 +510,6 @@ func (s *stateObject) CodeSize(db Database) int {
 		return len(s.code)
 	}
 	if bytes.Equal(s.CodeHash(), emptyCodeHash) {
-		if s.db.trie.IsVerkle() {
-		}
 		return 0
 	}
 	size, err := db.ContractCodeSize(s.addrHash, common.BytesToHash(s.CodeHash()))

--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -31,12 +31,13 @@ const (
 )
 
 var (
-	zero                = uint256.NewInt(0)
-	HeaderStorageOffset = uint256.NewInt(64)
-	CodeOffset          = uint256.NewInt(128)
-	MainStorageOffset   = new(uint256.Int).Lsh(uint256.NewInt(256), 31)
-	VerkleNodeWidth     = uint256.NewInt(256)
-	codeStorageDelta    = uint256.NewInt(0).Sub(CodeOffset, HeaderStorageOffset)
+	zero                               = uint256.NewInt(0)
+	HeaderStorageOffset                = uint256.NewInt(64)
+	CodeOffset                         = uint256.NewInt(128)
+	MainStorageOffset                  = new(uint256.Int).Lsh(uint256.NewInt(256), 31)
+	VerkleNodeWidth                    = uint256.NewInt(256)
+	codeStorageDelta                   = uint256.NewInt(0).Sub(CodeOffset, HeaderStorageOffset)
+	MainStorageMinusStorageDeltaOffset = new(uint256.Int).Sub(MainStorageOffset, codeStorageDelta)
 
 	getTreePolyIndex0Point *verkle.Point
 )
@@ -145,7 +146,7 @@ func GetTreeKeyStorageSlot(address []byte, storageKey *uint256.Int) []byte {
 	if storageKey.Cmp(codeStorageDelta) < 0 {
 		pos.Add(HeaderStorageOffset, storageKey)
 	} else {
-		pos.Add(MainStorageOffset, storageKey)
+		pos.Add(MainStorageMinusStorageDeltaOffset, storageKey)
 	}
 	treeIndex := new(uint256.Int).Div(pos, VerkleNodeWidth)
 
@@ -228,7 +229,7 @@ func GetTreeKeyStorageSlotWithEvaluatedAddress(evaluated *verkle.Point, storageK
 	if storageKey.Cmp(codeStorageDelta) < 0 {
 		pos.Add(HeaderStorageOffset, storageKey)
 	} else {
-		pos.Add(MainStorageOffset, storageKey)
+		pos.Add(MainStorageMinusStorageDeltaOffset, storageKey)
 	}
 	treeIndex := new(uint256.Int).Div(pos, VerkleNodeWidth)
 	// calculate the sub_index, i.e. the index in the stem tree.

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -175,7 +175,9 @@ func (trie *VerkleTrie) TryUpdateStem(key []byte, values [][]byte) {
 // by the caller while they are stored in the trie. If a node was not found in the
 // database, a trie.MissingNodeError is returned.
 func (trie *VerkleTrie) TryUpdate(key, value []byte) error {
-	return trie.root.Insert(key, value, func(h []byte) ([]byte, error) {
+	var v [32]byte
+	copy(v[:], value[:])
+	return trie.root.Insert(key, v[:], func(h []byte) ([]byte, error) {
 		return trie.db.diskdb.Get(h)
 	})
 }


### PR DESCRIPTION
These that are fixes for issues that have been identified on beverly hills after the relaunch, although they certainly affect Condrieu as well:

 * `TryUpdate` for `VerkleTrie` didn't make a copy of a buffer that was being reused, so the same, last value would be copied over all the inserted values;
 * The computation of the offset for slots outside of the header group were incorrect (off by 64)