### PR TITLE
fix: zero-root in produced block + sync

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2535,6 +2535,9 @@ func (bc *BlockChain) GetTrieFlushInterval() time.Duration {
 func (bc *BlockChain) StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, pragueTime *uint64) {
 	bc.stateCache.StartVerkleTransition(originalRoot, translatedRoot, chainConfig, pragueTime)
 }
+func (bc *BlockChain) ReorgThroughVerkleTransition() {
+	bc.stateCache.ReorgThroughVerkleTransition()
+}
 
 func (bc *BlockChain) EndVerkleTransition() {
 	bc.stateCache.EndVerkleTransition()

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -67,6 +67,8 @@ type Database interface {
 
 	StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, cancunTime *uint64)
 
+	ReorgThroughVerkleTransition()
+
 	EndVerkleTransition()
 
 	InTransition() bool
@@ -219,6 +221,7 @@ func (db *cachingDB) StartVerkleTransition(originalRoot, translatedRoot common.H
 	  |____|  |___|  /\___        \___  |____/\___  |   __/|___|  (____  |___|  |__|      |___|  (____  /_____/       \/\_/ |__|___|  /_____//_____/
                                                     |__|`)
 	db.started = true
+	db.ended = false
 	// db.AddTranslation(originalRoot, translatedRoot)
 	db.baseRoot = originalRoot
 	// initialize so that the first storage-less accounts are processed
@@ -226,6 +229,10 @@ func (db *cachingDB) StartVerkleTransition(originalRoot, translatedRoot common.H
 	if pragueTime != nil {
 		chainConfig.PragueTime = pragueTime
 	}
+}
+
+func (db *cachingDB) ReorgThroughVerkleTransition() {
+	db.ended, db.started = false, false
 }
 
 func (db *cachingDB) EndVerkleTransition() {

--- a/light/trie.go
+++ b/light/trie.go
@@ -105,6 +105,10 @@ func (db *odrDatabase) StartVerkleTransition(originalRoot common.Hash, translate
 	panic("not implemented") // TODO: Implement
 }
 
+func (db *odrDatabase) ReorgThroughVerkleTransition() {
+	panic("not implemented") // TODO: Implement
+}
+
 func (db *odrDatabase) EndVerkleTransition() {
 	panic("not implemented") // TODO: Implement
 }

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -386,7 +386,7 @@ func DeserializeAndVerifyVerkleProof(vp *verkle.VerkleProof, root []byte, stated
 		}
 	}
 
-	posttree, err := verkle.PostStateTreeFromStateDiff(pretree, statediff)
+	posttree, err := verkle.PostStateTreeFromProof(pretree, statediff)
 	if err != nil {
 		return fmt.Errorf("error rebuilding the post-tree from proof: %w", err)
 	}


### PR DESCRIPTION
### Zero-root in block production

The miner always creates an empty block, to make sure that one block will always be ready to deliver if the block production window expires. If a better block is produced before the end of the window, that new block will replace the empty block.

But with the empty block, `EndVerkleTransition` has already been called (if it's the end of the transition). So the `ended` variable is set to `true` while another block at the same height is being created. Result: the parent state root parameter in `OpenTrie`, which can be a MPT root, is interpreted as the root of a verkle tree. Since this root can't be found as a verkle root, it starts an empty verkle tree.

### Sync issue

Before the sync starts, the syncing node will create a first block on top of the genesis. Because by then, the `pragueTime` has passed, the transition will trigger before the production of that new block. Then a reorg happens, but the DB still has the transition marked as `ended`. Basically the same thing happens as the other bug described above.