### PR TITLE
trie/utils: fix incorrect bigint assignment

### DIFF
--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -277,7 +277,7 @@ func GetTreeKeyStorageSlotWithEvaluatedAddress(evaluated *verkle.Point, storageK
 	} else {
 		pos.Add(mainStorageOffsetBig, pos)
 	}
-	treeIndex, overflow := uint256.FromBig(pos.Div(pos, verkleNodeWidthBig))
+	treeIndex, overflow := uint256.FromBig(big.NewInt(0).Div(pos, verkleNodeWidthBig))
 	if overflow { // Must never happen considering the EIP definition.
 		panic("tree index overflow")
 	}


### PR DESCRIPTION
This goes back to our known `4ff31341ec17af3df4ecebbde12c2e632fba6641a56c95d624c4e3ab8a945276`.