### PR TITLE
save per-block conversion pointers, without ended and started

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1746,7 +1746,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		}
 
 		if parent.Number.Uint64() == conversionBlock {
-			bc.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), &parent.Time)
+			bc.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), &parent.Time, parent.Root)
 			bc.stateCache.SetLastMerkleRoot(parent.Root)
 		}
 		statedb, err := state.New(parent.Root, bc.stateCache, bc.snaps)
@@ -2532,8 +2532,8 @@ func (bc *BlockChain) GetTrieFlushInterval() time.Duration {
 	return time.Duration(bc.flushInterval.Load())
 }
 
-func (bc *BlockChain) StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, pragueTime *uint64) {
-	bc.stateCache.StartVerkleTransition(originalRoot, translatedRoot, chainConfig, pragueTime)
+func (bc *BlockChain) StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, pragueTime *uint64, root common.Hash) {
+	bc.stateCache.StartVerkleTransition(originalRoot, translatedRoot, chainConfig, pragueTime, root)
 }
 func (bc *BlockChain) ReorgThroughVerkleTransition() {
 	bc.stateCache.ReorgThroughVerkleTransition()

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -425,8 +425,8 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 		return nil, nil
 	}
 	var snaps *snapshot.Tree
+	triedb := state.NewDatabaseWithConfig(db, &trie.Config{Verkle: true})
 	for i := 0; i < n; i++ {
-		triedb := state.NewDatabaseWithConfig(db, nil)
 		triedb.EndVerkleTransition()
 		statedb, err := state.New(parent.Root(), triedb, snaps)
 		if err != nil {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -64,7 +64,7 @@ type Database interface {
 	// TrieDB retrieves the low level trie database used for data storage.
 	TrieDB() *trie.Database
 
-	StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, cancunTime *uint64)
+	StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, cancunTime *uint64, root common.Hash)
 
 	ReorgThroughVerkleTransition()
 
@@ -74,27 +74,27 @@ type Database interface {
 
 	Transitioned() bool
 
-	SetCurrentSlotHash(hash common.Hash)
+	SetCurrentSlotHash(common.Hash, common.Hash)
 
-	GetCurrentAccountAddress() *common.Address
+	GetCurrentAccountAddress(common.Hash) *common.Address
 
-	SetCurrentAccountAddress(common.Address)
+	SetCurrentAccountAddress(common.Address, common.Hash)
 
-	GetCurrentAccountHash() common.Hash
+	GetCurrentAccountHash(common.Hash) common.Hash
 
-	GetCurrentSlotHash() common.Hash
+	GetCurrentSlotHash(common.Hash) common.Hash
 
-	SetStorageProcessed(bool)
+	SetStorageProcessed(bool, common.Hash)
 
-	GetStorageProcessed() bool
+	GetStorageProcessed(common.Hash) bool
 
-	GetCurrentPreimageOffset() int64
+	GetCurrentPreimageOffset(common.Hash) int64
 
-	SetCurrentPreimageOffset(int64)
+	SetCurrentPreimageOffset(int64, common.Hash)
 
 	AddRootTranslation(originalRoot, translatedRoot common.Hash)
 
-	SetLastMerkleRoot(root common.Hash)
+	SetLastMerkleRoot(common.Hash)
 }
 
 // Trie is a Ethereum Merkle Patricia trie.
@@ -187,6 +187,10 @@ func NewDatabaseWithConfig(db ethdb.Database, config *trie.Config) Database {
 		codeCache:     lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
 		triedb:        trie.NewDatabaseWithConfig(db, config),
 		addrToPoint:   utils.NewPointCache(),
+		StorageProcessed:      map[common.Hash]bool{},
+		CurrentAccountAddress: map[common.Hash]*common.Address{},
+		CurrentSlotHash:       map[common.Hash]common.Hash{},
+		CurrentPreimageOffset: map[common.Hash]int64{},
 	}
 }
 
@@ -199,6 +203,10 @@ func NewDatabaseWithNodeDB(db ethdb.Database, triedb *trie.Database) Database {
 		triedb:        triedb,
 		addrToPoint:   utils.NewPointCache(),
 		ended:         triedb.IsVerkle(),
+		StorageProcessed:      map[common.Hash]bool{},
+		CurrentAccountAddress: map[common.Hash]*common.Address{},
+		CurrentSlotHash:       map[common.Hash]common.Hash{},
+		CurrentPreimageOffset: map[common.Hash]int64{},
 	}
 }
 
@@ -211,7 +219,7 @@ func (db *cachingDB) Transitioned() bool {
 }
 
 // Fork implements the fork
