### PR TITLE
refactor: move verkle gas accounting to its own block in TransitionDB

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -323,6 +323,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	if st.gas < gas {
 		return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, gas)
 	}
+	st.gas -= gas
+
 	if st.evm.ChainConfig().IsCancun(st.evm.Context.BlockNumber) {
 		targetAddr := msg.To()
 		originAddr := msg.From()
@@ -347,12 +349,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 				return nil, fmt.Errorf("%w: Insufficient funds to cover witness access costs for transaction: have %d, want %d", ErrInsufficientBalanceWitness, st.gas, gas)
 			}
 		}
-
-		if st.gas < gas {
-			return nil, fmt.Errorf("%w: Insufficient funds to cover witness access costs for transaction: have %d, want %d", ErrInsufficientBalanceWitness, st.gas, gas)
-		}
 	}
-	st.gas -= gas
 
 	// Check clause 6
 	if msg.Value().Sign() > 0 && !st.evm.Context.CanTransfer(st.state, msg.From(), msg.Value()) {


### PR DESCRIPTION
This PR is just needed to simplify the rebase, and to check that the tests are passing.