### PR TITLE
fixes to get TestProcessVerkle to work with the overlay branch

### DIFF
--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -430,6 +430,7 @@ func TestProcessVerkle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Log("verfied verkle proof")
 
 	_, err = blockchain.InsertChain(chain)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20230711114830-89d284b3f456
+	github.com/gballet/go-verkle v0.0.0-20230725193842-b2d852dc666b
 	github.com/go-stack/stack v1.8.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/golang/protobuf v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.0.0-20230710192927-5605a48fc20b
+	github.com/gballet/go-verkle v0.0.0-20230711114830-89d284b3f456
 	github.com/go-stack/stack v1.8.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,10 @@ github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqG
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/gballet/go-verkle v0.0.0-20230711114830-89d284b3f456 h1:ZZd48ay16TgKE1sl6pxrBCoygvsuvUc+7EU8UNZ3DJM=
 github.com/gballet/go-verkle v0.0.0-20230711114830-89d284b3f456/go.mod h1:+k9fzNguudDonU5q4/TUaTdmiHw3h3oGOIVmqyhaA3E=
+github.com/gballet/go-verkle v0.0.0-20230711131047-e8712ad59b6a h1:L+mkoO+l8Wo26XUJ+fL8t9J02SyyaDHp52djuEOmu1A=
+github.com/gballet/go-verkle v0.0.0-20230711131047-e8712ad59b6a/go.mod h1:+k9fzNguudDonU5q4/TUaTdmiHw3h3oGOIVmqyhaA3E=
+github.com/gballet/go-verkle v0.0.0-20230725193842-b2d852dc666b h1:2lDzSxjCii8FxrbuxtlFtFiw6c4nTPl9mhaZ6lgpwws=
+github.com/gballet/go-verkle v0.0.0-20230725193842-b2d852dc666b/go.mod h1:+k9fzNguudDonU5q4/TUaTdmiHw3h3oGOIVmqyhaA3E=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 h1:IZqZOB2fydHte3kUgx
 github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
-github.com/gballet/go-verkle v0.0.0-20230710192927-5605a48fc20b h1:JuUGDV6uWSMaSobZreNGPqk9WOObqD17/cQ/0WMZquw=
-github.com/gballet/go-verkle v0.0.0-20230710192927-5605a48fc20b/go.mod h1:+k9fzNguudDonU5q4/TUaTdmiHw3h3oGOIVmqyhaA3E=
+github.com/gballet/go-verkle v0.0.0-20230711114830-89d284b3f456 h1:ZZd48ay16TgKE1sl6pxrBCoygvsuvUc+7EU8UNZ3DJM=
+github.com/gballet/go-verkle v0.0.0-20230711114830-89d284b3f456/go.mod h1:+k9fzNguudDonU5q4/TUaTdmiHw3h3oGOIVmqyhaA3E=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/trie/transition.go
+++ b/trie/transition.go
@@ -192,7 +192,7 @@ func (t *TransitionTrie) TryUpdateStem(key []byte, values [][]byte) error {
 
 func (t *TransitionTrie) Copy() *TransitionTrie {
 	return &TransitionTrie{
-		overlay: t.overlay.Copy(t.overlay.db),
+		overlay: t.overlay.Copy(),
 		base:    t.base.Copy(),
 		storage: t.storage,
 	}

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -297,10 +297,10 @@ func (trie *VerkleTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValue
 	panic("not implemented")
 }
 
-func (trie *VerkleTrie) Copy(db *Database) *VerkleTrie {
+func (trie *VerkleTrie) Copy() *VerkleTrie {
 	return &VerkleTrie{
 		root: trie.root.Copy(),
-		db:   db,
+		db:   trie.db,
 	}
 }
 

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -309,10 +309,7 @@ func (trie *VerkleTrie) IsVerkle() bool {
 }
 
 func (trie *VerkleTrie) ProveAndSerialize(keys [][]byte, kv map[string][]byte) (*verkle.VerkleProof, verkle.StateDiff, error) {
-	resolver := func(path []byte) ([]byte, error) {
-		return trie.db.diskdb.Get(append([]byte("flat-"), path...))
-	}
-	proof, _, _, _, err := verkle.MakeVerkleMultiProof(trie.root, keys, resolver)
+	proof, _, _, _, err := verkle.MakeVerkleMultiProof(trie.root, keys)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -390,7 +387,7 @@ func deserializeVerkleProof(vp *verkle.VerkleProof, rootC *verkle.Point, statedi
 
 	// no need to resolve as the tree has been reconstructed from the proof
 	// and must not contain any unresolved nodes.
-	pe, _, _, err := tree.GetProofItems(proof.Keys, nil)
+	pe, _, _, err := tree.GetProofItems(proof.Keys)
 
 	return proof, pe.Cis, pe.Zis, pe.Yis, err
 }


### PR DESCRIPTION
Fixes a series of errors that got introduced with the overlay method, and who broke the verkle state processor test.

The basic problem is that the new type of tree, `TransitionTrie` wasn't supported by these tests, as a `VerkleTrie` was directly created for networks starting with a verkle genesis, and the overlay code assumes that there is always a transition period. The final fix will be to set the transition period as having ended at the genesis, for networks with verkle at genesis.

The dependency on the db in `(*VerkleTrie).CopyTrie` has also been removed for simplification.

There has been further simplifications in the base branch, and `ForkingDB` can be removed now that `TransitionTrie` does all the conversion job. This is not the purpose of that PR, though.