### PR TITLE
save on key hashing: lump code size update with first code chunk group

### DIFF
--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -155,16 +155,16 @@ func (t *VerkleTrie) TryUpdateAccount(key []byte, acc *types.StateAccount) error
 	return nil
 }
 
-func (trie *VerkleTrie) TryUpdateStem(key []byte, values [][]byte) {
+func (trie *VerkleTrie) TryUpdateStem(key []byte, values [][]byte) error {
 	resolver :=
 		func(h []byte) ([]byte, error) {
 			return trie.db.diskdb.Get(h)
 		}
 	switch root := trie.root.(type) {
 	case *verkle.InternalNode:
-		root.InsertStem(key, values, resolver)
+		return root.InsertStem(key, values, resolver)
 	case *verkle.StatelessNode:
-		root.InsertAtStem(key, values, resolver, true)
+		return root.InsertAtStem(key, values, resolver, true)
 	default:
 		panic("invalid root type")
 	}


### PR DESCRIPTION
In order to reduce the amount of hashing that is performed, reuse the key value of the first code chunk group in order to also store the code size.