### PR TITLE
fix: write trie preimage data to db

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1347,6 +1347,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	if err := blockBatch.Write(); err != nil {
 		log.Crit("Failed to write block into disk", "err", err)
 	}
+	state.Database().TrieDB().WritePreimages()
 	// Commit all cached state changes into underlying memory database.
 	root, err := state.Commit(block.NumberU64(), bc.chainConfig.IsEIP158(block.Number()))
 	if err != nil {


### PR DESCRIPTION
It seems that the recording of preimages coming from the tree was broken before PBSS. This is a fix, I still need to check if it is still currently needed in geth master.