### PR TITLE
fix: ensure point cache isn't nil in copy

### DIFF
--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -307,8 +307,9 @@ func (trie *VerkleTrie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
 
 func (trie *VerkleTrie) Copy() *VerkleTrie {
 	return &VerkleTrie{
-		root: trie.root.Copy(),
-		db:   trie.db,
+		root:       trie.root.Copy(),
+		db:         trie.db,
+		pointCache: trie.pointCache,
 	}
 }
 


### PR DESCRIPTION
The following stack trace was reported for kaustinen:

```
goroutine 208183 [running]:
[github.com/ethereum/go-ethereum/trie/utils.(*PointCache).GetTreeKeyHeader(0x0,](http://github.com/ethereum/go-ethereum/trie/utils.(*PointCache).GetTreeKeyHeader(0x0,) {0xc000b377e8, 0x14, 0x14})
	[github.com/ethereum/go-ethereum/trie/utils/verkle.go:65](http://github.com/ethereum/go-ethereum/trie/utils/verkle.go:65) +0x31
[github.com/ethereum/go-ethereum/trie/utils.(*PointCache).GetTreeKeyVersionCached(0x1a16820?,](http://github.com/ethereum/go-ethereum/trie/utils.(*PointCache).GetTreeKeyVersionCached(0x1a16820?,) {0xc000b377e8?, 0xe29a1b?, 0x4d?})
	[github.com/ethereum/go-ethereum/trie/utils/verkle.go:80](http://github.com/ethereum/go-ethereum/trie/utils/verkle.go:80) +0x1e
[github.com/ethereum/go-ethereum/trie.(*VerkleTrie).GetAccount(0xc019a66240,](http://github.com/ethereum/go-ethereum/trie.(*VerkleTrie).GetAccount(0xc019a66240,) {0x97, 0xc9, 0xb1, 0x68, 0xc5, 0xe1, 0x4d, 0x5d, 0x36, ...})
	[github.com/ethereum/go-ethereum/trie/verkle.go:104](http://github.com/ethereum/go-ethereum/trie/verkle.go:104) +0x65
[github.com/ethereum/go-ethereum/trie.(*TransitionTrie).GetAccount(0xc0192e8a08,](http://github.com/ethereum/go-ethereum/trie.(*TransitionTrie).GetAccount(0xc0192e8a08,) {0x97, 0xc9, 0xb1, 0x68, 0xc5, 0xe1, 0x4d, 0x5d, 0x36, ...})
	[github.com/ethereum/go-ethereum/trie/transition.go:74](http://github.com/ethereum/go-ethereum/trie/transition.go:74) +0x45
[github.com/ethereum/go-ethereum/core/state.(*StateDB).getDeletedStateObject(0xc0192fd680,](http://github.com/ethereum/go-ethereum/core/state.(*StateDB).getDeletedStateObject(0xc0192fd680,) {0x97, 0xc9, 0xb1, 0x68, 0xc5, 0xe1, 0x4d, 0x5d, 0x36, ...})
	[github.com/ethereum/go-ethereum/core/state/statedb.go:673](http://github.com/ethereum/go-ethereum/core/state/statedb.go:673) +0x3b2
[github.com/ethereum/go-ethereum/core/state.(*StateDB).getStateObject](http://github.com/ethereum/go-ethereum/core/state.(*StateDB).getStateObject)(...)
	[github.com/ethereum/go-ethereum/core/state/statedb.go:628](http://github.com/ethereum/go-ethereum/core/state/statedb.go:628)
[github.com/ethereum/go-ethereum/core/state.(*StateDB).GetNonce(0x57?,](http://github.com/ethereum/go-ethereum/core/state.(*StateDB).GetNonce(0x57?,) {0x97, 0xc9, 0xb1, 0x68, 0xc5, 0xe1, 0x4d, 0x5d, 0x36, ...})
```

That points out to a `nil` `pointCache` field. When a trie was copied, the point cache was left `nil`, which is the probable culprit for this issue.