### PR TITLE
VKT: Optimizations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20221129125207-513116151b28
+	github.com/gballet/go-verkle v0.0.0-20230112140635-3e8bae599d5c
 	github.com/go-stack/stack v1.8.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/golang/protobuf v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cespare/cp v0.1.0
 	github.com/cloudflare/cloudflare-go v0.14.0
 	github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f
-	github.com/crate-crypto/go-ipa v0.0.0-20221111143132-9aa5d42120bc
+	github.com/crate-crypto/go-ipa v0.0.0-20230112133036-98736f2f2808
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.8.0
 	github.com/docker/docker v1.6.2
@@ -107,6 +107,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/gballet/go-verkle => github.com/gballet/go-verkle v0.0.0-20221213233340-474c89b28152
-
-replace github.com/crate-crypto/go-ipa => github.com/jsign/go-ipa v0.0.0-20221213212217-fcc1cb4ffdd5
+replace github.com/gballet/go-verkle => github.com/gballet/go-verkle v0.0.0-20230112140635-3e8bae599d5c

--- a/go.mod
+++ b/go.mod
@@ -106,3 +106,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/gballet/go-verkle => github.com/gballet/go-verkle v0.0.0-20221213233340-474c89b28152
+
+replace github.com/crate-crypto/go-ipa => github.com/jsign/go-ipa v0.0.0-20221213212217-fcc1cb4ffdd5

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f/go.mod h1
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/crate-crypto/go-ipa v0.0.0-20230112133036-98736f2f2808 h1:zzhDwbi4il5p8+g4WjfX4nWaIo9A61bBS6Ltj8AkExg=
+github.com/crate-crypto/go-ipa v0.0.0-20230112133036-98736f2f2808/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -133,8 +135,8 @@ github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 h1:IZqZOB2fydHte3kUgx
 github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
-github.com/gballet/go-verkle v0.0.0-20221213233340-474c89b28152 h1:pn5LE8IKTJvFoUnE/SivDpM83+xLnQyx5Ae6tT2mTUc=
-github.com/gballet/go-verkle v0.0.0-20221213233340-474c89b28152/go.mod h1:9z/WEuMA3wlwr4m7/wWmS8Pz6pAaHZ0cTlDhY0aqqsM=
+github.com/gballet/go-verkle v0.0.0-20230112140635-3e8bae599d5c h1:ROHmmjPpri0ApcrUhpXZBsWaeFuyuVEDhrPK1dIsAqA=
+github.com/gballet/go-verkle v0.0.0-20230112140635-3e8bae599d5c/go.mod h1:hspihFYcpgSaKoVnQV+97jkJREFZdH/kiPTcBwIHCyM=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -251,8 +253,6 @@ github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e h1:UvSe12bq+U
 github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e/go.mod h1:G1CVv03EnqU1wYL2dFwXxW2An0az9JTl/ZsqXQeBlkU=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/jsign/go-ipa v0.0.0-20221213212217-fcc1cb4ffdd5 h1:7pT9gqhsfYrfcOP0Ew06ctN28CtxGlURMnpFHQx7tXg=
-github.com/jsign/go-ipa v0.0.0-20221213212217-fcc1cb4ffdd5/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,6 @@ github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f/go.mod h1
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/crate-crypto/go-ipa v0.0.0-20221111143132-9aa5d42120bc h1:mtR7MuscVeP/s0/ERWA2uSr5QOrRYy1pdvZqG1USfXI=
-github.com/crate-crypto/go-ipa v0.0.0-20221111143132-9aa5d42120bc/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -135,10 +133,8 @@ github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 h1:IZqZOB2fydHte3kUgx
 github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
-github.com/gballet/go-verkle v0.0.0-20221122140954-75ceda26b7db h1:YvtZfE11QEYWPjsQCyZLoZCGMsxJs9mTEbhF3MnM32Q=
-github.com/gballet/go-verkle v0.0.0-20221122140954-75ceda26b7db/go.mod h1:DMDd04jjQgdynaAwbEgiRERIGpC8fDjx0+y06an7Psg=
-github.com/gballet/go-verkle v0.0.0-20221129125207-513116151b28 h1:UbB7D2R1OQCkNFX+LYoo2pHZ0u5LhwR9ldUsY4ZbZqI=
-github.com/gballet/go-verkle v0.0.0-20221129125207-513116151b28/go.mod h1:DMDd04jjQgdynaAwbEgiRERIGpC8fDjx0+y06an7Psg=
+github.com/gballet/go-verkle v0.0.0-20221213233340-474c89b28152 h1:pn5LE8IKTJvFoUnE/SivDpM83+xLnQyx5Ae6tT2mTUc=
+github.com/gballet/go-verkle v0.0.0-20221213233340-474c89b28152/go.mod h1:9z/WEuMA3wlwr4m7/wWmS8Pz6pAaHZ0cTlDhY0aqqsM=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -255,6 +251,8 @@ github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e h1:UvSe12bq+U
 github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e/go.mod h1:G1CVv03EnqU1wYL2dFwXxW2An0az9JTl/ZsqXQeBlkU=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/jsign/go-ipa v0.0.0-20221213212217-fcc1cb4ffdd5 h1:7pT9gqhsfYrfcOP0Ew06ctN28CtxGlURMnpFHQx7tXg=
