### PR TITLE
re-enable snapshot

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -175,6 +175,17 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 			sdb.snapDestructs = make(map[common.Hash]struct{})
 			sdb.snapAccounts = make(map[common.Hash][]byte)
 			sdb.snapStorage = make(map[common.Hash]map[common.Hash][]byte)
+		} else {
+			if fdb, ok := db.(*ForkingDB); ok {
+				trans := fdb.getTranslation(root)
+				if trans != (common.Hash{}) {
+					if sdb.snap = sdb.snaps.Snapshot(trans); sdb.snap != nil {
+						sdb.snapDestructs = make(map[common.Hash]struct{})
+						sdb.snapAccounts = make(map[common.Hash][]byte)
+						sdb.snapStorage = make(map[common.Hash]map[common.Hash][]byte)
+					}
+				}
+			}
 		}
 	}
 	return sdb, nil


### PR DESCRIPTION
Separate the snapshot-reactivation from #226 in order to attribute a potential performance gain to it (as activating Cancun will likely kill performance).