### PR TITLE
workaround: force verkle activation at genesis

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -311,7 +311,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	head := bc.CurrentBlock()
 
 	// Declare the end of the verkle transition if need be
-	if bc.chainConfig.Rules(head.Number, false /* XXX */, head.Time).IsPrague {
+	if /* bc.chainConfig.Rules(head.Number, false /* XXX *, head.Time).IsPrague */ head.Number.Uint64() == 0 {
 		bc.stateCache.EndVerkleTransition()
 	}
 
@@ -1558,10 +1558,10 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		return 0, nil
 	}
 
-	conversionBlock, err := findVerkleConversionBlock()
-	if err != nil {
-		return 0, err
-	}
+	// conversionBlock, err := findVerkleConversionBlock()
+	// if err != nil {
+	// 	return 0, err
+	// }
 
 	// Start a parallel signature recovery (signer will fluke on fork transition, minimal perf loss)
 	SenderCacher.RecoverFromBlocks(types.MakeSigner(bc.chainConfig, chain[0].Number(), chain[0].Time()), chain)
@@ -1745,10 +1745,10 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			parent = bc.GetHeader(block.ParentHash(), block.NumberU64()-1)
 		}
 
-		if parent.Number.Uint64() == conversionBlock {
-			bc.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), &parent.Time)
-			bc.stateCache.SetLastMerkleRoot(parent.Root)
-		}
+		// if parent.Number.Uint64() == conversionBlock {
+		// 	bc.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), &parent.Time)
+		// 	bc.stateCache.SetLastMerkleRoot(parent.Root)
+		// }
 		statedb, err := state.New(parent.Root, bc.stateCache, bc.snaps)
 		if err != nil {
 			return it.index, err

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -125,7 +125,7 @@ func (ga *GenesisAlloc) deriveHash(cfg *params.ChainConfig, timestamp uint64) (c
 	// Create an ephemeral in-memory database for computing hash,
 	// all the derived states will be discarded to not pollute disk.
 	db := state.NewDatabase(rawdb.NewMemoryDatabase())
-	if cfg.IsPrague(big.NewInt(int64(0)), timestamp) {
+	if /* cfg.IsPrague(big.NewInt(int64(0)), timestamp) */ true {
 		db.EndVerkleTransition()
 	}
 	statedb, err := state.New(types.EmptyRootHash, db, nil)
@@ -153,7 +153,7 @@ func (ga *GenesisAlloc) flush(db ethdb.Database, triedb *trie.Database, blockhas
 	}
 
 	// End the verkle conversion at genesis if the fork block is 0
-	if triedb.IsVerkle() {
+	if /*triedb.IsVerkle() */ true {
 		statedb.Database().EndVerkleTransition()
 	}
 

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -529,12 +529,12 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 		return api.invalid(errors.New("invalid timestamp"), parent.Header()), nil
 	}
 	// Trigger the start of the verkle conversion if we're at the right block
-	if api.eth.BlockChain().Config().IsPrague(block.Number(), block.Time()) && !api.eth.BlockChain().Config().IsPrague(parent.Number(), parent.Time()) {
-		parent := api.eth.BlockChain().GetHeaderByNumber(block.NumberU64() - 1)
-		if !api.eth.BlockChain().Config().IsPrague(parent.Number, parent.Time) {
-			api.eth.BlockChain().StartVerkleTransition(parent.Root, common.Hash{}, api.eth.BlockChain().Config(), nil)
-		}
-	}
+	// if api.eth.BlockChain().Config().IsPrague(block.Number(), block.Time()) && !api.eth.BlockChain().Config().IsPrague(parent.Number(), parent.Time()) {
+	// 	parent := api.eth.BlockChain().GetHeaderByNumber(block.NumberU64() - 1)
+	// 	if !api.eth.BlockChain().Config().IsPrague(parent.Number, parent.Time) {
+	// 		api.eth.BlockChain().StartVerkleTransition(parent.Root, common.Hash{}, api.eth.BlockChain().Config(), nil)
+	// 	}
+	// }
 	// Reset db merge state in case of a reorg
 	if !api.eth.BlockChain().Config().IsPrague(block.Number(), block.Time()) {
 		api.eth.BlockChain().ReorgThroughVerkleTransition()

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -891,12 +891,12 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	}
 
 	// Trigger the start of the verkle conversion if we're at the right block
-	if w.chain.Config().IsPrague(header.Number, header.Time) {
-		parent := w.chain.GetHeaderByNumber(header.Number.Uint64() - 1)
-		if !w.chain.Config().IsPrague(parent.Number, parent.Time) {
-			w.chain.StartVerkleTransition(parent.Root, common.Hash{}, w.chain.Config(), nil)
-		}
-	}
+	// if w.chain.Config().IsPrague(header.Number, header.Time) {
+	// 	parent := w.chain.GetHeaderByNumber(header.Number.Uint64() - 1)
+	// 	if !w.chain.Config().IsPrague(parent.Number, parent.Time) {
+	// 		w.chain.StartVerkleTransition(parent.Root, common.Hash{}, w.chain.Config(), nil)
+	// 	}
+	// }
 
 	// Retrieve the parent state to execute on top and start a prefetcher for
 	// the miner to speed block sealing up a bit.
@@ -904,9 +904,9 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	if err != nil {
 		return nil, err
 	}
-	if w.chain.Config().IsPrague(header.Number, header.Time) {
-		core.OverlayVerkleTransition(state)
-	}
+	// if w.chain.Config().IsPrague(header.Number, header.Time) {
+	// 	core.OverlayVerkleTransition(state)
+	// }
 	// Run the consensus preparation with the default or customized consensus engine.
 	if err := w.engine.Prepare(w.chain, header); err != nil {
 		log.Error("Failed to prepare header for sealing", "err", err)


### PR DESCRIPTION
The previous iteration of the kaustinen testnet seemed to have an issue having `el_genesis.timestamp == pragueTime`, but the code needs that to be true in order to create a verkle genesis state.

This is a workaround to force verkle activation at genesis, although it would make sense to figure out why it fails in the regular condition (spindevnets does not have an issue with this, but it's also less complex).