### PR TITLE
fix: infinite loop when calling extcodecopy on empty code

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -424,7 +424,7 @@ func touchEachChunksOnReadAndChargeGas(offset, size uint64, contract *Contract, 
 	// reason that we do not need the last leaf is the account's code size
 	// is already in the AccessWitness so a stateless verifier can see that
 	// the code from the last leaf is not needed.
-	if code != nil && (size == 0 || offset > uint64(len(code))) {
+	if len(code) == 0 && size == 0 || offset > uint64(len(code)) {
 		return 0
 	}
 	var (


### PR DESCRIPTION
Fix a very insidious bug: the loop variable that inserted the chunks was implicitly set to be `uint64` and if the code was an empty (but non-`nil` slice, the insertion loop would become:

```golang
for i := 0; i < 0xFFFFFFFFFFFFFFFF; i++ {
  // ...
}
```