### PR TITLE
proof: verify keys, pre-state and post-state

### DIFF
--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -158,7 +158,7 @@ func (b *testWorkerBackend) newRandomVerkleUncle() *types.Block {
 	} else {
 		parent = b.chain.GetBlockByHash(b.chain.CurrentBlock().ParentHash)
 	}
-	blocks, _, _, _ := core.GenerateVerkleChain(b.chain.Config(), parent, b.chain.Engine(), b.db, 1, func(i int, gen *core.BlockGen) {
+	blocks, _, _, _, _ := core.GenerateVerkleChain(b.chain.Config(), parent, b.chain.Engine(), b.db, 1, func(i int, gen *core.BlockGen) {
 		var addr = make([]byte, common.AddressLength)
 		rand.Read(addr)
 		gen.SetCoinbase(common.BytesToAddress(addr))


### PR DESCRIPTION
This PR improves the proof verification code in many ways:
- We now check that the claimed keys in the proof actually match what we computed during the EVM block execution using the access witness.
- Same with the pre-state values, which we weren't checking.
- The post-state values validation now doesn't require building the post-state tree. What we do is use `trie.VerkleTrie` APIs to collect all tree-writes while StateDB dumps the dirty objects into the tree to calculate the new root. We then use these tree writes to figure which are the correct post-state values.

More about each point in comments.