### PR TITLE
print state root every 100 blocks

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -232,6 +232,11 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.engine.Finalize(p.bc, header, statedb, block.Transactions(), block.Uncles())
 
+	if block.NumberU64()%100 == 0 {
+		stateRoot := statedb.GetTrie().Hash()
+		log.Info("State root", "number", block.NumberU64(), "hash", stateRoot)
+	}
+
 	return receipts, allLogs, *usedGas, nil
 }
 


### PR DESCRIPTION
This PR adds a log line to print the current state tree root hash every 100 blocks.

Example screenshot:
![image](https://github.com/gballet/go-ethereum/assets/6136245/1fd920f2-64db-4796-8d11-21021e024d80)

(I haven't seen how verbose this frequency is for after-migration, but for the throughput we've seen lately, I think it should be fine. Also, at some point in the future this log line will be removed)