### PR TITLE
fix: reduce the PR footprint

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -373,7 +373,7 @@ func (s *stateObject) updateTrie(db Database) Trie {
 	if len(s.pendingStorage) > 0 {
 		s.pendingStorage = make(Storage)
 	}
-	return s.trie
+	return tr
 }
 
 // UpdateRoot sets the trie root to the current root hash of


### PR DESCRIPTION
This is a leftover from the time that a verkle tree could only be an account trie. I tested the fix on mainnet, want to see if the tests are passing.