### PR TITLE
fix: add ProofInBlocks to chain config

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -398,7 +398,7 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 		k    verkle.StateDiff
 		keys = state.Witness().Keys()
 	)
-	if chain.Config().IsPrague(header.Number, header.Time) && chain.Config().ProofInBlock {
+	if chain.Config().IsPrague(header.Number, header.Time) && chain.Config().ProofInBlocks {
 		// Open the pre-tree to prove the pre-state against
 		parent := chain.GetHeaderByNumber(header.Number.Uint64() - 1)
 		if parent == nil {
@@ -448,7 +448,7 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 
 	// Assemble and return the final block.
 	block := types.NewBlockWithWithdrawals(header, txs, uncles, receipts, withdrawals, trie.NewStackTrie(nil))
-	if chain.Config().IsPrague(header.Number, header.Time) && chain.Config().ProofInBlock {
+	if chain.Config().IsPrague(header.Number, header.Time) && chain.Config().ProofInBlocks {
 		block.SetVerkleProof(p, k)
 	}
 	return block, nil

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -454,7 +454,7 @@ func TestProcessVerkle(t *testing.T) {
 			PragueTime:                    u64(0),
 			TerminalTotalDifficulty:       common.Big0,
 			TerminalTotalDifficultyPassed: true,
-			ProofInBlock:                  true,
+			ProofInBlocks:                 true,
 		}
 		signer     = types.LatestSigner(config)
 		testKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")

--- a/params/config.go
+++ b/params/config.go
@@ -301,7 +301,7 @@ type ChainConfig struct {
 	IsDevMode bool          `json:"isDev,omitempty"`
 
 	// Proof in block
-	ProofInBlock bool `json:"proofInBlock,omitempty"`
+	ProofInBlocks bool `json:"proofInBlocks,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.


### PR DESCRIPTION
The field `proofInBlocks` need to be set to `true` in the genesis configuration.