### PR TITLE
fix: use an error to notify the transition tree that a deleted account was found in the overlay tree

### DIFF
--- a/trie/transition.go
+++ b/trie/transition.go
@@ -88,6 +88,11 @@ func (t *TransitionTrie) TryGet(addr, key []byte) ([]byte, error) {
 func (t *TransitionTrie) TryGetAccount(key []byte) (*types.StateAccount, error) {
 	data, err := t.overlay.TryGetAccount(key)
 	if err != nil {
+		// WORKAROUND, see the definition of errDeletedAccount
+		// for an explainer of why this if is needed.
+		if err == errDeletedAccount {
+			return nil, nil
+		}
 		return nil, err
 	}
 	if data != nil {


### PR DESCRIPTION
A bug was found, that was caused by an account created in MPT mode, being selfdestructed in verkle mode: getting the account from the overlay tree would report a missing account, which meant that the transition tree would go and get the data from the MPT, in which the account was not selfdestructed.