### PR TITLE
tests: add mpt vs vkt insertion benchmarks

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -38,6 +38,8 @@ const (
 	codeCacheSize = 64 * 1024 * 1024
 )
 
+var TestVKTOpenStateless = false
+
 // Database wraps access to tries and contract code.
 type Database interface {
 	// OpenTrie opens the main account trie.
@@ -256,6 +258,13 @@ func (db *VerkleDB) OpenTrie(root common.Hash) (Trie, error) {
 	r, err := verkle.ParseNode(payload, 0, root[:])
 	if err != nil {
 		panic(err)
+	}
+
+	if TestVKTOpenStateless {
+		r, err = verkle.ParseStatelessNode(payload, 0, root[:])
+		if err != nil {
+			panic(err)
+		}
 	}
 	return trie.NewVerkleTrie(r, db.db), err
 }

--- a/tests/tries_test.go
+++ b/tests/tries_test.go
@@ -1,0 +1,112 @@
+package tests
+
+import (
+	"fmt"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb/memorydb"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/gballet/go-verkle"
+)
+
+func BenchmarkTriesRandom(b *testing.B) {
+	numAccounts := []int{1_000, 5_000, 10_000}
+
+	for _, numAccounts := range numAccounts {
+		rs := rand.New(rand.NewSource(42))
+		accounts := getRandomStateAccounts(rs, numAccounts)
+
+		b.Run(fmt.Sprintf("MPT/%d accounts", numAccounts), func(b *testing.B) {
+			trie, _ := trie.NewStateTrie(trie.TrieID(common.Hash{}), trie.NewDatabase(memorydb.New()))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for k := 0; k < len(accounts); k++ {
+					trie.TryUpdateAccount(accounts[k].address[:], &accounts[k].stateAccount)
+				}
+				trie.Commit(true)
+			}
+		})
+		b.Run(fmt.Sprintf("VKT/%d accounts", numAccounts), func(b *testing.B) {
+			// Warmup VKT configuration
+			trie.NewVerkleTrie(verkle.New(), trie.NewDatabase(memorydb.New())).TryUpdate([]byte("00000000000000000000000000000012"), []byte("B"))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				trie := trie.NewVerkleTrie(verkle.New(), trie.NewDatabase(memorydb.New()))
+				for k := 0; k < len(accounts); k++ {
+					trie.TryUpdateAccount(accounts[k].address[:], &accounts[k].stateAccount)
+				}
+				trie.Commit(true)
+			}
+		})
+	}
+}
+
+type randomAccount struct {
+	address      common.Address
+	stateAccount types.StateAccount
+}
+
+func getRandomStateAccounts(rand *rand.Rand, count int) []randomAccount {
+	randomBytes := func(size int) []byte {
+		ret := make([]byte, size)
+		rand.Read(ret)
+		return ret
+	}
+
+	accounts := make([]randomAccount, count)
+	for i := range accounts {
+		accounts[i] = randomAccount{
+			address: common.BytesToAddress(randomBytes(common.AddressLength)),
+			stateAccount: types.StateAccount{
+				Nonce:    rand.Uint64(),
+				Balance:  big.NewInt(int64(rand.Uint64())),
+				Root:     common.Hash{},
+				CodeHash: nil,
+			},
+		}
+	}
+	return accounts
+}
+
+func BenchmarkTriesRandomVKTStateless(b *testing.B) {
+	numAccounts := []int{1_000, 5_000, 10_000}
+	state.TestVKTOpenStateless = true
+
+	for _, numAccounts := range numAccounts {
+		rs := rand.New(rand.NewSource(42))
+		accounts := getRandomStateAccounts(rs, numAccounts)
+
+		b.Run(fmt.Sprintf("%d accounts", numAccounts), func(b *testing.B) {
+			trieDB := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &trie.Config{UseVerkle: true})
+
+			prevTrie, _ := trieDB.OpenTrie(common.Hash{})
+			for k := 0; k < len(accounts); k++ {
+				prevTrie.TryUpdateAccount(accounts[k].address[:], &accounts[k].stateAccount)
+			}
+			prevTrie.Commit(false)
+
+			accounts := getRandomStateAccounts(rs, numAccounts)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				trie, err := trieDB.OpenTrie(prevTrie.Hash())
+				if err != nil {
+					b.Fatal(err)
+				}
+				for k := 0; k < len(accounts); k++ {
+					trie.TryUpdateAccount(accounts[k].address[:], &accounts[k].stateAccount)
+				}
+				trie.Commit(true)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds two benchmarks:
- A comparison of MPT and VKTs inserting a different number of key-values
- A similar insertion benchmark for VKT, but against a stateless VKT so we can understand deserialization overheads.

Running these benchmarks on my desktop computer shows significant gap in performance between the two:
```
$ go test ./tests -run=none -bench=BenchmarkTriesRandom
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/tests
cpu: AMD Ryzen 7 3800XT 8-Core Processor            
BenchmarkTriesRandom/MPT/1000_accounts-16                   1066           1071067 ns/op          166047 B/op       3024 allocs/op
BenchmarkTriesRandom/VKT/1000_accounts-16                     20          61900194 ns/op         9494036 B/op      32842 allocs/op
BenchmarkTriesRandom/MPT/5000_accounts-16                    262           4042749 ns/op          832332 B/op      15024 allocs/op
BenchmarkTriesRandom/VKT/5000_accounts-16                      4         282367474 ns/op        43465564 B/op     150956 allocs/op
BenchmarkTriesRandom/MPT/10000_accounts-16                   133           8312897 ns/op         1740491 B/op      30891 allocs/op
BenchmarkTriesRandom/VKT/10000_accounts-16                     2         575018258 ns/op        87431768 B/op     303385 allocs/op
BenchmarkTriesRandomVKTStateless/1000_accounts-16             14          75025065 ns/op        10103659 B/op      37719 allocs/op
BenchmarkTriesRandomVKTStateless/5000_accounts-16              4         320815470 ns/op        48202616 B/op     173598 allocs/op
BenchmarkTriesRandomVKTStateless/10000_accounts-16                     2         680707633 ns/op        104035452 B/op    369356 allocs/op
PASS
ok      github.com/ethereum/go-ethereum/tests   18.057s
```

I've been looking a bit closer on possible _whys_, and I've some ideas to start experimenting. But here we have at least the current baseline to try making the gap smaller.

Note that these benchmarks are 100% focused on comparing the tries performance. In a real block execution, the block execution is composed on many other tasks. For example, if trie insertions are 40% of the work of executing a block, then their performance difference would only impact ~40% of the block execution. (40% is an example).