### PR TITLE
Overlay Tree preimages exporting and usage

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -145,6 +145,17 @@ The export-preimages command exports hash preimages to an RLP encoded stream.
 It's deprecated, please use "geth db export" instead.
 `,
 	}
+	exportOverlayPreimagesCommand = &cli.Command{
+		Action:    exportOverlayPreimages,
+		Name:      "export-overlay-preimages",
+		Usage:     "Export the preimage in overlay tree migration order",
+		ArgsUsage: "<dumpfile>",
+		Flags:     flags.Merge([]cli.Flag{}, utils.DatabasePathFlags),
+		Description: `
+The export-overlay-preimages command exports hash preimages to a flat file, in exactly
+the expected order for the overlay tree migration.
+`,
+	}
 	dumpCommand = &cli.Command{
 		Action:    dump,
 		Name:      "dump",
@@ -388,6 +399,24 @@ func exportPreimages(ctx *cli.Context) error {
 	start := time.Now()
 
 	if err := utils.ExportPreimages(db, ctx.Args().First()); err != nil {
+		utils.Fatalf("Export error: %v\n", err)
+	}
+	fmt.Printf("Export done in %v\n", time.Since(start))
+	return nil
+}
+
+// exportOverlayPreimages dumps the preimage data to a flat file.
+func exportOverlayPreimages(ctx *cli.Context) error {
+	if ctx.Args().Len() < 1 {
+		utils.Fatalf("This command requires an argument.")
+	}
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	chain, _ := utils.MakeChain(ctx, stack)
+
+	start := time.Now()
+	if err := utils.ExportOverlayPreimages(chain, ctx.Args().First()); err != nil {
 		utils.Fatalf("Export error: %v\n", err)
 	}
 	fmt.Printf("Export done in %v\n", time.Since(start))

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -150,7 +150,7 @@ It's deprecated, please use "geth db export" instead.
 		Name:      "export-overlay-preimages",
 		Usage:     "Export the preimage in overlay tree migration order",
 		ArgsUsage: "<dumpfile>",
-		Flags:     flags.Merge([]cli.Flag{}, utils.DatabasePathFlags),
+		Flags:     flags.Merge([]cli.Flag{utils.TreeRootFlag}, utils.DatabasePathFlags),
 		Description: `
 The export-overlay-preimages command exports hash preimages to a flat file, in exactly
 the expected order for the overlay tree migration.
