### PR TITLE
use the cachingDB instead of a custom VerkleDB

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -303,8 +303,10 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		Cache:     cacheConfig.TrieCleanLimit,
 		Journal:   cacheConfig.TrieCleanJournal,
 		Preimages: cacheConfig.Preimages,
-		UseVerkle: chainConfig.IsCancun(head.Header().Number),
 	})
+	if bc.chainConfig.IsCancun(head.Header().Number) {
+		bc.stateCache.EndVerkleTransition()
+	}
 
 	if _, err := state.New(head.Root(), bc.stateCache, bc.snaps); err != nil {
 		// Head state is missing, before the state recovery, find out the

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -385,7 +385,9 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 	}
 	var snaps *snapshot.Tree
 	for i := 0; i < n; i++ {
-		statedb, err := state.New(parent.Root(), state.NewDatabaseWithConfig(db, &trie.Config{UseVerkle: true}), snaps)
+		triedb := state.NewDatabaseWithConfig(db, nil)
+		triedb.EndVerkleTransition()
+		statedb, err := state.New(parent.Root(), triedb, snaps)
 		if err != nil {
 			panic(fmt.Sprintf("could not find state for block %d: err=%v, parent root=%x", i, err, parent.Root()))
 		}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -118,12 +118,12 @@ func (ga *GenesisAlloc) UnmarshalJSON(data []byte) error {
 // deriveHash computes the state root according to the genesis specification.
 func (ga *GenesisAlloc) deriveHash(cfg *params.ChainConfig) (common.Hash, error) {
 	var trieCfg *trie.Config
-	if cfg != nil {
-		trieCfg = &trie.Config{UseVerkle: cfg.IsCancun(big.NewInt(int64(0)))}
-	}
 	// Create an ephemeral in-memory database for computing hash,
 	// all the derived states will be discarded to not pollute disk.
 	db := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), trieCfg)
+	if cfg.IsCancun(big.NewInt(int64(0))) {
+		db.EndVerkleTransition()
+	}
 	statedb, err := state.New(common.Hash{}, db, nil)
 	if err != nil {
 		return common.Hash{}, err
@@ -144,10 +144,11 @@ func (ga *GenesisAlloc) deriveHash(cfg *params.ChainConfig) (common.Hash, error)
 // Also, the genesis state specification will be flushed as well.
 func (ga *GenesisAlloc) flush(db ethdb.Database, cfg *params.ChainConfig) error {
 	trieCfg := &trie.Config{Preimages: true}
-	if cfg != nil {
-		trieCfg.UseVerkle = cfg.IsCancun(big.NewInt(int64(0)))
+	triedb := state.NewDatabaseWithConfig(db, trieCfg)
+	if cfg.IsCancun(big.NewInt(int64(0))) {
+		triedb.EndVerkleTransition()
 	}
-	statedb, err := state.New(common.Hash{}, state.NewDatabaseWithConfig(db, trieCfg), nil)
+	statedb, err := state.New(common.Hash{}, triedb, nil)
 	if err != nil {
 		return err
 	}
@@ -338,21 +339,13 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 		if storedcfg == nil {
 			panic("this should never be reached: if genesis is nil, the config is already present or 'geth init' is being called which created it (in the code above, which means genesis != nil)")
 		}
-
-		if storedcfg.CancunBlock != nil {
-			if storedcfg.CancunBlock.Cmp(big.NewInt(0)) != 0 {
-				panic("cancun block must be 0")
-			}
-
-			trieCfg = &trie.Config{UseVerkle: storedcfg.IsCancun(big.NewInt(header.Number.Int64()))}
-		}
-	} else {
-		trieCfg = &trie.Config{
-			UseVerkle: genesis.Config.IsCancun(big.NewInt(0)),
-		}
 	}
 
-	if _, err := state.New(header.Root, state.NewDatabaseWithConfig(db, trieCfg), nil); err != nil {
+	triedb := state.NewDatabaseWithConfig(db, trieCfg)
+	if genesis != nil && genesis.Config != nil && genesis.Config.IsCancun(big.NewInt(0)) {
+		triedb.EndVerkleTransition()
+	}
+	if _, err := state.New(header.Root, triedb, nil); err != nil {
 		if genesis == nil {
 			genesis = DefaultGenesisBlock()
 		}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -121,7 +121,8 @@ func (ga *GenesisAlloc) deriveHash(cfg *params.ChainConfig) (common.Hash, error)
 	// Create an ephemeral in-memory database for computing hash,
 	// all the derived states will be discarded to not pollute disk.
 	db := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), trieCfg)
-	if cfg.IsCancun(big.NewInt(int64(0))) {
+	// TODO remove the nil config check once we have rebased, it should never be nil
+	if cfg != nil && cfg.IsCancun(big.NewInt(int64(0))) {
 		db.EndVerkleTransition()
 	}
 	statedb, err := state.New(common.Hash{}, db, nil)
@@ -145,7 +146,8 @@ func (ga *GenesisAlloc) deriveHash(cfg *params.ChainConfig) (common.Hash, error)
 func (ga *GenesisAlloc) flush(db ethdb.Database, cfg *params.ChainConfig) error {
 	trieCfg := &trie.Config{Preimages: true}
 	triedb := state.NewDatabaseWithConfig(db, trieCfg)
-	if cfg.IsCancun(big.NewInt(int64(0))) {
+	// TODO same here, see deriveHash
+	if cfg != nil && cfg.IsCancun(big.NewInt(int64(0))) {
 		triedb.EndVerkleTransition()
 	}
 	statedb, err := state.New(common.Hash{}, triedb, nil)

--- a/core/state/access_witness.go
+++ b/core/state/access_witness.go
@@ -251,7 +251,7 @@ func (aw *AccessWitness) Copy() *AccessWitness {
 }
 
 func (aw *AccessWitness) GetTreeKeyVersionCached(addr []byte) []byte {
-	return aw.statedb.db.(*VerkleDB).addrToPoint.GetTreeKeyVersionCached(addr)
+	return aw.statedb.db.(*cachingDB).addrToPoint.GetTreeKeyVersionCached(addr)
 }
 
 func (aw *AccessWitness) TouchAndChargeProofOfAbsence(addr []byte) uint64 {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -514,7 +514,7 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 			groupOffset := (chunknr + 128) % 256
 			if groupOffset == 0 /* start of new group */ || chunknr == 0 /* first chunk in header group */ {
 				values = make([][]byte, verkle.NodeWidth)
-				key = utils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.db.db.(*VerkleDB).GetTreeKeyHeader(obj.address[:]), uint256.NewInt(chunknr))
+				key = utils.GetTreeKeyCodeChunkWithEvaluatedAddress(obj.db.db.(*cachingDB).GetTreeKeyHeader(obj.address[:]), uint256.NewInt(chunknr))
 			}
 			values[groupOffset] = chunks[i : i+32]
 

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/trie"
 )
 
 // Tests that updating a state trie does not leak any database writes prior to
@@ -964,7 +963,7 @@ func TestFlushOrderDataLoss(t *testing.T) {
 func TestCodeChunkOverflow(t *testing.T) {
 	// Create an empty state database
 	db := rawdb.NewMemoryDatabase()
-	state, _ := New(common.Hash{}, NewDatabaseWithConfig(db, &trie.Config{UseVerkle: true}), nil)
+	state, _ := New(common.Hash{}, NewDatabaseWithConfig(db, nil), nil)
 
 	// Update it with some accounts
 	addr := common.BytesToAddress([]byte{1})

--- a/light/trie.go
+++ b/light/trie.go
@@ -99,6 +99,10 @@ func (db *odrDatabase) DiskDB() ethdb.KeyValueStore {
 	panic("not implemented")
 }
 
+func (db *odrDatabase) EndVerkleTransition() {
+	panic("not implemented")
+}
+
 type odrTrie struct {
 	db   *odrDatabase
 	id   *TrieID

--- a/trie/database.go
+++ b/trie/database.go
@@ -268,7 +268,6 @@ type Config struct {
 	Cache     int    // Memory allowance (MB) to use for caching trie nodes in memory
 	Journal   string // Journal of clean cache to survive node restarts
 	Preimages bool   // Flag whether the preimage of trie key is recorded
-	UseVerkle bool   // Flag whether the data is stored in a verkle trie
 }
 
 // NewDatabase creates a new trie database to store ephemeral trie content before


### PR DESCRIPTION
This is a preparation for the rebase on top of master: instead of using a custom `VerkleDB`, implement the equivalent of `ForkDB` from the overlay method, and call the `EndVerkleTransition()` method in order to switch to verkle mode. In particular, calling it at genesis time will make for a fully verkle network.