### PR TITLE
fix: do not attempt to decode RLP when reading from the verkle tree

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -238,7 +238,12 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 			tr = s.getTrie(db)
 		}
 		start := time.Now()
-		enc, err = s.getTrie(db).TryGet(key.Bytes())
+		if s.db.GetTrie().IsVerkle() {
+			key := trieUtils.GetTreeKeyStorageSlot(s.Address().Bytes(), uint256.NewInt(0).SetBytes(key.Bytes()))
+			enc, err = tr.TryGet(key)
+		} else {
+			enc, err = tr.TryGet(key.Bytes())
+		}
 		if metrics.EnabledExpensive {
 			s.db.StorageReads += time.Since(start)
 		}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -231,8 +231,11 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	}
 	// If the snapshot is unavailable or reading from it fails, load from the database.
 	if s.db.snap == nil || err != nil {
+		var tr Trie
 		if s.db.GetTrie().IsVerkle() {
-			panic("verkle trees use the snapshot")
+			tr = s.db.GetTrie()
+		} else {
+			tr = s.getTrie(db)
 		}
 		start := time.Now()
 		enc, err = s.getTrie(db).TryGet(key.Bytes())

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -210,8 +210,9 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	}
 	// If no live objects are available, attempt to use snapshots
 	var (
-		enc []byte
-		err error
+		enc   []byte
+		err   error
+		value common.Hash
 	)
 	if s.db.snap != nil {
 		// If the object was destructed in *this* block (and potentially resurrected),
@@ -240,7 +241,9 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 		start := time.Now()
 		if s.db.GetTrie().IsVerkle() {
 			key := trieUtils.GetTreeKeyStorageSlot(s.Address().Bytes(), uint256.NewInt(0).SetBytes(key.Bytes()))
-			enc, err = tr.TryGet(key)
+			var v []byte
+			v, err = tr.TryGet(key)
+			copy(value[:], v)
 		} else {
 			enc, err = tr.TryGet(key.Bytes())
 		}
@@ -252,7 +255,6 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 			return common.Hash{}
 		}
 	}
-	var value common.Hash
 	if len(enc) > 0 {
 		_, content, _, err := rlp.Split(enc)
 		if err != nil {


### PR DESCRIPTION
Third step in my sepolia replay investigation: verkle trees don't use RLP, so a decode attempt should not be attempted in that case. This introduces another regression, though, in which it seems that the conversion now introduces invalid nodes. This could be a versioning error.