@@ -415,8 +415,17 @@ func exportOverlayPreimages(ctx *cli.Context) error {
 
 	chain, _ := utils.MakeChain(ctx, stack)
 
+	var root common.Hash
+	if ctx.String(utils.TreeRootFlag.Name) != "" {
+		rootBytes := common.FromHex(ctx.String(utils.StartKeyFlag.Name))
+		if len(rootBytes) != common.HashLength {
+			return fmt.Errorf("invalid root hash length")
+		}
+		root = common.BytesToHash(rootBytes)
+	}
+
 	start := time.Now()
-	if err := utils.ExportOverlayPreimages(chain, ctx.Args().First()); err != nil {
+	if err := utils.ExportOverlayPreimages(chain, ctx.Args().First(), root); err != nil {
 		utils.Fatalf("Export error: %v\n", err)
 	}
 	fmt.Printf("Export done in %v\n", time.Since(start))

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -213,6 +213,7 @@ func init() {
 		exportCommand,
 		importPreimagesCommand,
 		exportPreimagesCommand,
+		exportOverlayPreimagesCommand,
 		removedbCommand,
 		dumpCommand,
 		dumpGenesisCommand,

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -386,7 +386,7 @@ func ExportPreimages(db ethdb.Database, fn string) error {
 
 // ExportOverlayPreimages exports all known hash preimages into the specified file,
 // in the same order as expected by the overlay tree migration.
-func ExportOverlayPreimages(chain *core.BlockChain, fn string) error {
+func ExportOverlayPreimages(chain *core.BlockChain, fn string, root common.Hash) error {
 	log.Info("Exporting preimages", "file", fn)
 
 	fh, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
@@ -403,9 +403,11 @@ func ExportOverlayPreimages(chain *core.BlockChain, fn string) error {
 		return fmt.Errorf("failed to open statedb: %w", err)
 	}
 
-	mptRoot := chain.CurrentBlock().Root()
+	if root == (common.Hash{}) {
+		root = chain.CurrentBlock().Root()
+	}
 
-	accIt, err := statedb.Snaps().AccountIterator(mptRoot, common.Hash{})
+	accIt, err := statedb.Snaps().AccountIterator(root, common.Hash{})
 	if err != nil {
 		return err
 	}
@@ -426,7 +428,7 @@ func ExportOverlayPreimages(chain *core.BlockChain, fn string) error {
 		}
 
 		if acc.HasStorage() {
-			stIt, err := statedb.Snaps().StorageIterator(mptRoot, accIt.Hash(), common.Hash{})
+			stIt, err := statedb.Snaps().StorageIterator(root, accIt.Hash(), common.Hash{})
 			if err != nil {
 				return fmt.Errorf("failed to create storage iterator: %w", err)
 			}

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -170,6 +170,10 @@ func ImportChain(chain *core.BlockChain, fn string) error {
 	}
 	defer fh.Close()
 
+	if _, err := fh.Seek(18224628422, 0); err != nil {
+		panic(err)
+	}
+
 	var reader io.Reader = fh
 	if strings.HasSuffix(fn, ".gz") {
 		if reader, err = gzip.NewReader(reader); err != nil {

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -170,10 +170,6 @@ func ImportChain(chain *core.BlockChain, fn string) error {
 	}
 	defer fh.Close()
 
-	if _, err := fh.Seek(18224628422, 0); err != nil {
-		panic(err)
-	}
-
 	var reader io.Reader = fh
 	if strings.HasSuffix(fn, ".gz") {
 		if reader, err = gzip.NewReader(reader); err != nil {

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
@@ -375,6 +376,73 @@ func ExportPreimages(db ethdb.Database, fn string) error {
 			return err
 		}
 	}
+	log.Info("Exported preimages", "file", fn)
+	return nil
+}
+
+// ExportOverlayPreimages exports all known hash preimages into the specified file,
+// in the same order as expected by the overlay tree migration.
+func ExportOverlayPreimages(chain *core.BlockChain, fn string) error {
+	log.Info("Exporting preimages", "file", fn)
+
+	fh, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	writer := bufio.NewWriter(fh)
+	defer writer.Flush()
+
+	statedb, err := chain.State()
+	if err != nil {
+		return fmt.Errorf("failed to open statedb: %w", err)
+	}
+
+	mptRoot := chain.CurrentBlock().Root()
+
+	accIt, err := statedb.Snaps().AccountIterator(mptRoot, common.Hash{})
+	if err != nil {
+		return err
+	}
+	defer accIt.Release()
+
+	count := 0
+	for accIt.Next() {
+		acc, err := snapshot.FullAccount(accIt.Account())
+		if err != nil {
+			return fmt.Errorf("invalid account encountered during traversal: %s", err)
+		}
+		addr := rawdb.ReadPreimage(statedb.Database().DiskDB(), accIt.Hash())
+		if len(addr) != 20 {
+			return fmt.Errorf("addr len is zero is not 32: %d", len(addr))
+		}
+		if _, err := writer.Write(addr); err != nil {
+			return fmt.Errorf("failed to write addr preimage: %w", err)
+		}
+
+		if acc.HasStorage() {
+			stIt, err := statedb.Snaps().StorageIterator(mptRoot, accIt.Hash(), common.Hash{})
+			if err != nil {
+				return fmt.Errorf("failed to create storage iterator: %w", err)
+			}
+			for stIt.Next() {
+				slotnr := rawdb.ReadPreimage(statedb.Database().DiskDB(), stIt.Hash())
+				if len(slotnr) != 32 {
+					return fmt.Errorf("slotnr not 32 len")
+				}
+				if _, err := writer.Write(slotnr); err != nil {
+					return fmt.Errorf("failed to write slotnr preimage: %w", err)
+				}
+			}
+			stIt.Release()
+		}
+		count++
+		if count%100000 == 0 {
+			log.Info("Last exported account", "account", accIt.Hash())
+		}
+	}
+
 	log.Info("Exported preimages", "file", fn)
 	return nil
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -219,6 +219,11 @@ var (
 		Usage: "Max number of elements (0 = no limit)",
 		Value: 0,
 	}
+	TreeRootFlag = &cli.StringFlag{
+		Name:  "roothash",
+		Usage: "Root hash of the tree (if empty, use the latest)",
+		Value: "",
+	}
 
 	defaultSyncMode = ethconfig.Defaults.SyncMode
 	SyncModeFlag    = &flags.TextMarshalerFlag{

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
@@ -73,17 +74,23 @@ type Database interface {
 
 	Transitioned() bool
 
-	SetCurrentAccountHash(hash common.Hash)
+	SetCurrentSlotHash(hash common.Hash)
+
+	GetCurrentAccountAddress() common.Address
+
+	SetCurrentAccountAddress(common.Address)
 
 	GetCurrentAccountHash() common.Hash
-
-	SetCurrentSlotHash(hash common.Hash)
 
 	GetCurrentSlotHash() common.Hash
 
 	SetStorageProcessed(bool)
 
 	GetStorageProcessed() bool
+
+	GetCurrentPreimageOffset() int64
+
+	SetCurrentPreimageOffset(int64)
 
 	AddRootTranslation(originalRoot, translatedRoot common.Hash)
 }
@@ -246,9 +253,10 @@ type cachingDB struct {
 
 	addrToPoint *utils.PointCache
 
-	baseRoot           common.Hash // hash of the read-only base tree
-	CurrentAccountHash common.Hash // hash of the last translated account
-	CurrentSlotHash    common.Hash // hash of the last translated storage slot
+	baseRoot              common.Hash    // hash of the read-only base tree
+	CurrentAccountAddress common.Address // addresss of the last translated account
+	CurrentSlotHash       common.Hash    // hash of the last translated storage slot
+	CurrentPreimageOffset int64          // next byte to read from the preimage file
 
 	// Mark whether the storage for an account has been processed. This is useful if the
 	// maximum number of leaves of the conversion is reached before the whole storage is
@@ -409,12 +417,28 @@ func (db *cachingDB) GetTreeKeyHeader(addr []byte) *verkle.Point {
 	return db.addrToPoint.GetTreeKeyHeader(addr)
 }
 
-func (db *cachingDB) SetCurrentAccountHash(hash common.Hash) {
-	db.CurrentAccountHash = hash
+func (db *cachingDB) SetCurrentAccountAddress(addr common.Address) {
+	db.CurrentAccountAddress = addr
 }
 
 func (db *cachingDB) GetCurrentAccountHash() common.Hash {
-	return db.CurrentAccountHash
+	var addrHash common.Hash
+	if db.CurrentAccountAddress != (common.Address{}) {
+		addrHash = crypto.Keccak256Hash(db.CurrentAccountAddress[:])
+	}
+	return addrHash
+}
+
+func (db *cachingDB) GetCurrentAccountAddress() common.Address {
+	return db.CurrentAccountAddress
+}
+
+func (db *cachingDB) GetCurrentPreimageOffset() int64 {
+	return db.CurrentPreimageOffset
+}
+
+func (db *cachingDB) SetCurrentPreimageOffset(offset int64) {
+	db.CurrentPreimageOffset = offset
 }
 
 func (db *cachingDB) SetCurrentSlotHash(hash common.Hash) {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -76,7 +76,7 @@ type Database interface {
 
 	SetCurrentSlotHash(hash common.Hash)
 
-	GetCurrentAccountAddress() common.Address
+	GetCurrentAccountAddress() *common.Address
 
 	SetCurrentAccountAddress(common.Address)
 
@@ -253,10 +253,10 @@ type cachingDB struct {
 
 	addrToPoint *utils.PointCache
 
-	baseRoot              common.Hash    // hash of the read-only base tree
-	CurrentAccountAddress common.Address // addresss of the last translated account
-	CurrentSlotHash       common.Hash    // hash of the last translated storage slot
-	CurrentPreimageOffset int64          // next byte to read from the preimage file
+	baseRoot              common.Hash     // hash of the read-only base tree
+	CurrentAccountAddress *common.Address // addresss of the last translated account
+	CurrentSlotHash       common.Hash     // hash of the last translated storage slot
+	CurrentPreimageOffset int64           // next byte to read from the preimage file
 
 	// Mark whether the storage for an account has been processed. This is useful if the
 	// maximum number of leaves of the conversion is reached before the whole storage is
@@ -418,18 +418,18 @@ func (db *cachingDB) GetTreeKeyHeader(addr []byte) *verkle.Point {
 }
 
 func (db *cachingDB) SetCurrentAccountAddress(addr common.Address) {
-	db.CurrentAccountAddress = addr
+	db.CurrentAccountAddress = &addr
 }
 
 func (db *cachingDB) GetCurrentAccountHash() common.Hash {
 	var addrHash common.Hash
-	if db.CurrentAccountAddress != (common.Address{}) {
+	if db.CurrentAccountAddress != nil {
 		addrHash = crypto.Keccak256Hash(db.CurrentAccountAddress[:])
 	}
 	return addrHash
 }
 
-func (db *cachingDB) GetCurrentAccountAddress() common.Address {
+func (db *cachingDB) GetCurrentAccountAddress() *common.Address {
 	return db.CurrentAccountAddress
 }
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -133,16 +133,16 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		accIt.Next()
 
 		// If we're about to start with the migration process, we have to read the first account hash preimage.
-		if migrdb.GetCurrentAccountAddress() == (common.Address{}) {
+		if migrdb.GetCurrentAccountAddress() == nil {
 			var addr common.Address
 			if _, err := io.ReadFull(fpreimages, addr[:]); err != nil {
 				return nil, nil, 0, fmt.Errorf("reading preimage file: %s", err)
 			}
-			if crypto.Keccak256Hash(addr[:]) != accIt.Hash() {
+			migrdb.SetCurrentAccountAddress(addr)
+			if migrdb.GetCurrentAccountHash() != accIt.Hash() {
 				return nil, nil, 0, fmt.Errorf("preimage file does not match account hash: %s != %s", crypto.Keccak256Hash(addr[:]), accIt.Hash())
 			}
 			preimageSeek += int64(len(addr))
-			migrdb.SetCurrentAccountAddress(addr)
 		}
 
 		const maxMovedCount = 10000

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -103,6 +103,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 
 	// Overlay tree migration logic
 	migrdb := statedb.Database()
+	// TODO: avoid opening the preimages file here and make it part of, potentially, statedb.Database().
 	filePreimages, err := os.Open("preimages.bin")
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("opening preimage file: %s", err)
@@ -137,7 +138,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 			if _, err := io.ReadFull(fpreimages, addr[:]); err != nil {
 				return nil, nil, 0, fmt.Errorf("reading preimage file: %s", err)
 			}
-			// fmt.Printf("first account: %s != %s\n", crypto.Keccak256Hash(addr[:]), accIt.Hash())
 			if crypto.Keccak256Hash(addr[:]) != accIt.Hash() {
 				return nil, nil, 0, fmt.Errorf("preimage file does not match account hash: %s != %s", crypto.Keccak256Hash(addr[:]), accIt.Hash())
 			}
@@ -199,7 +199,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 					if _, err := io.ReadFull(fpreimages, slotnr[:]); err != nil {
 						return nil, nil, 0, fmt.Errorf("reading preimage file: %s", err)
 					}
-					// fmt.Printf("slot: %s != %s\n", crypto.Keccak256Hash(slotnr[:]), stIt.Hash())
 					if crypto.Keccak256Hash(slotnr[:]) != stIt.Hash() {
 						return nil, nil, 0, fmt.Errorf("preimage file does not match storage hash: %s!=%s", crypto.Keccak256Hash(slotnr[:]), stIt.Hash())
 					}

--- a/light/trie.go
+++ b/light/trie.go
@@ -117,12 +117,16 @@ func (db *odrDatabase) Transitioned() bool {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetCurrentAccountHash(hash common.Hash) {
+func (db *odrDatabase) SetCurrentAccountAddress(common.Address) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentAccountHash() common.Hash {
+func (db *odrDatabase) GetCurrentAccountAddress() common.Address {
 	panic("not implemented") // TODO: Implement
+}
+
+func (*odrDatabase) GetCurrentAccountHash() common.Hash {
+	panic("unimplemented")
 }
 
 func (db *odrDatabase) SetCurrentSlotHash(hash common.Hash) {
@@ -138,6 +142,14 @@ func (db *odrDatabase) SetStorageProcessed(_ bool) {
 }
 
 func (db *odrDatabase) GetStorageProcessed() bool {
+	panic("not implemented") // TODO: Implement
+}
+
+func (db *odrDatabase) GetCurrentPreimageOffset() int64 {
+	panic("not implemented") // TODO: Implement
+}
+
+func (db *odrDatabase) SetCurrentPreimageOffset(int64) {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/light/trie.go
+++ b/light/trie.go
@@ -121,7 +121,7 @@ func (db *odrDatabase) SetCurrentAccountAddress(common.Address) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentAccountAddress() common.Address {
+func (db *odrDatabase) GetCurrentAccountAddress() *common.Address {
 	panic("not implemented") // TODO: Implement
 }
 


### PR DESCRIPTION
This is a PR that:
- Adds a tool for exporting preimages in a flat file in the same order they'll be walked in the Overlay Tree migration.
- Use this file in the overlay tree migration.

This PR is a draft, and only the first bullet is in... it will continue to evolve, including the second bullet.

To run the tool: `go run ./cmd/geth --datadir=/pathto/.ethereum export-overlay-preimages preimages.bin`