### PR TITLE
overlay-tree: allow resumable runs

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1688,7 +1688,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 		}
 
 		if parent.Number.Uint64() == conversionBlock {
-			bc.StartVerkleTransition(parent.Root, emptyVerkleRoot)
+			if err := bc.StartVerkleTransition(parent.Root, emptyVerkleRoot); err != nil {
+				return it.index, fmt.Errorf("failed to start verkle transition: %s", err)
+			}
 		}
 		statedb, err := state.New(parent.Root, bc.stateCache, bc.snaps)
 		if err != nil {
@@ -2459,8 +2461,8 @@ func (bc *BlockChain) SetBlockValidatorAndProcessorForTesting(v Validator, p Pro
 	bc.processor = p
 }
 
-func (bc *BlockChain) StartVerkleTransition(originalRoot, translatedRoot common.Hash) {
-	bc.stateCache.(*state.ForkingDB).StartTransition(originalRoot, translatedRoot)
+func (bc *BlockChain) StartVerkleTransition(originalRoot, translatedRoot common.Hash) error {
+	return bc.stateCache.(*state.ForkingDB).StartTransition(originalRoot, translatedRoot)
 }
 
 func (bc *BlockChain) AddRootTranslation(originalRoot, translatedRoot common.Hash) {


### PR DESCRIPTION
This PR attempts to collect all needed changes to allow to resume a run of an overlay tree chain importing:
- It saves `started` and `ended` markers.
- It saves the translation roots.

The goal is to allow:
- To stop and resume a run in the middle of the transaction to continue; that's convenient for us.
- To stop and resume after a full conversion to allow to iterate more rapidly on the context of a fully converted tree reg performance improvements.

There's a reasonable chance that something else might be missing or needs to be fixed in this branch, since I've confirmed that as is it doesn't fully work reading the right snapshot on the second run.

Note that this PR is targeting `reenable-snapshots` as expected.
