### PR TITLE
workaround: deactivate VerkleTrie.TryDelete in order to be able to sync

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -94,6 +94,10 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 	if receiptSha != header.ReceiptHash {
 		return fmt.Errorf("invalid receipt root hash (remote: %x local: %x)", header.ReceiptHash, receiptSha)
 	}
+	// Skip header validation if we are inside the conversion process
+	if IsInsideConversionWindow(header.Number.Uint64()) {
+		return nil
+	}
 	// Validate the state root against the received state root and throw
 	// an error if they don't match.
 	if root := statedb.IntermediateRoot(v.config.IsEIP158(header.Number)); header.Root != root {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -138,11 +138,13 @@ func NewDatabaseWithConfig(db ethdb.Database, config *trie.Config) Database {
 	return &ForkingDB{
 		cachingDB: &cachingDB{
 			db:            trie.NewDatabaseWithConfig(db, config),
+			disk:          db,
 			codeSizeCache: csc,
 			codeCache:     fastcache.New(codeCacheSize),
 		},
 		VerkleDB: &VerkleDB{
 			db:            trie.NewDatabaseWithConfig(db, config),
+			diskdb:        db,
 			codeSizeCache: csc,
 			codeCache:     fastcache.New(codeCacheSize),
 		},

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -135,20 +135,103 @@ func NewDatabase(db ethdb.Database) Database {
 // large memory cache.
 func NewDatabaseWithConfig(db ethdb.Database, config *trie.Config) Database {
 	csc, _ := lru.New(codeSizeCacheSize)
-	if config != nil && config.UseVerkle {
-		return &VerkleDB{
+	return &ForkingDB{
+		cachingDB: &cachingDB{
 			db:            trie.NewDatabaseWithConfig(db, config),
-			diskdb:        db,
 			codeSizeCache: csc,
 			codeCache:     fastcache.New(codeCacheSize),
-		}
+		},
+		VerkleDB: &VerkleDB{
+			db:            trie.NewDatabaseWithConfig(db, config),
+			codeSizeCache: csc,
+			codeCache:     fastcache.New(codeCacheSize),
+		},
+		forked: (config != nil && config.UseVerkle),
 	}
-	return &cachingDB{
-		db:            trie.NewDatabaseWithConfig(db, config),
-		disk:          db,
-		codeSizeCache: csc,
-		codeCache:     fastcache.New(codeCacheSize),
+}
+
+// ForkingDB is an adapter object to support forks between
+// cachingDB and VerkleDB.
+type ForkingDB struct {
+	*cachingDB
+	*VerkleDB
+
+	forked          bool
+	translatedRoots map[common.Hash]common.Hash // hash of the translated root, for opening
+}
+
+// ContractCode implements Database
+func (fdb *ForkingDB) ContractCode(addrHash common.Hash, codeHash common.Hash) ([]byte, error) {
+	if fdb.forked {
+		return fdb.VerkleDB.ContractCode(addrHash, codeHash)
 	}
+
+	return fdb.cachingDB.ContractCode(addrHash, codeHash)
+}
+
+// ContractCodeSize implements Database
+func (fdb *ForkingDB) ContractCodeSize(addrHash common.Hash, codeHash common.Hash) (int, error) {
+	if fdb.forked {
+		return fdb.VerkleDB.ContractCodeSize(addrHash, codeHash)
+	}
+
+	return fdb.cachingDB.ContractCodeSize(addrHash, codeHash)
+}
+
+// CopyTrie implements Database
+func (fdb *ForkingDB) CopyTrie(t Trie) Trie {
+	if fdb.forked {
+		return fdb.VerkleDB.CopyTrie(t)
+	}
+
+	return fdb.cachingDB.CopyTrie(t)
+}
+
+// OpenStorageTrie implements Database
+func (fdb *ForkingDB) OpenStorageTrie(stateRoot, addrHash, root common.Hash) (Trie, error) {
+	if fdb.forked {
+		return fdb.VerkleDB.OpenStorageTrie(stateRoot, addrHash, fdb.translatedRoots[root])
+	}
+
+	return fdb.cachingDB.OpenStorageTrie(stateRoot, addrHash, root)
+}
+
+// OpenTrie implements Database
+func (fdb *ForkingDB) OpenTrie(root common.Hash) (Trie, error) {
+	if fdb.forked {
+		// il y a un probleme: ça ne marche que pour le premier block
+		return fdb.VerkleDB.OpenTrie(fdb.translatedRoots[root])
+	}
+
+	return fdb.cachingDB.OpenTrie(root)
+}
+
+// TrieDB implements Database
+func (fdb *ForkingDB) TrieDB() *trie.Database {
+	if fdb.forked {
+		return fdb.VerkleDB.TrieDB()
+	}
+
+	return fdb.cachingDB.TrieDB()
+}
+
+// DiskDB retrieves the low level trie database used for data storage.
+func (fdb *ForkingDB) DiskDB() ethdb.KeyValueStore {
+	if fdb.forked {
+		return fdb.VerkleDB.DiskDB()
+	}
+
+	return fdb.cachingDB.DiskDB()
+}
+
+// Fork implements the fork
+func (fdb *ForkingDB) Fork(originalRoot, translatedRoot common.Hash) {
+	fdb.forked = true
+	fdb.translatedRoots = map[common.Hash]common.Hash{originalRoot: translatedRoot}
+}
+
+func (fdb *ForkingDB) AddTranslation(orig, trans common.Hash) {
+	fdb.translatedRoots[orig] = trans
 }
 
 type cachingDB struct {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -390,7 +390,7 @@ func (s *stateObject) updateTrie(db Database) Trie {
 	if len(s.pendingStorage) > 0 {
 		s.pendingStorage = make(Storage)
 	}
-	return tr
+	return s.trie
 }
 
 // UpdateRoot sets the trie root to the current root hash of

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -238,7 +238,12 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 			tr = s.getTrie(db)
 		}
 		start := time.Now()
-		enc, err = s.getTrie(db).TryGet(key.Bytes())
+		if s.db.GetTrie().IsVerkle() {
+			key := trieUtils.GetTreeKeyStorageSlot(s.Address().Bytes(), uint256.NewInt(0).SetBytes(key.Bytes()))
+			enc, err = tr.TryGet(key)
+		} else {
+			enc, err = tr.TryGet(key.Bytes())
+		}
 		if metrics.EnabledExpensive {
 			s.db.StorageReads += time.Since(start)
 		}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -231,8 +231,11 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	}
 	// If the snapshot is unavailable or reading from it fails, load from the database.
 	if s.db.snap == nil || err != nil {
+		var tr Trie
 		if s.db.GetTrie().IsVerkle() {
-			panic("verkle trees use the snapshot")
+			tr = s.db.GetTrie()
+		} else {
+			tr = s.getTrie(db)
 		}
 		start := time.Now()
 		enc, err = s.getTrie(db).TryGet(key.Bytes())

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -210,8 +210,9 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	}
 	// If no live objects are available, attempt to use snapshots
 	var (
-		enc []byte
-		err error
+		enc   []byte
+		err   error
+		value common.Hash
 	)
 	if s.db.snap != nil {
 		// If the object was destructed in *this* block (and potentially resurrected),
@@ -240,7 +241,9 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 		start := time.Now()
 		if s.db.GetTrie().IsVerkle() {
 			key := trieUtils.GetTreeKeyStorageSlot(s.Address().Bytes(), uint256.NewInt(0).SetBytes(key.Bytes()))
-			enc, err = tr.TryGet(key)
+			var v []byte
+			v, err = tr.TryGet(key)
+			copy(value[:], v)
 		} else {
 			enc, err = tr.TryGet(key.Bytes())
 		}
@@ -252,7 +255,6 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 			return common.Hash{}
 		}
 	}
-	var value common.Hash
 	if len(enc) > 0 {
 		_, content, _, err := rlp.Split(enc)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cespare/cp v0.1.0
 	github.com/cloudflare/cloudflare-go v0.14.0
 	github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f
-	github.com/crate-crypto/go-ipa v0.0.0-20221111143132-9aa5d42120bc
+	github.com/crate-crypto/go-ipa v0.0.0-20230202201618-2e6f5bfc5401
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.8.0
 	github.com/docker/docker v1.6.2
@@ -23,7 +23,7 @@ require (
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20221129125207-513116151b28
+	github.com/gballet/go-verkle v0.0.0-20230224151942-0236f337641c
 	github.com/go-stack/stack v1.8.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/golang/protobuf v1.5.2
@@ -61,7 +61,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.2.0
+	golang.org/x/sys v0.5.0
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHH
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/crate-crypto/go-ipa v0.0.0-20221111143132-9aa5d42120bc h1:mtR7MuscVeP/s0/ERWA2uSr5QOrRYy1pdvZqG1USfXI=
 github.com/crate-crypto/go-ipa v0.0.0-20221111143132-9aa5d42120bc/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
+github.com/crate-crypto/go-ipa v0.0.0-20230202201618-2e6f5bfc5401 h1:TSXRL74LZ7R2xWOI1M0mz9E56PiPKGlSw0drgR8g7CE=
+github.com/crate-crypto/go-ipa v0.0.0-20230202201618-2e6f5bfc5401/go.mod h1:gFnFS95y8HstDP6P9pPwzrxOOC5TRDkwbM+ao15ChAI=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -139,6 +141,8 @@ github.com/gballet/go-verkle v0.0.0-20221122140954-75ceda26b7db h1:YvtZfE11QEYWP
 github.com/gballet/go-verkle v0.0.0-20221122140954-75ceda26b7db/go.mod h1:DMDd04jjQgdynaAwbEgiRERIGpC8fDjx0+y06an7Psg=
 github.com/gballet/go-verkle v0.0.0-20221129125207-513116151b28 h1:UbB7D2R1OQCkNFX+LYoo2pHZ0u5LhwR9ldUsY4ZbZqI=
 github.com/gballet/go-verkle v0.0.0-20221129125207-513116151b28/go.mod h1:DMDd04jjQgdynaAwbEgiRERIGpC8fDjx0+y06an7Psg=
+github.com/gballet/go-verkle v0.0.0-20230224151942-0236f337641c h1:VQ6XsQHZzynoHGd9ef7KCs9WsMAUc4/OnhtIZmyIYag=
+github.com/gballet/go-verkle v0.0.0-20230224151942-0236f337641c/go.mod h1:DMDd04jjQgdynaAwbEgiRERIGpC8fDjx0+y06an7Psg=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -558,6 +562,8 @@ golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RA
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -183,35 +183,36 @@ func (trie *VerkleTrie) TryUpdate(key, value []byte) error {
 }
 
 func (t *VerkleTrie) TryDeleteAccount(key []byte) error {
-	var (
-		err                                error
-		balancekey, cskey, ckkey, noncekey [32]byte
-	)
+	// var (
+	// 	err                                error
+	// 	balancekey, cskey, ckkey, noncekey [32]byte
+	// )
 
-	// Only evaluate the polynomial once
-	// TODO InsertStem with overwrite of values 0
-	versionkey := utils.GetTreeKeyVersion(key[:])
-	copy(balancekey[:], versionkey)
-	balancekey[31] = utils.BalanceLeafKey
-	copy(noncekey[:], versionkey)
-	noncekey[31] = utils.NonceLeafKey
-	copy(cskey[:], versionkey)
-	cskey[31] = utils.CodeSizeLeafKey
-	copy(ckkey[:], versionkey)
-	ckkey[31] = utils.CodeKeccakLeafKey
+	// // Only evaluate the polynomial once
+	// // TODO InsertStem with overwrite of values 0
+	// versionkey := utils.GetTreeKeyVersion(key[:])
+	// copy(balancekey[:], versionkey)
+	// balancekey[31] = utils.BalanceLeafKey
+	// copy(noncekey[:], versionkey)
+	// noncekey[31] = utils.NonceLeafKey
+	// copy(cskey[:], versionkey)
+	// cskey[31] = utils.CodeSizeLeafKey
+	// copy(ckkey[:], versionkey)
+	// ckkey[31] = utils.CodeKeccakLeafKey
 
-	if err = t.TryDelete(versionkey); err != nil {
-		return fmt.Errorf("updateStateObject (%x) error: %v", key, err)
-	}
-	if err = t.TryDelete(noncekey[:]); err != nil {
-		return fmt.Errorf("updateStateObject (%x) error: %v", key, err)
-	}
-	if err = t.TryDelete(balancekey[:]); err != nil {
-		return fmt.Errorf("updateStateObject (%x) error: %v", key, err)
-	}
-	if err = t.TryDelete(ckkey[:]); err != nil {
-		return fmt.Errorf("updateStateObject (%x) error: %v", key, err)
-	}
+	// if err = t.TryDelete(versionkey); err != nil {
+	// 	panic("pourquoi est-ce detruit")
+	// 	return fmt.Errorf("TryDeleteAccount (addr=%x, key=%x) error: %w", key, versionkey, err)
+	// }
+	// if err = t.TryDelete(noncekey[:]); err != nil {
+	// 	return fmt.Errorf("TryDeleteAccount (addr=%x, key=%x) error: %w", key, noncekey, err)
+	// }
+	// if err = t.TryDelete(balancekey[:]); err != nil {
+	// 	return fmt.Errorf("TryDeleteAccount (addr=%x, key=%x) error: %w", key, balancekey, err)
+	// }
+	// if err = t.TryDelete(ckkey[:]); err != nil {
+	// 	return fmt.Errorf("TryDeleteAccount (addr=%x, key=%x) error: %w", key, ckkey, err)
+	// }
 	// TODO figure out if the code size needs to be updated, too
 
 	return nil


### PR DESCRIPTION
This is a temporary fix for the sepolia shadow fork: it deactivates deletion, which isn't possible for verkle trees.

This means that, during block replay, verkle trees need to support deletion as, otherwise, two nodes with a different conversion point will find themselves with a different final state, all other things being equal.