### PR TITLE
fix: read-touch the code size and Keccak of the origin

### DIFF
--- a/core/types/access_witness.go
+++ b/core/types/access_witness.go
@@ -388,6 +388,8 @@ func (aw *AccessWitness) TouchTxOriginAndComputeGas(originAddr []byte) uint64 {
 	ckkey[31] = utils.CodeKeccakLeafKey
 
 	gas += aw.TouchAddressOnReadAndComputeGas(versionkey)
+	gas += aw.TouchAddressOnReadAndComputeGas(cskey[:])
+	gas += aw.TouchAddressOnReadAndComputeGas(ckkey[:])
 	gas += aw.TouchAddressOnWriteAndComputeGas(noncekey[:])
 	gas += aw.TouchAddressOnWriteAndComputeGas(balancekey[:])
 


### PR DESCRIPTION
The spec says that, when sending a transaction from an account, the leave for the code size and keccak should be accessed. This PR ensures that these locations are accessed and the gas charged for it.