### PR TITLE
fix: incorrect access copy

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -138,7 +138,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 		chainRules:  chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil, blockCtx.Time),
 	}
 	if txCtx.Accesses == nil && chainConfig.IsPrague(blockCtx.BlockNumber, blockCtx.Time) {
-		txCtx.Accesses = evm.StateDB.(*state.StateDB).NewAccessWitness()
+		evm.Accesses = evm.StateDB.(*state.StateDB).NewAccessWitness()
 	}
 	evm.interpreter = NewEVMInterpreter(evm)
 	return evm


### PR DESCRIPTION
The evm's `TxContext` structure is copied from another. The code that would initialize the access witness if it detected that the latter was missing, was updating the _source_ structure, assuming this was a pointer. As a result, and especially in the context of an RPC call, the copied `TxContext` would still be `nil` and crash somewhere else.

Since there are many places that the allocation happens during normal block production/execution, this would not appear outside of RPC calls.