### PR TITLE
trie/verkle: use capped batch size

### DIFF
--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -258,8 +258,11 @@ func (trie *VerkleTrie) Commit(_ bool) (common.Hash, *NodeSet, error) {
 	}
 
 	batch := trie.db.diskdb.NewBatch()
+	const keyPrefix = "flat-"
+	path := make([]byte, 0, len(keyPrefix)+32)
+	path = append(path, []byte(keyPrefix)...)
 	for _, node := range nodes {
-		path := append([]byte("flat-"), node.Path...)
+		path := append(path[:len(keyPrefix)], node.Path...)
 
 		if err := batch.Put(path, node.SerializedBytes); err != nil {
 			return common.Hash{}, nil, fmt.Errorf("put node to disk: %s", err)


### PR DESCRIPTION
This PR:
- Honors IdealBatchSize for DB batch inserts.
- Changes N allocations per numbers of nodes saved in the db per Commit, to only 1.