### PR TITLE
verkle migration: faster stage2 conversion

### DIFF
--- a/cmd/geth/verkle.go
+++ b/cmd/geth/verkle.go
@@ -787,8 +787,6 @@ func sortKeys(ctx *cli.Context) error {
 		// Process secondLvlLeaves items and pipe the results to readyToSerializeSubtree.
 		log.Info("Building tree", "name", file.Name())
 		readyToSerializeSubtree := make(chan []verkle.SerializedNode)
-		// var lock sync.Mutex
-		// var roots []*verkle.InternalNode
 		go func() {
 			group, _ := errgroup.WithContext(context.Background())
 			group.SetLimit(runtime.NumCPU())
@@ -805,9 +803,6 @@ func sortKeys(ctx *cli.Context) error {
 					sort.Slice(nodes, func(i, j int) bool {
 						return bytes.Compare(nodes[i].CommitmentBytes[:], nodes[j].CommitmentBytes[:]) < 0
 					})
-					// lock.Lock()
-					// roots = append(roots, root)
-					// lock.Unlock()
 
 					stem := leavesData[0].Stem
 					point, err := verkle.GetInternalNodeCommitment(root, stem[:2])
@@ -841,9 +836,6 @@ func sortKeys(ctx *cli.Context) error {
 				}
 			}
 		}
-
-		// root := verkle.MergeLevelTwoPartitions(roots)
-		// log.Info("Building tree finished", "root", fmt.Sprintf("%x", root.Commit().Bytes()))
 
 		runtime.GC()
 	}

--- a/cmd/geth/verkle.go
+++ b/cmd/geth/verkle.go
@@ -846,7 +846,10 @@ func sortKeys(ctx *cli.Context) error {
 				}
 				leaves := verkle.BatchNewLeafNode(leavesData[start:end])
 				roots[i] = verkle.BatchInsertOrderedLeaves(leaves)
-				roots[i].Commit()
+
+				if _, err := roots[i].BatchSerialize(); err != nil {
+					panic(err)
+				}
 			}()
 		}
 		wg.Wait()
@@ -855,9 +858,6 @@ func sortKeys(ctx *cli.Context) error {
 		log.Info("Building tree finished", "root", fmt.Sprintf("%x", root.Commit().Bytes()))
 
 		log.Info("Serializing tree")
-		if _, err := root.BatchSerialize(); err != nil {
-			panic(err)
-		}
 
 		runtime.GC()
 	}