+github.com/jsign/go-ipa v0.0.0-20221213212217-fcc1cb4ffdd5/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -554,7 +552,6 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211020174200-9d6173849985/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/tests/tries_test.go
+++ b/tests/tries_test.go
@@ -1,0 +1,76 @@
+package tests
+
+import (
+	"fmt"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb/memorydb"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/gballet/go-verkle"
+)
+
+func BenchmarkTriesRandom(b *testing.B) {
+	numAccounts := []int{1_000, 5_000, 10_000}
+
+	for _, numAccounts := range numAccounts {
+		rs := rand.New(rand.NewSource(42))
+		accounts := getRandomStateAccounts(rs, numAccounts)
+
+		b.Run(fmt.Sprintf("MPT/%d accounts", numAccounts), func(b *testing.B) {
+			trie, _ := trie.NewStateTrie(trie.TrieID(common.Hash{}), trie.NewDatabase(memorydb.New()))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for k := 0; k < len(accounts); k++ {
+					trie.TryUpdateAccount(accounts[k].address[:], &accounts[k].stateAccount)
+				}
+				trie.Commit(true)
+			}
+		})
+		b.Run(fmt.Sprintf("VKT/%d accounts", numAccounts), func(b *testing.B) {
+			// Warmup VKT configuration
+			trie.NewVerkleTrie(verkle.New(), trie.NewDatabase(memorydb.New())).TryUpdate([]byte("00000000000000000000000000000012"), []byte("B"))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				trie := trie.NewVerkleTrie(verkle.New(), trie.NewDatabase(memorydb.New()))
+				for k := 0; k < len(accounts); k++ {
+					trie.TryUpdateAccount(accounts[k].address[:], &accounts[k].stateAccount)
+				}
+				trie.Commit(false)
+			}
+		})
+	}
+}
+
+type randomAccount struct {
+	address      common.Address
+	stateAccount types.StateAccount
+}
+
+func getRandomStateAccounts(rand *rand.Rand, count int) []randomAccount {
+	randomBytes := func(size int) []byte {
+		ret := make([]byte, size)
+		rand.Read(ret)
+		return ret
+	}
+
+	accounts := make([]randomAccount, count)
+	for i := range accounts {
+		accounts[i] = randomAccount{
+			address: common.BytesToAddress(randomBytes(common.AddressLength)),
+			stateAccount: types.StateAccount{
+				Nonce:    rand.Uint64(),
+				Balance:  big.NewInt(int64(rand.Uint64())),
+				Root:     common.Hash{},
+				CodeHash: nil,
+			},
+		}
+	}
+	return accounts
+}

--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -82,9 +82,11 @@ func GetTreeKey(address []byte, treeIndex *uint256.Int, subIndex byte) []byte {
 	//   32-byte aligned big-endian representation (BE({00,...,AA,BB,CC})).
 	// - poly[4]'s byte representation is the same as the *low* 16 bytes (trieIndexBytes[:16]) of
 	//   the 32-byte aligned big-endian representation (BE({00,00,...}).
-	trieIndexBytes := treeIndex.Bytes32()
-	verkle.FromBytes(&poly[3], trieIndexBytes[16:])
-	verkle.FromBytes(&poly[4], trieIndexBytes[:16])
+	if !treeIndex.IsZero() {
+		trieIndexBytes := treeIndex.Bytes32()
+		verkle.FromBytes(&poly[3], trieIndexBytes[16:])
+		verkle.FromBytes(&poly[4], trieIndexBytes[:16])
+	}
 
 	cfg := verkle.GetConfig()
 	ret := cfg.CommitToPoly(poly[:], 0)

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -119,7 +119,7 @@ func (t *VerkleTrie) TryUpdateAccount(key []byte, acc *types.StateAccount) error
 	var (
 		err            error
 		nonce, balance [32]byte
-		values         = make([][]byte, 4)
+		values         = make([][]byte, 256)
 		stem           = utils.GetTreeKeyVersion(key[:])
 	)
 


### PR DESCRIPTION
This PR contains more optimizations apart from the ones in:
- https://github.com/gballet/go-verkle/pull/314
- https://github.com/crate-crypto/go-ipa/pull/31

The `go.mod` in this PR uses those branches; we should update the official commits whenever those PRs are merged.

Apart from that, we're doing other optimizations that will be explained in PR comments.

The results are significant comparing `beverly-hills` vs this PR:
```
name                               old time/op    new time/op    delta
TriesRandom/VKT/1000_accounts-16     56.8ms ± 3%    22.9ms ± 3%  -59.73%  (p=0.001 n=10+5)
TriesRandom/VKT/5000_accounts-16      264ms ± 2%      76ms ± 2%  -71.34%  (p=0.001 n=10+5)
TriesRandom/VKT/10000_accounts-16     535ms ± 2%     146ms ± 5%  -72.78%  (p=0.001 n=10+5)

name                               old alloc/op   new alloc/op   delta
TriesRandom/VKT/1000_accounts-16     9.56MB ± 0%    9.76MB ± 0%   +2.13%  (p=0.001 n=9+5)
TriesRandom/VKT/5000_accounts-16     43.5MB ± 0%    43.9MB ± 0%   +0.94%  (p=0.002 n=8+5)
TriesRandom/VKT/10000_accounts-16    87.5MB ± 0%    88.2MB ± 0%   +0.83%  (p=0.001 n=10+5)

name                               old allocs/op  new allocs/op  delta
TriesRandom/VKT/1000_accounts-16      32.8k ± 0%     35.5k ± 0%   +8.08%  (p=0.001 n=9+5)
TriesRandom/VKT/5000_accounts-16       151k ± 0%      144k ± 0%   -4.88%  (p=0.001 n=10+5)
TriesRandom/VKT/10000_accounts-16      303k ± 0%      285k ± 0%   -5.97%  (p=0.001 n=10+5)
```
