### PR TITLE
fix snapshot handling ahead of shapella rebase

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -156,19 +156,6 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 	}
 	if tr.IsVerkle() {
 		sdb.witness = NewAccessWitness(sdb)
-		if sdb.snaps == nil {
-			snapconfig := snapshot.Config{
-				CacheSize:  256,
-				Recovery:   false,
-				NoBuild:    false,
-				AsyncBuild: false,
-				Verkle:     true,
-			}
-			sdb.snaps, err = snapshot.New(snapconfig, db.DiskDB(), db.TrieDB(), root)
-			if err != nil {
-				return nil, err
-			}
-		}
 	}
 	if sdb.snaps != nil {
 		if sdb.snap = sdb.snaps.Snapshot(root); sdb.snap != nil {

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -104,10 +104,10 @@ func (t *VerkleTrie) TryGetAccount(key []byte) (*types.StateAccount, error) {
 	if len(values[utils.NonceLeafKey]) > 0 {
 		acc.Nonce = binary.LittleEndian.Uint64(values[utils.NonceLeafKey])
 	}
-	balance := values[utils.BalanceLeafKey]
-	if len(balance) > 0 {
-		for i := 0; i < len(balance)/2; i++ {
-			balance[len(balance)-i-1], balance[i] = balance[i], balance[len(balance)-i-1]
+	var balance [32]byte
+	if len(values[utils.BalanceLeafKey]) > 0 {
+		for i := 0; i < len(balance); i++ {
+			balance[len(balance)-i-1] = values[utils.BalanceLeafKey][i]
 		}
 	}
 	acc.Balance = new(big.Int).SetBytes(balance[:])


### PR DESCRIPTION
rationale: rebasing the verkle branch on top of shapella introduces some issues because so far the presence of the snapshot was always required, which is much harder to activate in more recent revisions of the code. While I could still hack my way to get it working, the best approach is to make sure that the genesis can be generated without a snapshot, which is the way things should be done for the verkle code to be merged.