--- a/cmd/geth/verkle.go
+++ b/cmd/geth/verkle.go
@@ -788,7 +788,7 @@ func sortKeys(ctx *cli.Context) error {
 					// We generate the LeafNodes in an optimized way.
 					leaves := verkle.BatchNewLeafNode(leavesData)
 					// We do an optimized tree construction from all the leaves at once.
-					// Note this is a partial tree since all the keys have hte same first two bytes of the stem.
+					// Note this is a partial tree since all the keys have the same first two bytes of the stem.
 					root := verkle.BatchInsertOrderedLeaves(leaves)
 					root.Commit()
 

--- a/cmd/geth/verkle.go
+++ b/cmd/geth/verkle.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"runtime"
@@ -776,18 +775,9 @@ func sortKeys(ctx *cli.Context) error {
 
 		log.Info("Processing file", "name", file.Name())
 		numTuples := len(data) / 64
-		tuples := make([][64]byte, 0, numTuples)
-		reader := bytes.NewReader(data)
-		for {
-			var tuple [64]byte
-			err := binary.Read(reader, binary.LittleEndian, &tuple)
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			if err != nil {
-				panic(err)
-			}
-			tuples = append(tuples, tuple)
+		tuples := make([][]byte, numTuples)
+		for i := 0; i < numTuples; i++ {
+			tuples[i] = data[i*64 : (i+1)*64]
 		}
 
 		// Sort tuples by key

--- a/cmd/geth/verkle.go
+++ b/cmd/geth/verkle.go
@@ -846,6 +846,7 @@ func sortKeys(ctx *cli.Context) error {
 				}
 				leaves := verkle.BatchNewLeafNode(leavesData[start:end])
 				roots[i] = verkle.BatchInsertOrderedLeaves(leaves)
+				roots[i].Commit()
 			}()
 		}
 		wg.Wait()
@@ -857,6 +858,8 @@ func sortKeys(ctx *cli.Context) error {
 		if _, err := root.BatchSerialize(); err != nil {
 			panic(err)
 		}
+
+		runtime.GC()
 	}
 
 	log.Info("Finished", "elapsed", common.PrettyDuration(time.Since(start)))

--- a/cmd/geth/verkle.go
+++ b/cmd/geth/verkle.go
@@ -890,7 +890,7 @@ func getSortedLeavesData(fname string, secondLvlLeavesData chan []verkle.BatchNe
 	log.Info("Merging file", "name", fname)
 	var (
 		stem   []byte
-		values = make(map[int][]byte, 5)
+		values = make(map[byte][]byte, 5)
 		last   []byte
 	)
 	if len(tuples) > 0 {
@@ -906,10 +906,10 @@ func getSortedLeavesData(fname string, secondLvlLeavesData chan []verkle.BatchNe
 				leavesData = make([]verkle.BatchNewLeafNodeData, 0, len(leavesData))
 			}
 			last = stem
-			values = make(map[int][]byte)
+			values = make(map[byte][]byte)
 		}
 
-		values[int(tuples[i][31])] = tuples[i][32:]
+		values[tuples[i][31]] = tuples[i][32:]
 	}
 	leavesData = append(leavesData, verkle.BatchNewLeafNodeData{Stem: last, Values: values})
 	secondLvlLeavesData <- leavesData

--- a/cmd/geth/verkle.go
+++ b/cmd/geth/verkle.go
@@ -809,10 +809,7 @@ func sortKeys(ctx *cli.Context) error {
 					// in secondLevelCommitment[a][b]. Note that each goroutine is working on a different
 					// place in the array, so there's no race-condition.
 					stem := leavesData[0].Stem // All the leaves have the same first 2-byte stem, take the first one.
-					point, err := verkle.GetInternalNodeCommitment(root, stem[:2])
-					if err != nil {
-						log.Crit("Failed to get commitment", "error", err)
-					}
+					point := verkle.GetInternalNodeCommitment(root, stem[:2])
 					secondLevelCommitment[stem[0]][stem[1]] = point.Bytes()
 
 					// Send the nodes to serializedTrees which will write them to disk.

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20230406161123-14eaab595ed4
+	github.com/gballet/go-verkle v0.0.0-20230413150157-a32ba2800509
 	github.com/go-stack/stack v1.8.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/golang/protobuf v1.5.2
@@ -106,5 +106,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/crate-crypto/go-ipa => github.com/jsign/go-ipa v0.0.0-20230323132738-cd121cd65e68

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20230413135631-4bea2763ed0f
+	github.com/gballet/go-verkle v0.0.0-20230406161123-14eaab595ed4
 	github.com/go-stack/stack v1.8.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/golang/protobuf v1.5.2
@@ -107,4 +107,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/gballet/go-verkle => ../../go-verkle
+replace github.com/crate-crypto/go-ipa => github.com/jsign/go-ipa v0.0.0-20230323132738-cd121cd65e68

--- a/go.mod
+++ b/go.mod
@@ -106,3 +106,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/gballet/go-verkle => ../../go-verkle

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20230413150157-a32ba2800509
+	github.com/gballet/go-verkle v0.0.0-20230413165055-0ebfd8549906
 	github.com/go-stack/stack v1.8.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -137,10 +137,8 @@ github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 h1:IZqZOB2fydHte3kUgx
 github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
-github.com/gballet/go-verkle v0.0.0-20230317174103-141354da6b11 h1:x4hiQFgr1SlqR4IoAZiXLFZK4L7KbibqkORqa1fwKp8=
-github.com/gballet/go-verkle v0.0.0-20230317174103-141354da6b11/go.mod h1:IyOnn1kujMWaT+wet/6Ix1BtvYwateOBy9puuWH/8sw=
-github.com/gballet/go-verkle v0.0.0-20230413135631-4bea2763ed0f h1:gP4uR2/1qx6hsIzbRI28JWcsVuP7xyjyj6SpLnoFobc=
-github.com/gballet/go-verkle v0.0.0-20230413135631-4bea2763ed0f/go.mod h1:P3bwGrLhsUNIsUDlq2yzMPvO1c/15oiB3JS85P+hNfw=
+github.com/gballet/go-verkle v0.0.0-20230406161123-14eaab595ed4 h1:C7DwAGkiiI07J0BuV2dmp+QSuURjuFlZVFKU0L/uong=
+github.com/gballet/go-verkle v0.0.0-20230406161123-14eaab595ed4/go.mod h1:IyOnn1kujMWaT+wet/6Ix1BtvYwateOBy9puuWH/8sw=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -257,6 +255,8 @@ github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e h1:UvSe12bq+U
 github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e/go.mod h1:G1CVv03EnqU1wYL2dFwXxW2An0az9JTl/ZsqXQeBlkU=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/jsign/go-ipa v0.0.0-20230323132738-cd121cd65e68 h1:w0ko/S0wlKJvv0uV70abNCxYd6fkiGUQqT93afrfcmM=
+github.com/jsign/go-ipa v0.0.0-20230323132738-cd121cd65e68/go.mod h1:gzbVz57IDJgQ9rLQwfSk696JGWof8ftznEL9GoAv3NI=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 h1:IZqZOB2fydHte3kUgx
 github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
-github.com/gballet/go-verkle v0.0.0-20230413150157-a32ba2800509 h1:x1PgDhyRk2RKDXjLEVhSf2TW2aia9F+aD44GQYbLnvk=
-github.com/gballet/go-verkle v0.0.0-20230413150157-a32ba2800509/go.mod h1:P3bwGrLhsUNIsUDlq2yzMPvO1c/15oiB3JS85P+hNfw=
+github.com/gballet/go-verkle v0.0.0-20230413165055-0ebfd8549906 h1:T/z0/Xg6VwrTdw6oZcQyw6vLjDF5+g/15ppwSWgBMP8=
+github.com/gballet/go-verkle v0.0.0-20230413165055-0ebfd8549906/go.mod h1:P3bwGrLhsUNIsUDlq2yzMPvO1c/15oiB3JS85P+hNfw=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -554,8 +554,6 @@ golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211020174200-9d6173849985/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,6 @@ github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f/go.mod h1
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/crate-crypto/go-ipa v0.0.0-20230315201338-1643fdc2ead8 h1:2EBbIwPDRqlCD2K34Eojyy0x9d3RhOuHAZfbQm508X8=
-github.com/crate-crypto/go-ipa v0.0.0-20230315201338-1643fdc2ead8/go.mod h1:gzbVz57IDJgQ9rLQwfSk696JGWof8ftznEL9GoAv3NI=
 github.com/crate-crypto/go-ipa v0.0.0-20230410135559-ce4a96995014 h1:bbyTlFQ12wkFA6aVL+9HrBZwVl85AN0VS/Bwam7o93U=
 github.com/crate-crypto/go-ipa v0.0.0-20230410135559-ce4a96995014/go.mod h1:gzbVz57IDJgQ9rLQwfSk696JGWof8ftznEL9GoAv3NI=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -137,8 +135,8 @@ github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 h1:IZqZOB2fydHte3kUgx
 github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
-github.com/gballet/go-verkle v0.0.0-20230406161123-14eaab595ed4 h1:C7DwAGkiiI07J0BuV2dmp+QSuURjuFlZVFKU0L/uong=
-github.com/gballet/go-verkle v0.0.0-20230406161123-14eaab595ed4/go.mod h1:IyOnn1kujMWaT+wet/6Ix1BtvYwateOBy9puuWH/8sw=
+github.com/gballet/go-verkle v0.0.0-20230413150157-a32ba2800509 h1:x1PgDhyRk2RKDXjLEVhSf2TW2aia9F+aD44GQYbLnvk=
+github.com/gballet/go-verkle v0.0.0-20230413150157-a32ba2800509/go.mod h1:P3bwGrLhsUNIsUDlq2yzMPvO1c/15oiB3JS85P+hNfw=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -255,8 +253,6 @@ github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e h1:UvSe12bq+U
 github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e/go.mod h1:G1CVv03EnqU1wYL2dFwXxW2An0az9JTl/ZsqXQeBlkU=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/jsign/go-ipa v0.0.0-20230323132738-cd121cd65e68 h1:w0ko/S0wlKJvv0uV70abNCxYd6fkiGUQqT93afrfcmM=
-github.com/jsign/go-ipa v0.0.0-20230323132738-cd121cd65e68/go.mod h1:gzbVz57IDJgQ9rLQwfSk696JGWof8ftznEL9GoAv3NI=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=


### PR DESCRIPTION
This PR optimizes stage2 Verkle Tree state migration both in CPU and memory.

The complete changeset involves not only this PR, but also assistance from new methods and other changes in `go-verkle` (see https://github.com/gballet/go-verkle/pull/338).

As a quick comparison of performance (my machine, 16 cores and 16GiB of RAM):
- Previous version: a single file took ~4min using >16GiB of RAM, and it only did tree building.
- This version: a single file takes ~20s using up to <5GiB of RAM, and it does the full conversion (tree building, serialization, and saving to DB). This is in a context where LevelDB compactions aren't running.

I went somewhat heavy in commenting on the code, but here are some highlights:
- It runs one file at a time in the most efficient way possible.
- It uses all available cores for all the needed CPU work. (We could easily allow adding a flag to put a cap on the number of cores allowed to be used for this if needed)
- The overall code architecture is a pipeline of processing the raw file, building the tree, serializing nodes, and saving them to the database simultaneously. This is carefully crafted to avoid blocking and liberate heap memory as fast as possible.
- The [mentioned go-verkle PR](https://github.com/gballet/go-verkle/pull/338) has some new specially created methods for cryptographic optimizations regarding batching LeafNode creation and serialization work.
- All key/values saved to the database are presorted by keys to help for db compactions.

Considering all this, in my machine, using <5GiB of RAM and 16 cores (and probably even less) we can process data much faster than the database can keep up with the insertions. The mentioned 20s-per-file is in a context where no database compaction runs simultaneously. 

I'm doing a full run in the 256 files now, and definitely, LevelDB compactions are dominating overhead. We're running things here with the default flags, but I'm interested in hearing if a different set of options could be better.

I can share some logs about this run since I also included some _time elapsed per file_ and _estimated time_, which allows us to understand how compactions affect the run. I think the conclusion is that we probably achieved more than enough efficiency now at this stage2 conversion.