### PR TITLE
fix: use the verkle key when reading from a verkle tree

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -238,7 +238,12 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 			tr = s.getTrie(db)
 		}
 		start := time.Now()
-		enc, err = s.getTrie(db).TryGet(key.Bytes())
+		if s.db.GetTrie().IsVerkle() {
+			key := trieUtils.GetTreeKeyStorageSlot(s.Address().Bytes(), uint256.NewInt(0).SetBytes(key.Bytes()))
+			enc, err = tr.TryGet(key)
+		} else {
+			enc, err = tr.TryGet(key.Bytes())
+		}
 		if metrics.EnabledExpensive {
 			s.db.StorageReads += time.Since(start)
 		}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -231,8 +231,11 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	}
 	// If the snapshot is unavailable or reading from it fails, load from the database.
 	if s.db.snap == nil || err != nil {
+		var tr Trie
 		if s.db.GetTrie().IsVerkle() {
-			panic("verkle trees use the snapshot")
+			tr = s.db.GetTrie()
+		} else {
+			tr = s.getTrie(db)
 		}
 		start := time.Now()
 		enc, err = s.getTrie(db).TryGet(key.Bytes())


### PR DESCRIPTION
Second step when investigating the sepolia shadow fork replay bugs: use the keys. This step fixes reading the correct value, but it will cause an error down the line (see next PR for details).