### PR TITLE
fix: only update dirty code

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -522,7 +522,7 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 	if err := s.trie.TryUpdateAccount(addr[:], &obj.data); err != nil {
 		s.setError(fmt.Errorf("updateStateObject (%x) error: %w", addr[:], err))
 	}
-	if s.trie.IsVerkle() {
+	if s.trie.IsVerkle() && obj.dirtyCode {
 		var (
 			chunks = trie.ChunkifyCode(obj.code)
 			values [][]byte


### PR DESCRIPTION
This reduces the (old) replay branch execution time by 20s