### PR TITLE
return compressed commitment as root commitment

### DIFF
--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -276,8 +276,6 @@ func (trie *VerkleTrie) Commit(_ bool) (common.Hash, *NodeSet, error) {
 	batch.Write()
 
 	// Serialize root commitment in compressed form, and only the root commitment
-	// TODO figure out if Hash() is the correct function to call, or if PointToHash() should
-	// be called instead.
 	rootH := root.Hash().BytesLE()
 	return common.BytesToHash(rootH[:]), nil, nil
 }

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -276,6 +276,8 @@ func (trie *VerkleTrie) Commit(_ bool) (common.Hash, *NodeSet, error) {
 	batch.Write()
 
 	// Serialize root commitment in compressed form, and only the root commitment
+	// TODO figure out if Hash() is the correct function to call, or if PointToHash() should
+	// be called instead.
 	rootH := root.Hash().BytesLE()
 	return common.BytesToHash(rootH[:]), nil, nil
 }

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -275,7 +275,7 @@ func (trie *VerkleTrie) Commit(_ bool) (common.Hash, *NodeSet, error) {
 	}
 	batch.Write()
 
-	// Serialize root commitment in compressed form, and only the root commitment
+	// Serialize root commitment form
 	rootH := root.Hash().BytesLE()
 	return common.BytesToHash(rootH[:]), nil, nil
 }

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -275,7 +275,9 @@ func (trie *VerkleTrie) Commit(_ bool) (common.Hash, *NodeSet, error) {
 	}
 	batch.Write()
 
-	return common.BytesToHash(nodes[0].CommitmentBytes[:32]), nil, nil
+	// Serialize root commitment in compressed form, and only the root commitment
+	rootH := root.Hash().BytesLE()
+	return common.BytesToHash(rootH[:]), nil, nil
 }
 
 // NodeIterator returns an iterator that returns nodes of the trie. Iteration


### PR DESCRIPTION
This is the last missing piece before pbss/replay-fixes can be merged into the pbss PR, so that everything can be collapsed into a PR that is ready for rebase.