### PR TITLE
handle the end of the verkle transition through triedb init

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -268,7 +268,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 }
 
 func MakePreState(db ethdb.Database, accounts core.GenesisAlloc) *state.StateDB {
-	sdb := state.NewDatabaseWithConfig(db, &trie.Config{Preimages: true})
+	sdb := state.NewDatabaseWithConfig(db, &trie.Config{Preimages: true}, false)
 	statedb, _ := state.New(common.Hash{}, sdb, nil)
 	for addr, a := range accounts {
 		statedb.SetCode(addr, a.Code)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -303,10 +303,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		Cache:     cacheConfig.TrieCleanLimit,
 		Journal:   cacheConfig.TrieCleanJournal,
 		Preimages: cacheConfig.Preimages,
-	})
-	if bc.chainConfig.IsCancun(head.Header().Number) {
-		bc.stateCache.EndVerkleTransition()
-	}
+	}, chainConfig.IsCancun(head.Header().Number))
 
 	if _, err := state.New(head.Root(), bc.stateCache, bc.snaps); err != nil {
 		// Head state is missing, before the state recovery, find out the

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -385,8 +385,7 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 	}
 	var snaps *snapshot.Tree
 	for i := 0; i < n; i++ {
-		triedb := state.NewDatabaseWithConfig(db, nil)
-		triedb.EndVerkleTransition()
+		triedb := state.NewDatabaseWithConfig(db, nil, true)
 		statedb, err := state.New(parent.Root(), triedb, snaps)
 		if err != nil {
 			panic(fmt.Sprintf("could not find state for block %d: err=%v, parent root=%x", i, err, parent.Root()))

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -120,11 +120,8 @@ func (ga *GenesisAlloc) deriveHash(cfg *params.ChainConfig) (common.Hash, error)
 	var trieCfg *trie.Config
 	// Create an ephemeral in-memory database for computing hash,
 	// all the derived states will be discarded to not pollute disk.
-	db := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), trieCfg)
+	db := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), trieCfg, cfg.IsCancun(big.NewInt(int64(0))))
 	// TODO remove the nil config check once we have rebased, it should never be nil
