### PR TITLE
fix: vkt delete in transition in cachingdb rebased

### DIFF
--- a/trie/verkle_iterator_test.go
+++ b/trie/verkle_iterator_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestVerkleIterator(t *testing.T) {
-	trie := NewVerkleTrie(verkle.New(), NewDatabase(rawdb.NewMemoryDatabase()), utils.NewPointCache())
+	trie := NewVerkleTrie(verkle.New(), NewDatabase(rawdb.NewMemoryDatabase()), utils.NewPointCache(), true)
 	account0 := &types.StateAccount{
 		Nonce:    1,
 		Balance:  big.NewInt(2),


### PR DESCRIPTION
During the transition, when a deleted account has been found, a special error is returned so that the `TransitionTrie` knows that a deleted account was found in the verkle tree, and that it should not try to search the MPT for an older version of that account.

Once the transition has ended, `TransitionTrie` is no longer used, and so that error should not be sent. This PR makes sure that is the case.

Such an instance occurs around block 4,713,525. 