### PR TITLE
dedup call to ChunkifyCode, same as replay branch

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -523,19 +523,11 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 		s.setError(fmt.Errorf("updateStateObject (%x) error: %w", addr[:], err))
 	}
 	if s.trie.IsVerkle() {
-		if len(obj.code) > 0 {
-			cs := make([]byte, 32)
-			binary.LittleEndian.PutUint64(cs, uint64(len(obj.code)))
-			if err := s.trie.TryUpdate(trieUtils.GetTreeKeyCodeSize(addr[:]), cs); err != nil {
-				s.setError(fmt.Errorf("updateStateObject (%x) error: %w", addr[:], err))
-			}
-
-			if obj.dirtyCode {
-				chunks := trie.ChunkifyCode(obj.code)
-				for i := 0; i < len(chunks); i += 32 {
-					s.trie.TryUpdate(trieUtils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.pointEval, uint256.NewInt(uint64(i)/32)), chunks[i:i+32])
-				}
-			}
+		cs := make([]byte, 32)
+		binary.LittleEndian.PutUint64(cs, uint64(len(obj.code)))
+		key := trieUtils.GetTreeKeyCodeSize(addr[:])
+		if err := s.trie.TryUpdate(key, cs); err != nil {
+			s.setError(fmt.Errorf("updateStateObject (%x) error: %w", addr[:], err))
 		}
 	}
 

--- a/core/types/access_witness.go
+++ b/core/types/access_witness.go
@@ -27,8 +27,8 @@ type VerkleStem [31]byte
 
 // Mode specifies how a tree location has been accessed
 // for the byte value:
-//	the first bit is set if the branch has been edited
-//	the second bit is set if the branch has been read
+// * the first bit is set if the branch has been edited
+// * the second bit is set if the branch has been read
 type Mode byte
 
 const (

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -382,10 +382,6 @@ func opCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 	return nil, nil
 }
 
-func touchEachChunksOnReadAndChargeGasWithAddress(offset, size uint64, contract *Contract, code []byte, accesses *types.AccessWitness, deployment bool) uint64 {
-	return touchEachChunksOnReadAndChargeGas(offset, size, contract, code, accesses, deployment)
-}
-
 // touchChunkOnReadAndChargeGas is a helper function to touch every chunk in a code range and charge witness gas costs
 func touchChunkOnReadAndChargeGas(chunks trie.ChunkedCode, offset uint64, evals [][]byte, code []byte, accesses *types.AccessWitness, deployment bool) uint64 {
 	// note that in the case where the executed code is outside the range of


### PR DESCRIPTION
This change was already present in the block replay branch, but had not been transferred to the Beverly Hills branch.