-func (db *cachingDB) StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, pragueTime *uint64) {
+func (db *cachingDB) StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, pragueTime *uint64, root common.Hash) {
 	fmt.Println(`
 	__________.__                       .__                .__                   __       .__                               .__          ____         
 	\__    ___|  |__   ____        ____ |  |   ____ ______ |  |__ _____    _____/  |_     |  |__ _____    ______    __  _  _|__| ____   / ___\ ______
@@ -224,7 +232,13 @@ func (db *cachingDB) StartVerkleTransition(originalRoot, translatedRoot common.H
 	// db.AddTranslation(originalRoot, translatedRoot)
 	db.baseRoot = originalRoot
 	// initialize so that the first storage-less accounts are processed
-	db.StorageProcessed = true
+	db.StorageProcessed[root] = true
+
+	// Reinitialize values in case of a reorg
+	db.CurrentAccountAddress[root] = &(common.Address{})
+	db.CurrentSlotHash[root] = common.Hash{}
+	db.CurrentPreimageOffset[root] = 0
+
 	if pragueTime != nil {
 		chainConfig.PragueTime = pragueTime
 	}
@@ -263,14 +277,14 @@ type cachingDB struct {
 	addrToPoint *utils.PointCache
 
 	baseRoot              common.Hash     // hash of the read-only base tree
-	CurrentAccountAddress *common.Address // addresss of the last translated account
-	CurrentSlotHash       common.Hash     // hash of the last translated storage slot
-	CurrentPreimageOffset int64           // next byte to read from the preimage file
+	CurrentAccountAddress map[common.Hash]*common.Address // addresss of the last translated account
+	CurrentSlotHash       map[common.Hash]common.Hash     // hash of the last translated storage slot
+	CurrentPreimageOffset map[common.Hash]int64           // next byte to read from the preimage file
 
 	// Mark whether the storage for an account has been processed. This is useful if the
 	// maximum number of leaves of the conversion is reached before the whole storage is
 	// processed.
-	StorageProcessed bool
+	StorageProcessed map[common.Hash]bool
 }
 
 func (db *cachingDB) openMPTTrie(root common.Hash) (Trie, error) {
@@ -450,49 +464,49 @@ func (db *cachingDB) GetTreeKeyHeader(addr []byte) *verkle.Point {
 	return db.addrToPoint.GetTreeKeyHeader(addr)
 }
 
-func (db *cachingDB) SetCurrentAccountAddress(addr common.Address) {
-	db.CurrentAccountAddress = &addr
+func (db *cachingDB) SetCurrentAccountAddress(addr common.Address, root common.Hash) {
+	db.CurrentAccountAddress[root] = &addr
 }
 
-func (db *cachingDB) GetCurrentAccountHash() common.Hash {
+func (db *cachingDB) GetCurrentAccountHash(root common.Hash) common.Hash {
 	var addrHash common.Hash
-	if db.CurrentAccountAddress != nil {
-		addrHash = crypto.Keccak256Hash(db.CurrentAccountAddress[:])
+	if db.CurrentAccountAddress[root] != nil {
+		addrHash = crypto.Keccak256Hash(db.CurrentAccountAddress[root][:])
 	}
 	return addrHash
 }
 
-func (db *cachingDB) GetCurrentAccountAddress() *common.Address {
-	return db.CurrentAccountAddress
+func (db *cachingDB) GetCurrentAccountAddress(root common.Hash) *common.Address {
+	return db.CurrentAccountAddress[root]
 }
 
-func (db *cachingDB) GetCurrentPreimageOffset() int64 {
-	return db.CurrentPreimageOffset
+func (db *cachingDB) GetCurrentPreimageOffset(root common.Hash) int64 {
+	return db.CurrentPreimageOffset[root]
 }
 
-func (db *cachingDB) SetCurrentPreimageOffset(offset int64) {
-	db.CurrentPreimageOffset = offset
+func (db *cachingDB) SetCurrentPreimageOffset(offset int64, root common.Hash) {
+	db.CurrentPreimageOffset[root] = offset
 }
 
-func (db *cachingDB) SetCurrentSlotHash(hash common.Hash) {
-	db.CurrentSlotHash = hash
+func (db *cachingDB) SetCurrentSlotHash(hash common.Hash, root common.Hash) {
+	db.CurrentSlotHash[root] = hash
 }
 
-func (db *cachingDB) GetCurrentSlotHash() common.Hash {
-	return db.CurrentSlotHash
+func (db *cachingDB) GetCurrentSlotHash(root common.Hash) common.Hash {
+	return db.CurrentSlotHash[root]
 }
 
-func (db *cachingDB) SetStorageProcessed(processed bool) {
-	db.StorageProcessed = processed
+func (db *cachingDB) SetStorageProcessed(processed bool, root common.Hash) {
+	db.StorageProcessed[root] = processed
 }
 
-func (db *cachingDB) GetStorageProcessed() bool {
-	return db.StorageProcessed
+func (db *cachingDB) GetStorageProcessed(root common.Hash) bool {
+	return db.StorageProcessed[root]
 }
 
 func (db *cachingDB) AddRootTranslation(originalRoot, translatedRoot common.Hash) {
 }
 
-func (db *cachingDB) SetLastMerkleRoot(root common.Hash) {
-	db.LastMerkleRoot = root
+func (db *cachingDB) SetLastMerkleRoot(merkleRoot common.Hash) {
+	db.LastMerkleRoot = merkleRoot
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -106,7 +106,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 
 	// Perform the overlay transition, if relevant
-	if err := OverlayVerkleTransition(statedb); err != nil {
+	parent := p.bc.GetHeaderByHash(header.ParentHash)
+	if err := OverlayVerkleTransition(statedb, parent.Root); err != nil {
 		return nil, nil, 0, fmt.Errorf("error performing verkle overlay transition: %w", err)
 	}
 

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -532,7 +532,7 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 	if api.eth.BlockChain().Config().IsPrague(block.Number(), block.Time()) && !api.eth.BlockChain().Config().IsPrague(parent.Number(), parent.Time()) {
 		parent := api.eth.BlockChain().GetHeaderByNumber(block.NumberU64() - 1)
 		if !api.eth.BlockChain().Config().IsPrague(parent.Number, parent.Time) {
-			api.eth.BlockChain().StartVerkleTransition(parent.Root, common.Hash{}, api.eth.BlockChain().Config(), nil)
+			api.eth.BlockChain().StartVerkleTransition(parent.Root, common.Hash{}, api.eth.BlockChain().Config(), nil, parent.Root)
 		}
 	}
 	// Reset db merge state in case of a reorg

--- a/light/trie.go
+++ b/light/trie.go
@@ -101,7 +101,7 @@ func (db *odrDatabase) DiskDB() ethdb.KeyValueStore {
 	panic("not implemented")
 }
 
-func (db *odrDatabase) StartVerkleTransition(originalRoot common.Hash, translatedRoot common.Hash, chainConfig *params.ChainConfig, _ *uint64) {
+func (db *odrDatabase) StartVerkleTransition(originalRoot common.Hash, translatedRoot common.Hash, chainConfig *params.ChainConfig, _ *uint64, _ common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/light/trie.go
+++ b/light/trie.go
@@ -121,47 +121,47 @@ func (db *odrDatabase) Transitioned() bool {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetCurrentSlotHash(hash common.Hash) {
+func (db *odrDatabase) SetCurrentSlotHash(common.Hash, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentAccountAddress() *common.Address {
+func (db *odrDatabase) GetCurrentAccountAddress(common.Hash) *common.Address {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetCurrentAccountAddress(_ common.Address) {
+func (db *odrDatabase) SetCurrentAccountAddress(common.Address, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentAccountHash() common.Hash {
+func (db *odrDatabase) GetCurrentAccountHash(common.Hash) common.Hash {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentSlotHash() common.Hash {
+func (db *odrDatabase) GetCurrentSlotHash(common.Hash) common.Hash {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetStorageProcessed(_ bool) {
+func (db *odrDatabase) SetStorageProcessed(bool, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetStorageProcessed() bool {
+func (db *odrDatabase) GetStorageProcessed(common.Hash) bool {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentPreimageOffset() int64 {
+func (db *odrDatabase) GetCurrentPreimageOffset(common.Hash) int64 {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetCurrentPreimageOffset(_ int64) {
+func (db *odrDatabase) SetCurrentPreimageOffset(int64, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) AddRootTranslation(originalRoot common.Hash, translatedRoot common.Hash) {
+func (db *odrDatabase) AddRootTranslation(common.Hash, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetLastMerkleRoot(root common.Hash) {
+func (db *odrDatabase) SetLastMerkleRoot(common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -894,7 +894,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	if w.chain.Config().IsPrague(header.Number, header.Time) {
 		parent := w.chain.GetHeaderByNumber(header.Number.Uint64() - 1)
 		if !w.chain.Config().IsPrague(parent.Number, parent.Time) {
-			w.chain.StartVerkleTransition(parent.Root, common.Hash{}, w.chain.Config(), nil)
+			w.chain.StartVerkleTransition(parent.Root, common.Hash{}, w.chain.Config(), nil, parent.Root)
 		}
 	}
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -905,7 +905,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		return nil, err
 	}
 	if w.chain.Config().IsPrague(header.Number, header.Time) {
-		core.OverlayVerkleTransition(state)
+		core.OverlayVerkleTransition(state, parent.Root)
 	}
 	// Run the consensus preparation with the default or customized consensus engine.
 	if err := w.engine.Prepare(w.chain, header); err != nil {


### PR DESCRIPTION
This is a rewrite of #298 in which `started` and `ended` are kept global.

TODO:

 * [x] check the verkle test passes in `state_processor_test.go`
 * [ ] check that on spindevnets
 * [ ] confirm it still works with kaustinen
 * [ ] check that the `root` argument in `StartVerkleTransition` isn't redudant with `originalRoot`.