### PR TITLE
ci: update precomp download link

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,6 +43,6 @@ jobs:
         with:
           go-version: 1.18
       - name: Download precomputed points
-        run: wget -nv https://github.com/gballet/go-verkle/releases/download/banderwagonv2/precomp -Otrie/utils/precomp
+        run: wget -nv https://github.com/gballet/go-verkle/releases/download/banderwagonv3/precomp -Otrie/utils/precomp
       - name: Test
         run: go test ./...


### PR DESCRIPTION
Download the latest precomp file. If we don't do this, we'll get some errors in our CI.

See https://github.com/gballet/go-ethereum/issues/186