### PR TITLE
fix: decide if genesis is verkle using genesis timestamp

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"runtime"
 	"strconv"

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -208,7 +208,7 @@ func initGenesis(ctx *cli.Context) error {
 		}
 		triedb := trie.NewDatabaseWithConfig(chaindb, &trie.Config{
 			Preimages: ctx.Bool(utils.CachePreimagesFlag.Name),
-			Verkle:    true,
+			Verkle:    genesis.Config.IsPrague(big.NewInt(0), genesis.Timestamp),
 		})
 		_, hash, err := core.SetupGenesisBlock(chaindb, triedb, genesis)
 		if err != nil {


### PR DESCRIPTION
Verkle mode is hardcoded in the `init` command, this should not be the case: it should be taken from the genesis data.