-	if cfg != nil && cfg.IsCancun(big.NewInt(int64(0))) {
-		db.EndVerkleTransition()
-	}
 	statedb, err := state.New(common.Hash{}, db, nil)
 	if err != nil {
 		return common.Hash{}, err
@@ -145,11 +142,7 @@ func (ga *GenesisAlloc) deriveHash(cfg *params.ChainConfig) (common.Hash, error)
 // Also, the genesis state specification will be flushed as well.
 func (ga *GenesisAlloc) flush(db ethdb.Database, cfg *params.ChainConfig) error {
 	trieCfg := &trie.Config{Preimages: true}
-	triedb := state.NewDatabaseWithConfig(db, trieCfg)
-	// TODO same here, see deriveHash
-	if cfg != nil && cfg.IsCancun(big.NewInt(int64(0))) {
-		triedb.EndVerkleTransition()
-	}
+	triedb := state.NewDatabaseWithConfig(db, trieCfg, cfg.IsCancun(big.NewInt(int64(0))))
 	statedb, err := state.New(common.Hash{}, triedb, nil)
 	if err != nil {
 		return err
@@ -343,7 +336,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 		}
 	}
 
-	triedb := state.NewDatabaseWithConfig(db, trieCfg)
+	triedb := state.NewDatabaseWithConfig(db, trieCfg, genesis.Config.IsCancun(big.NewInt(0)))
 	if genesis != nil && genesis.Config != nil && genesis.Config.IsCancun(big.NewInt(0)) {
 		triedb.EndVerkleTransition()
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -120,7 +120,8 @@ func (ga *GenesisAlloc) deriveHash(cfg *params.ChainConfig) (common.Hash, error)
 	var trieCfg *trie.Config
 	// Create an ephemeral in-memory database for computing hash,
 	// all the derived states will be discarded to not pollute disk.
-	db := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), trieCfg, cfg.IsCancun(big.NewInt(int64(0))))
+	convertedToVerkle := cfg != nil && cfg.IsCancun(big.NewInt(int64(0)))
+	db := state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), trieCfg, convertedToVerkle)
 	// TODO remove the nil config check once we have rebased, it should never be nil
 	statedb, err := state.New(common.Hash{}, db, nil)
 	if err != nil {
@@ -142,7 +143,8 @@ func (ga *GenesisAlloc) deriveHash(cfg *params.ChainConfig) (common.Hash, error)
 // Also, the genesis state specification will be flushed as well.
 func (ga *GenesisAlloc) flush(db ethdb.Database, cfg *params.ChainConfig) error {
 	trieCfg := &trie.Config{Preimages: true}
-	triedb := state.NewDatabaseWithConfig(db, trieCfg, cfg.IsCancun(big.NewInt(int64(0))))
+	convertedToVerkle := cfg != nil && cfg.IsCancun(big.NewInt(int64(0)))
+	triedb := state.NewDatabaseWithConfig(db, trieCfg, convertedToVerkle)
 	statedb, err := state.New(common.Hash{}, triedb, nil)
 	if err != nil {
 		return err
@@ -336,7 +338,8 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 		}
 	}
 
-	triedb := state.NewDatabaseWithConfig(db, trieCfg, genesis.Config.IsCancun(big.NewInt(0)))
+	convertedToVerkle := genesis != nil && genesis.Config != nil && genesis.Config.IsCancun(big.NewInt(0))
+	triedb := state.NewDatabaseWithConfig(db, trieCfg, convertedToVerkle)
 	if genesis != nil && genesis.Config != nil && genesis.Config.IsCancun(big.NewInt(0)) {
 		triedb.EndVerkleTransition()
 	}

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -41,7 +41,7 @@ func newStateTest() *stateTest {
 
 func TestDump(t *testing.T) {
 	db := rawdb.NewMemoryDatabase()
-	sdb, _ := New(common.Hash{}, NewDatabaseWithConfig(db, &trie.Config{Preimages: true}), nil)
+	sdb, _ := New(common.Hash{}, NewDatabaseWithConfig(db, &trie.Config{Preimages: true}, false), nil)
 	s := &stateTest{db: db, state: sdb}
 
 	// generate a few entries

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -963,7 +963,7 @@ func TestFlushOrderDataLoss(t *testing.T) {
 func TestCodeChunkOverflow(t *testing.T) {
 	// Create an empty state database
 	db := rawdb.NewMemoryDatabase()
-	state, _ := New(common.Hash{}, NewDatabaseWithConfig(db, nil), nil)
+	state, _ := New(common.Hash{}, NewDatabaseWithConfig(db, nil, true), nil)
 
 	// Update it with some accounts
 	addr := common.BytesToAddress([]byte{1})

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -67,7 +67,7 @@ func TestAccountRange(t *testing.T) {
 	t.Parallel()
 
 	var (
-		statedb  = state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &trie.Config{Preimages: true})
+		statedb  = state.NewDatabaseWithConfig(rawdb.NewMemoryDatabase(), &trie.Config{Preimages: true}, false)
 		state, _ = state.New(common.Hash{}, statedb, nil)
 		addrs    = [AccountRangeMaxResults * 2]common.Address{}
 		m        = map[common.Address]bool{}

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -83,7 +83,7 @@ func (eth *Ethereum) StateAtBlock(block *types.Block, reexec uint64, base *state
 		if preferDisk {
 			// Create an ephemeral trie.Database for isolating the live one. Otherwise
 			// the internal junks created by tracing will be persisted into the disk.
-			database = state.NewDatabaseWithConfig(eth.chainDb, &trie.Config{Cache: 16})
+			database = state.NewDatabaseWithConfig(eth.chainDb, &trie.Config{Cache: 16}, base.GetTrie().IsVerkle())
 			if statedb, err = state.New(block.Root(), database, nil); err == nil {
 				log.Info("Found disk backend for state trie", "root", block.Root(), "number", block.Number())
 				return statedb, noopReleaser, nil
@@ -98,7 +98,7 @@ func (eth *Ethereum) StateAtBlock(block *types.Block, reexec uint64, base *state
 
 		// Create an ephemeral trie.Database for isolating the live one. Otherwise
 		// the internal junks created by tracing will be persisted into the disk.
-		database = state.NewDatabaseWithConfig(eth.chainDb, &trie.Config{Cache: 16})
+		database = state.NewDatabaseWithConfig(eth.chainDb, &trie.Config{Cache: 16}, eth.BlockChain().Config().IsCancun(current.Number()))
 
 		// If we didn't check the live database, do check state over ephemeral database,
 		// otherwise we would rewind past a persisted block (specific corner case is


### PR DESCRIPTION
In order to simplify the commit diff, the call to `EndVerkleTransition` is moved from being dispersed all over the code base, to `NewDatabaseWithConfig`. There are several reasons for this:

 1. The tree opening is ultimately done in `OpenTrie`, so it makes sense to move the decision as to which type of tree that is, close to that function
 2. After the rebase, there will be another type of `NewDatabase(...)` function, and this function will follow the same model, if it makes sense to Gary