### PR TITLE
core: resumable overlay transition runs

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1688,7 +1688,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 		}
 
 		if parent.Number.Uint64() == conversionBlock {
-			bc.StartVerkleTransition(parent.Root, emptyVerkleRoot)
+			if err := bc.StartVerkleTransition(parent.Root, emptyVerkleRoot); err != nil {
+				return it.index, fmt.Errorf("failed to start verkle transition: %s", err)
+			}
 		}
 		statedb, err := state.New(parent.Root, bc.stateCache, bc.snaps)
 		if err != nil {
@@ -2459,8 +2461,8 @@ func (bc *BlockChain) SetBlockValidatorAndProcessorForTesting(v Validator, p Pro
 	bc.processor = p
 }
 
-func (bc *BlockChain) StartVerkleTransition(originalRoot, translatedRoot common.Hash) {
-	bc.stateCache.(*state.ForkingDB).StartTransition(originalRoot, translatedRoot)
+func (bc *BlockChain) StartVerkleTransition(originalRoot, translatedRoot common.Hash) error {
+	return bc.stateCache.(*state.ForkingDB).StartTransition(originalRoot, translatedRoot)
 }
 
 func (bc *BlockChain) AddRootTranslation(originalRoot, translatedRoot common.Hash) {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -113,7 +113,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 			defer accIt.Release()
 			accIt.Next()
 
-			const maxMovedCount = 10_000
+			const maxMovedCount = 1_000
 			// mkv will be assiting in the collection of up to maxMovedCount key values to be migrated to the VKT.
 			// It has internal caches to do efficient MPT->VKT key calculations, which will be discarded after
 			// this function.

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -113,7 +113,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 			defer accIt.Release()
 			accIt.Next()
 
-			const maxMovedCount = 1000
+			const maxMovedCount = 10_000
 			// mkv will be assiting in the collection of up to maxMovedCount key values to be migrated to the VKT.
 			// It has internal caches to do efficient MPT->VKT key calculations, which will be discarded after
 			// this function.
@@ -209,7 +209,9 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 					} else {
 						// case when the account iterator has
 						// reached the end but count < maxCount
-						fdb.EndTransition()
+						if err := fdb.EndTransition(); err != nil {
+							return nil, nil, 0, fmt.Errorf("could not end transition: %s", err)
+						}
 						break
 					}
 				}


### PR DESCRIPTION
This PR saves to the db the start and end markers for the overlay transition. 
This is done to detect on a re-run if the overlay transition has finished. 

It can't still resume an in-progress (interrupted) transition. 