### PR TITLE
implement OpenStorageTrie for verkle trees

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -45,7 +45,7 @@ type Database interface {
 	OpenTrie(root common.Hash) (Trie, error)
 
 	// OpenStorageTrie opens the storage trie of an account.
-	OpenStorageTrie(stateRoot common.Hash, addrHash, root common.Hash) (Trie, error)
+	OpenStorageTrie(stateRoot common.Hash, addrHash, root common.Hash, main Trie) (Trie, error)
 
 	// CopyTrie returns an independent copy of the given trie.
 	CopyTrie(Trie) Trie
@@ -190,9 +190,9 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 }
 
 // OpenStorageTrie opens the storage trie of an account.
-func (db *cachingDB) OpenStorageTrie(stateRoot common.Hash, addrHash, root common.Hash) (Trie, error) {
+func (db *cachingDB) OpenStorageTrie(stateRoot common.Hash, addrHash, root common.Hash, self Trie) (Trie, error) {
 	if db.ended {
-		panic("not yet implemented")
+		return self, nil
 	}
 	tr, err := trie.NewStateTrie(trie.StorageTrieID(stateRoot, addrHash, root), db.db)
 	if err != nil {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -192,6 +192,8 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 // OpenStorageTrie opens the storage trie of an account.
 func (db *cachingDB) OpenStorageTrie(stateRoot common.Hash, addrHash, root common.Hash, self Trie) (Trie, error) {
 	if db.ended {
+		// TODO return an adapter object to detect whether this is a storage trie. Or just a regular
+		// VerkleTrie after adding a "storage" flag to the VerkleTrie.
 		return self, nil
 	}
 	tr, err := trie.NewStateTrie(trie.StorageTrieID(stateRoot, addrHash, root), db.db)

--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -118,7 +118,7 @@ func (it *NodeIterator) step() error {
 	if err := rlp.Decode(bytes.NewReader(it.stateIt.LeafBlob()), &account); err != nil {
 		return err
 	}
-	dataTrie, err := it.state.db.OpenStorageTrie(it.state.originalRoot, common.BytesToHash(it.stateIt.LeafKey()), account.Root)
+	dataTrie, err := it.state.db.OpenStorageTrie(it.state.originalRoot, common.BytesToHash(it.stateIt.LeafKey()), account.Root, nil)
 	if err != nil {
 		return err
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -374,7 +374,7 @@ func (s *stateObject) updateTrie(db Database) Trie {
 	if len(s.pendingStorage) > 0 {
 		s.pendingStorage = make(Storage)
 	}
-	return tr // XXX voir si je dois renvoyer s.trie
+	return tr
 }
 
 // UpdateRoot sets the trie root to the current root hash of

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -160,9 +160,9 @@ func (s *stateObject) getTrie(db Database) Trie {
 		}
 		if s.trie == nil {
 			var err error
-			s.trie, err = db.OpenStorageTrie(s.db.originalRoot, s.addrHash, s.data.Root)
+			s.trie, err = db.OpenStorageTrie(s.db.originalRoot, s.addrHash, s.data.Root, s.db.trie)
 			if err != nil {
-				s.trie, _ = db.OpenStorageTrie(s.db.originalRoot, s.addrHash, common.Hash{})
+				s.trie, _ = db.OpenStorageTrie(s.db.originalRoot, s.addrHash, common.Hash{}, s.db.trie)
 				s.setError(fmt.Errorf("can't create storage trie: %v", err))
 			}
 		}
@@ -223,18 +223,14 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	// If the snapshot is unavailable or reading from it fails, load from the database.
 	if s.db.snap == nil || err != nil {
 		var tr Trie
-		if s.db.GetTrie().IsVerkle() {
-			tr = s.db.GetTrie()
-		} else {
-			tr = s.getTrie(db)
-		}
+		tr = s.getTrie(db)
 		start := time.Now()
 		if s.db.GetTrie().IsVerkle() {
 			var v []byte
 			v, err = tr.TryGet(s.address[:], key.Bytes())
 			copy(value[:], v)
 		} else {
-			enc, err = s.getTrie(db).TryGet(s.address[:], key.Bytes())
+			enc, err = tr.TryGet(s.address[:], key.Bytes())
 		}
 		if metrics.EnabledExpensive {
 			s.db.StorageReads += time.Since(start)
@@ -332,12 +328,8 @@ func (s *stateObject) updateTrie(db Database) Trie {
 	// The snapshot storage map for the object
 	var storage map[common.Hash][]byte
 	// Insert all the pending updates into the trie
-	var tr Trie
-	if s.db.trie.IsVerkle() {
-		tr = s.db.trie
-	} else {
-		tr = s.getTrie(db)
-	}
+	tr := s.getTrie(db)
+
 	hasher := s.db.hasher
 
 	usedStorage := make([][]byte, 0, len(s.pendingStorage))
@@ -382,7 +374,7 @@ func (s *stateObject) updateTrie(db Database) Trie {
 	if len(s.pendingStorage) > 0 {
 		s.pendingStorage = make(Storage)
 	}
-	return tr
+	return tr // XXX voir si je dois renvoyer s.trie
 }
 
 // UpdateRoot sets the trie root to the current root hash of

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -222,8 +222,7 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	}
 	// If the snapshot is unavailable or reading from it fails, load from the database.
 	if s.db.snap == nil || err != nil {
-		var tr Trie
-		tr = s.getTrie(db)
+		tr := s.getTrie(db)
 		start := time.Now()
 		if s.db.GetTrie().IsVerkle() {
 			var v []byte

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -300,7 +300,7 @@ func (sf *subfetcher) loop() {
 		}
 		sf.trie = trie
 	} else {
-		trie, err := sf.db.OpenStorageTrie(sf.state, sf.owner, sf.root)
+		trie, err := sf.db.OpenStorageTrie(sf.state, sf.owner, sf.root, nil /* safe to set to nil for now, as there is no prefetcher for verkle */)
 		if err != nil {
 			log.Warn("Trie prefetcher failed opening trie", "root", sf.root, "err", err)
 			return

--- a/les/server_requests.go
+++ b/les/server_requests.go
@@ -428,7 +428,7 @@ func handleGetProofs(msg Decoder) (serveRequestFn, uint64, uint64, error) {
 					p.bumpInvalid()
 					continue
 				}
-				trie, err = statedb.OpenStorageTrie(root, common.BytesToHash(request.AccKey), account.Root)
+				trie, err = statedb.OpenStorageTrie(root, common.BytesToHash(request.AccKey), account.Root, nil)
 				if trie == nil || err != nil {
 					p.Log().Warn("Failed to open storage trie for proof", "block", header.Number, "hash", header.Hash(), "account", common.BytesToHash(request.AccKey), "root", account.Root, "err", err)
 					continue

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -87,7 +87,7 @@ func (odr *testOdr) Retrieve(ctx context.Context, req OdrRequest) error {
 			t   state.Trie
 		)
 		if len(req.Id.AccKey) > 0 {
-			t, err = odr.serverState.OpenStorageTrie(req.Id.StateRoot, common.BytesToHash(req.Id.AccKey), req.Id.Root)
+			t, err = odr.serverState.OpenStorageTrie(req.Id.StateRoot, common.BytesToHash(req.Id.AccKey), req.Id.Root, nil)
 		} else {
 			t, err = odr.serverState.OpenTrie(req.Id.Root)
 		}

--- a/light/trie.go
+++ b/light/trie.go
@@ -54,7 +54,7 @@ func (db *odrDatabase) OpenTrie(root common.Hash) (state.Trie, error) {
 	return &odrTrie{db: db, id: db.id}, nil
 }
 
-func (db *odrDatabase) OpenStorageTrie(state, addrHash, root common.Hash) (state.Trie, error) {
+func (db *odrDatabase) OpenStorageTrie(state, addrHash, root common.Hash, _ state.Trie) (state.Trie, error) {
 	return &odrTrie{db: db, id: StorageTrieID(db.id, addrHash, root)}, nil
 }
 

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -238,7 +238,7 @@ func (trie *VerkleTrie) Commit(_ bool) (common.Hash, *NodeSet, error) {
 		}
 	}
 
-	return nodes[0].CommitmentBytes, NewNodeSet(common.Hash{}), nil
+	return nodes[0].CommitmentBytes, nil, nil
 }
 
 // NodeIterator returns an iterator that returns nodes of the trie. Iteration

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -238,7 +238,7 @@ func (trie *VerkleTrie) Commit(_ bool) (common.Hash, *NodeSet, error) {
 		}
 	}
 
-	return nodes[0].CommitmentBytes, nil, nil
+	return nodes[0].CommitmentBytes, nil /* XXX this fixes the multiple 0-owner issue, but something more significant should be returned */, nil
 }
 
 // NodeIterator returns an iterator that returns nodes of the trie. Iteration


### PR DESCRIPTION
Implement `OpenStorageTrie` to return the main tree, so that there is less of a need to check for the trie type in `statedb.go` & `state_object.go`.

**NOTE** this will kill performance because the trie root will be calculated each time that a storage trie's `Commit` method will be called. A fix for this consists in adding an adapter pattern to hold that `Commit` should be a no-op. This PR shoots for correctness, not performance.