### PR TITLE
fix: copy balance leaf to new buffer in TryGetAccount

### DIFF
--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -104,10 +104,10 @@ func (t *VerkleTrie) TryGetAccount(key []byte) (*types.StateAccount, error) {
 	if len(values[utils.NonceLeafKey]) > 0 {
 		acc.Nonce = binary.LittleEndian.Uint64(values[utils.NonceLeafKey])
 	}
-	balance := values[utils.BalanceLeafKey]
-	if len(balance) > 0 {
-		for i := 0; i < len(balance)/2; i++ {
-			balance[len(balance)-i-1], balance[i] = balance[i], balance[len(balance)-i-1]
+	var balance [32]byte
+	if len(values[utils.BalanceLeafKey]) > 0 {
+		for i := 0; i < len(balance); i++ {
+			balance[len(balance)-i-1] = values[utils.BalanceLeafKey][i]
 		}
 	}
 	acc.Balance = new(big.Int).SetBytes(balance[:])


### PR DESCRIPTION
This is an error that popped up while attempting to remove the snapshot in tests: the buffer containing the data corresponding to an account's balance is endian-swapped and before  being copied to a `big.Int`. This means the value in the trie is endian-swapped, and then saved as such when it's serialized. This will cause some commitment computation errors (on top of being the incorrect data).