### PR TITLE
save overlay conversion iterator pointers at each block

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -425,9 +425,9 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 		return nil, nil
 	}
 	var snaps *snapshot.Tree
+	triedb := state.NewDatabaseWithConfig(db, nil)
+	triedb.EndVerkleTransition(parent.Root())
 	for i := 0; i < n; i++ {
-		triedb := state.NewDatabaseWithConfig(db, nil)
-		triedb.EndVerkleTransition()
 		statedb, err := state.New(parent.Root(), triedb, snaps)
 		if err != nil {
 			panic(fmt.Sprintf("could not find state for block %d: err=%v, parent root=%x", i, err, parent.Root()))

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -425,9 +425,11 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 		return nil, nil
 	}
 	var snaps *snapshot.Tree
-	triedb := state.NewDatabaseWithConfig(db, nil)
-	triedb.EndVerkleTransition(parent.Root())
+	triedb := state.NewDatabaseWithConfig(db, &trie.Config{Verkle: true})
 	for i := 0; i < n; i++ {
+		// This needs to be activated because now InTransiton/Transitionned
+		// depend on the root hash, so you have to mark it as such.
+		triedb.EndVerkleTransition(parent.Root())
 		statedb, err := state.New(parent.Root(), triedb, snaps)
 		if err != nil {
 			panic(fmt.Sprintf("could not find state for block %d: err=%v, parent root=%x", i, err, parent.Root()))

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -126,7 +126,7 @@ func (ga *GenesisAlloc) deriveHash(cfg *params.ChainConfig, timestamp uint64) (c
 	// all the derived states will be discarded to not pollute disk.
 	db := state.NewDatabase(rawdb.NewMemoryDatabase())
 	if cfg.IsPrague(big.NewInt(int64(0)), timestamp) {
-		db.EndVerkleTransition(common.Hash{})
+		db.EndVerkleTransition(types.EmptyRootHash)
 	}
 	statedb, err := state.New(types.EmptyRootHash, db, nil)
 	if err != nil {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -126,7 +126,7 @@ func (ga *GenesisAlloc) deriveHash(cfg *params.ChainConfig, timestamp uint64) (c
 	// all the derived states will be discarded to not pollute disk.
 	db := state.NewDatabase(rawdb.NewMemoryDatabase())
 	if cfg.IsPrague(big.NewInt(int64(0)), timestamp) {
-		db.EndVerkleTransition()
+		db.EndVerkleTransition(common.Hash{})
 	}
 	statedb, err := state.New(types.EmptyRootHash, db, nil)
 	if err != nil {
@@ -154,7 +154,7 @@ func (ga *GenesisAlloc) flush(db ethdb.Database, triedb *trie.Database, blockhas
 
 	// End the verkle conversion at genesis if the fork block is 0
 	if triedb.IsVerkle() {
-		statedb.Database().EndVerkleTransition()
+		statedb.Database().EndVerkleTransition(common.Hash{})
 	}
 
 	for addr, account := range *ga {

--- a/core/overlay_transition.go
+++ b/core/overlay_transition.go
@@ -35,19 +35,19 @@ import (
 )
 
 // OverlayVerkleTransition contains the overlay conversion logic
-func OverlayVerkleTransition(statedb *state.StateDB) error {
+func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash) error {
 	migrdb := statedb.Database()
 
 	// verkle transition: if the conversion process is in progress, move
 	// N values from the MPT into the verkle tree.
-	if migrdb.InTransition() {
+	if migrdb.InTransition(root) {
 		var (
 			now             = time.Now()
 			tt              = statedb.GetTrie().(*trie.TransitionTrie)
 			mpt             = tt.Base()
 			vkt             = tt.Overlay()
 			hasPreimagesBin = false
-			preimageSeek    = migrdb.GetCurrentPreimageOffset()
+			preimageSeek    = migrdb.GetCurrentPreimageOffset(root)
 			fpreimages      *bufio.Reader
 		)
 
@@ -65,7 +65,7 @@ func OverlayVerkleTransition(statedb *state.StateDB) error {
 			hasPreimagesBin = true
 		}
 
-		accIt, err := statedb.Snaps().AccountIterator(mpt.Hash(), migrdb.GetCurrentAccountHash())
+		accIt, err := statedb.Snaps().AccountIterator(mpt.Hash(), migrdb.GetCurrentAccountHash(root))
 		if err != nil {
 			return err
 		}
@@ -73,7 +73,7 @@ func OverlayVerkleTransition(statedb *state.StateDB) error {
 		accIt.Next()
 
 		// If we're about to start with the migration process, we have to read the first account hash preimage.
-		if migrdb.GetCurrentAccountAddress() == nil {
+		if migrdb.GetCurrentAccountAddress(root) == nil {
 			var addr common.Address
 			if hasPreimagesBin {
 				if _, err := io.ReadFull(fpreimages, addr[:]); err != nil {
@@ -85,8 +85,8 @@ func OverlayVerkleTransition(statedb *state.StateDB) error {
 					return fmt.Errorf("addr len is zero is not 32: %d", len(addr))
 				}
 			}
-			migrdb.SetCurrentAccountAddress(addr)
-			if migrdb.GetCurrentAccountHash() != accIt.Hash() {
+			migrdb.SetCurrentAccountAddress(addr, root)
+			if migrdb.GetCurrentAccountHash(root) != accIt.Hash() {
 				return fmt.Errorf("preimage file does not match account hash: %s != %s", crypto.Keccak256Hash(addr[:]), accIt.Hash())
 			}
 			preimageSeek += int64(len(addr))
@@ -108,7 +108,7 @@ func OverlayVerkleTransition(statedb *state.StateDB) error {
 				log.Error("Invalid account encountered during traversal", "error", err)
 				return err
 			}
-			vkt.SetStorageRootConversion(*migrdb.GetCurrentAccountAddress(), acc.Root)
+			vkt.SetStorageRootConversion(*migrdb.GetCurrentAccountAddress(root), acc.Root)
 
 			// Start with processing the storage, because once the account is
 			// converted, the `stateRoot` field loses its meaning. Which means
@@ -120,7 +120,7 @@ func OverlayVerkleTransition(statedb *state.StateDB) error {
 			// to during normal block execution. A mitigation strategy has been
 			// introduced with the `*StorageRootConversion` fields in VerkleDB.
 			if acc.HasStorage() {
-				stIt, err := statedb.Snaps().StorageIterator(mpt.Hash(), accIt.Hash(), migrdb.GetCurrentSlotHash())
+				stIt, err := statedb.Snaps().StorageIterator(mpt.Hash(), accIt.Hash(), migrdb.GetCurrentSlotHash(root))
 				if err != nil {
 					return err
 				}
@@ -132,7 +132,7 @@ func OverlayVerkleTransition(statedb *state.StateDB) error {
 				// processing the storage for that account where we left off.
 				// If the entire storage was processed, then the iterator was
 				// created in vain, but it's ok as this will not happen often.
-				for ; !migrdb.GetStorageProcessed() && count < maxMovedCount; count++ {
+				for ; !migrdb.GetStorageProcessed(root) && count < maxMovedCount; count++ {
 					var (
 						value     []byte   // slot value after RLP decoding
 						safeValue [32]byte // 32-byte aligned value
@@ -160,12 +160,12 @@ func OverlayVerkleTransition(statedb *state.StateDB) error {
 					}
 					preimageSeek += int64(len(slotnr))
 
-					mkv.addStorageSlot(migrdb.GetCurrentAccountAddress().Bytes(), slotnr, safeValue[:])
+					mkv.addStorageSlot(migrdb.GetCurrentAccountAddress(root).Bytes(), slotnr, safeValue[:])
 
 					// advance the storage iterator
-					migrdb.SetStorageProcessed(!stIt.Next())
-					if !migrdb.GetStorageProcessed() {
-						migrdb.SetCurrentSlotHash(stIt.Hash())
+					migrdb.SetStorageProcessed(!stIt.Next(), root)
+					if !migrdb.GetStorageProcessed(root) {
+						migrdb.SetCurrentSlotHash(stIt.Hash(), root)
 					}
 				}
 				stIt.Release()
@@ -178,20 +178,20 @@ func OverlayVerkleTransition(statedb *state.StateDB) error {
 			if count < maxMovedCount {
 				count++ // count increase for the account itself
 
-				mkv.addAccount(migrdb.GetCurrentAccountAddress().Bytes(), acc)
-				vkt.ClearStrorageRootConversion(*migrdb.GetCurrentAccountAddress())
+				mkv.addAccount(migrdb.GetCurrentAccountAddress(root).Bytes(), acc)
+				vkt.ClearStrorageRootConversion(*migrdb.GetCurrentAccountAddress(root))
 
 				// Store the account code if present
 				if !bytes.Equal(acc.CodeHash, types.EmptyCodeHash[:]) {
 					code := rawdb.ReadCode(statedb.Database().DiskDB(), common.BytesToHash(acc.CodeHash))
 					chunks := trie.ChunkifyCode(code)
 
-					mkv.addAccountCode(migrdb.GetCurrentAccountAddress().Bytes(), uint64(len(code)), chunks)
+					mkv.addAccountCode(migrdb.GetCurrentAccountAddress(root).Bytes(), uint64(len(code)), chunks)
 				}
 
 				// reset storage iterator marker for next account
-				migrdb.SetStorageProcessed(false)
-				migrdb.SetCurrentSlotHash(common.Hash{})
+				migrdb.SetStorageProcessed(false, root)
+				migrdb.SetCurrentSlotHash(common.Hash{}, root)
 
 				// Move to the next account, if available - or end
 				// the transition otherwise.
@@ -212,18 +212,18 @@ func OverlayVerkleTransition(statedb *state.StateDB) error {
 						return fmt.Errorf("preimage file does not match account hash: %s != %s", crypto.Keccak256Hash(addr[:]), accIt.Hash())
 					}
 					preimageSeek += int64(len(addr))
-					migrdb.SetCurrentAccountAddress(addr)
+					migrdb.SetCurrentAccountAddress(addr, root)
 				} else {
 					// case when the account iterator has
 					// reached the end but count < maxCount
-					migrdb.EndVerkleTransition()
+					migrdb.EndVerkleTransition(root)
 					break
 				}
 			}
 		}
-		migrdb.SetCurrentPreimageOffset(preimageSeek)
+		migrdb.SetCurrentPreimageOffset(preimageSeek, root)
 
-		log.Info("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account", statedb.Database().GetCurrentAccountHash())
+		log.Info("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account", statedb.Database().GetCurrentAccountHash(root))
 
 		// Take all the collected key-values and prepare the new leaf values.
 		// This fires a background routine that will start doing the work that

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -191,7 +191,7 @@ func NewDatabaseWithConfig(db ethdb.Database, config *trie.Config) Database {
 		CurrentAccountAddress: map[common.Hash]*common.Address{},
 		CurrentSlotHash:       map[common.Hash]common.Hash{},
 		CurrentPreimageOffset: map[common.Hash]int64{}, started: map[common.Hash]bool{},
-		ended: map[common.Hash]bool{},
+		ended: map[common.Hash]bool{(common.Hash{}): (config != nil && config.Verkle), types.EmptyRootHash: (config != nil && config.Verkle)},
 	}
 }
 
@@ -208,7 +208,7 @@ func NewDatabaseWithNodeDB(db ethdb.Database, triedb *trie.Database) Database {
 		CurrentSlotHash:       map[common.Hash]common.Hash{},
 		CurrentPreimageOffset: map[common.Hash]int64{},
 		started:               map[common.Hash]bool{},
-		ended:                 map[common.Hash]bool{},
+		ended:                 map[common.Hash]bool{types.EmptyRootHash: triedb.IsVerkle(), (common.Hash{}): triedb.IsVerkle()},
 	}
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1039,7 +1039,7 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 	root := s.trie.Hash()
 
 	// Save the root of the MPT so that it can be used during the transition
-	if !s.Database().InTransition() && !s.Database().Transitioned() {
+	if !s.Database().InTransition(root) && !s.Database().Transitioned(root) {
 		s.Database().SetLastMerkleRoot(root)
 	}
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -106,7 +106,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 
 	// Perform the overlay transition, if relevant
-	if err := OverlayVerkleTransition(statedb); err != nil {
+	parent := p.bc.GetHeaderByHash(header.ParentHash)
+	if err := OverlayVerkleTransition(statedb, parent.Root); err != nil {
 		return nil, nil, 0, fmt.Errorf("error performing verkle overlay transition: %w", err)
 	}
 

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -532,7 +532,7 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 	if api.eth.BlockChain().Config().IsPrague(block.Number(), block.Time()) && !api.eth.BlockChain().Config().IsPrague(parent.Number(), parent.Time()) {
 		parent := api.eth.BlockChain().GetHeaderByNumber(block.NumberU64() - 1)
 		if !api.eth.BlockChain().Config().IsPrague(parent.Number, parent.Time) {
-			api.eth.BlockChain().StartVerkleTransition(parent.Root, common.Hash{}, api.eth.BlockChain().Config(), nil)
+			api.eth.BlockChain().StartVerkleTransition(parent.Root, api.eth.BlockChain().Config(), api.eth.BlockChain().Config().PragueTime, parent.Root)
 		}
 	}
 	// Reset db merge state in case of a reorg

--- a/light/trie.go
+++ b/light/trie.go
@@ -101,7 +101,7 @@ func (db *odrDatabase) DiskDB() ethdb.KeyValueStore {
 	panic("not implemented")
 }
 
-func (db *odrDatabase) StartVerkleTransition(originalRoot common.Hash, translatedRoot common.Hash, chainConfig *params.ChainConfig, _ *uint64) {
+func (db *odrDatabase) StartVerkleTransition(originalRoot common.Hash, chainConfig *params.ChainConfig, _ *uint64, _ common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
@@ -109,59 +109,59 @@ func (db *odrDatabase) ReorgThroughVerkleTransition() {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) EndVerkleTransition() {
+func (db *odrDatabase) EndVerkleTransition(common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) InTransition() bool {
+func (db *odrDatabase) InTransition(common.Hash) bool {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) Transitioned() bool {
+func (db *odrDatabase) Transitioned(common.Hash) bool {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetCurrentSlotHash(hash common.Hash) {
+func (db *odrDatabase) SetCurrentSlotHash(common.Hash, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentAccountAddress() *common.Address {
+func (db *odrDatabase) GetCurrentAccountAddress(common.Hash) *common.Address {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetCurrentAccountAddress(_ common.Address) {
+func (db *odrDatabase) SetCurrentAccountAddress(common.Address, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentAccountHash() common.Hash {
+func (db *odrDatabase) GetCurrentAccountHash(common.Hash) common.Hash {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentSlotHash() common.Hash {
+func (db *odrDatabase) GetCurrentSlotHash(common.Hash) common.Hash {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetStorageProcessed(_ bool) {
+func (db *odrDatabase) SetStorageProcessed(bool, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetStorageProcessed() bool {
+func (db *odrDatabase) GetStorageProcessed(common.Hash) bool {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentPreimageOffset() int64 {
+func (db *odrDatabase) GetCurrentPreimageOffset(common.Hash) int64 {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetCurrentPreimageOffset(_ int64) {
+func (db *odrDatabase) SetCurrentPreimageOffset(int64, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) AddRootTranslation(originalRoot common.Hash, translatedRoot common.Hash) {
+func (db *odrDatabase) AddRootTranslation(common.Hash, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetLastMerkleRoot(root common.Hash) {
+func (db *odrDatabase) SetLastMerkleRoot(common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -894,7 +894,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	if w.chain.Config().IsPrague(header.Number, header.Time) {
 		parent := w.chain.GetHeaderByNumber(header.Number.Uint64() - 1)
 		if !w.chain.Config().IsPrague(parent.Number, parent.Time) {
-			w.chain.StartVerkleTransition(parent.Root, common.Hash{}, w.chain.Config(), nil)
+			w.chain.StartVerkleTransition(parent.Root, w.chain.Config(), w.chain.Config().PragueTime, parent.Root)
 		}
 	}
 
@@ -905,7 +905,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		return nil, err
 	}
 	if w.chain.Config().IsPrague(header.Number, header.Time) {
-		core.OverlayVerkleTransition(state)
+		core.OverlayVerkleTransition(state, parent.Root)
 	}
 	// Run the consensus preparation with the default or customized consensus engine.
 	if err := w.engine.Prepare(w.chain, header); err != nil {


### PR DESCRIPTION
This is in preparation for the shadow fork. It appeared, while performing the overlay transition with Kaustinen rebased on shapella, that the conversion at a slot after genesis got broken. Bugs happened because the transition was executed multiple times at the same block height, but the iterator pointers were not rewound.

This PR introduces per-block iterator pointers. More exactly, iterator pointers are related to the state root hash of the parent of the block that uses these iterators. If a block is reexecuted multiple times, then the pointers that are used will be initialized with how they were when that parent block was sealed.

The choice of linking the iterator pointers to the parent root hash instead of e.g. the slot number, comes from the fact that it's simpler to code. We might (probably will, in fact) change that after some refactoring, e.g. a rebase of the kaustinen branch on top of PBSS. Right now, this should be good enough for a reorg-less shadowfork.