### PR TITLE
re-enable cancun block

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1688,7 +1688,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 		}
 
 		if parent.Number.Uint64() == conversionBlock {
-			bc.StartVerkleTransition(parent.Root, emptyVerkleRoot)
+			bc.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), parent.Number)
 		}
 		statedb, err := state.New(parent.Root, bc.stateCache, bc.snaps)
 		if err != nil {
@@ -2459,8 +2459,8 @@ func (bc *BlockChain) SetBlockValidatorAndProcessorForTesting(v Validator, p Pro
 	bc.processor = p
 }
 
-func (bc *BlockChain) StartVerkleTransition(originalRoot, translatedRoot common.Hash) {
-	bc.stateCache.(*state.ForkingDB).StartTransition(originalRoot, translatedRoot)
+func (bc *BlockChain) StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, cancunBlock *big.Int) {
+	bc.stateCache.(*state.ForkingDB).StartTransition(originalRoot, translatedRoot, chainConfig, cancunBlock)
 }
 
 func (bc *BlockChain) AddRootTranslation(originalRoot, translatedRoot common.Hash) {

--- a/core/state/access_witness.go
+++ b/core/state/access_witness.go
@@ -251,7 +251,7 @@ func (aw *AccessWitness) Copy() *AccessWitness {
 }
 
 func (aw *AccessWitness) GetTreeKeyVersionCached(addr []byte) []byte {
-	return aw.statedb.db.(*VerkleDB).addrToPoint.GetTreeKeyVersionCached(addr)
+	return aw.statedb.db.(*ForkingDB).addrToPoint.GetTreeKeyVersionCached(addr)
 }
 
 func (aw *AccessWitness) TouchAndChargeProofOfAbsence(addr []byte) uint64 {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -19,6 +19,7 @@ package state
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"sync"
 
 	"github.com/VictoriaMetrics/fastcache"
@@ -26,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/gballet/go-verkle"
@@ -283,7 +285,7 @@ func (fdg *ForkingDB) Transitionned() bool {
 }
 
 // Fork implements the fork
-func (fdb *ForkingDB) StartTransition(originalRoot, translatedRoot common.Hash) {
+func (fdb *ForkingDB) StartTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, cancunBlock *big.Int) {
 	fmt.Println(`
 	__________.__                       .__                .__                   __       .__                               .__          ____         
 	\__    ___|  |__   ____        ____ |  |   ____ ______ |  |__ _____    _____/  |_     |  |__ _____    ______    __  _  _|__| ____   / ___\ ______
@@ -296,6 +298,7 @@ func (fdb *ForkingDB) StartTransition(originalRoot, translatedRoot common.Hash) 
 	fdb.baseRoot = originalRoot
 	// initialize so that the first storage-less accounts are processed
 	fdb.StorageProcessed = true
+	chainConfig.CancunBlock = cancunBlock
 }
 
 func (fdb *ForkingDB) EndTransition() {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -159,11 +159,11 @@ const (
 	RefundQuotientEIP3529 uint64 = 5
 
 	// Verkle tree EIP: costs associated to witness accesses
-	WitnessBranchReadCost  = uint64(1900)
-	WitnessChunkReadCost   = uint64(200)
-	WitnessBranchWriteCost = uint64(3000)
-	WitnessChunkWriteCost  = uint64(500)
-	WitnessChunkFillCost   = uint64(6200)
+	WitnessBranchReadCost  = uint64(0)
+	WitnessChunkReadCost   = uint64(0)
+	WitnessBranchWriteCost = uint64(0)
+	WitnessChunkWriteCost  = uint64(0)
+	WitnessChunkFillCost   = uint64(0)
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations


### PR DESCRIPTION
This PR forces the `CancunBlock` to be set when the verkle transition starts, and ensure that the translated root is used to find the snapshot.