### PR TITLE
workaround: disable check for root presence

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -341,23 +341,23 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 	}
 	// We have the genesis block in database(perhaps in ancient database)
 	// but the corresponding state is missing.
-	header := rawdb.ReadHeader(db, stored, 0)
-	if header.Root != types.EmptyRootHash && !rawdb.HasLegacyTrieNode(db, header.Root) {
-		if genesis == nil {
-			genesis = DefaultGenesisBlock()
-		}
-		// Ensure the stored genesis matches with the given one.
-		hash := genesis.ToBlock().Hash()
-		if hash != stored {
-			return genesis.Config, hash, &GenesisMismatchError{stored, hash}
-		}
-		block, err := genesis.Commit(db, triedb)
-		if err != nil {
-			return genesis.Config, hash, err
-		}
-		applyOverrides(genesis.Config)
-		return genesis.Config, block.Hash(), nil
-	}
+	// header := rawdb.ReadHeader(db, stored, 0)
+	// if header.Root != types.EmptyRootHash && !rawdb.HasLegacyTrieNode(db, header.Root) {
+	// 	if genesis == nil {
+	// 		genesis = DefaultGenesisBlock()
+	// 	}
+	// 	// Ensure the stored genesis matches with the given one.
+	// 	hash := genesis.ToBlock().Hash()
+	// 	if hash != stored {
+	// 		return genesis.Config, hash, &GenesisMismatchError{stored, hash}
+	// 	}
+	// 	block, err := genesis.Commit(db, triedb)
+	// 	if err != nil {
+	// 		return genesis.Config, hash, err
+	// 	}
+	// 	applyOverrides(genesis.Config)
+	// 	return genesis.Config, block.Hash(), nil
+	// }
 	// Check whether the genesis block is already written.
 	if genesis != nil {
 		hash := genesis.ToBlock().Hash()


### PR DESCRIPTION
This is a workaround for #264: the genesis code tries to load the root from the tree, using the standard database schema.

The schema that is currently used is different, so it will not find the root. Since this check is not necessary for a kaustinen startup, deactivate it.