### PR TITLE
fix: activate verkle at genesis

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -208,6 +208,7 @@ func initGenesis(ctx *cli.Context) error {
 		}
 		triedb := trie.NewDatabaseWithConfig(chaindb, &trie.Config{
 			Preimages: ctx.Bool(utils.CachePreimagesFlag.Name),
+			Verkle:    true,
 		})
 		_, hash, err := core.SetupGenesisBlock(chaindb, triedb, genesis)
 		if err != nil {


### PR DESCRIPTION
Verkle mode wasn't activated in the `triedb` which means that the genesis allocation data was stored in an MPT, in spite of the root hash being correct.