### PR TITLE
post-genesis transition

### DIFF
--- a/.github/workflows/conversion.yml
+++ b/.github/workflows/conversion.yml
@@ -1,0 +1,75 @@
+name: Overlay conversion
+
+on:
+  push:
+    branches: [ master, transition-post-genesis, store-transition-state-in-db ]
+  pull_request:
+    branches: [ master, kaustinen-with-shapella, transition-post-genesis, store-transition-state-in-db, lock-overlay-transition  ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.21.1
+
+      - name: Cleanup from previous runs
+        run: |
+          rm -f log.txt
+          rm -rf .shadowfork
+          rm -f genesis.json
+
+      - name: Download genesis file
+        run: wget https://gist.githubusercontent.com/gballet/0b02a025428aa0e7b67941864d54716c/raw/bfb4e158bca5217b356a19b2ec55c4a45a7b2bad/genesis.json
+
+      - name: Init data
+        run: go run ./cmd/geth --dev --cache.preimages init genesis.json
+
+      - name: Run geth in devmode
+        run: go run ./cmd/geth --dev --dev.period=5 --cache.preimages --http --datadir=.shadowfork --override.overlay-stride=10 --override.prague=$(($(date +%s) + 45)) > log.txt &
+
+      - name: Wait for the transition to start
+        run: |
+          start_time=$(date +%s)
+          while true; do
+            sleep 5
+            current_time=$(date +%s)
+            elapsed_time=$((current_time - start_time))
+
+            # 2 minute timeout
+            if [ $elapsed_time -ge 120 ]; then
+              kill -9 $(pgrep -f geth)
+              exit 1
+            fi
+
+            # Check for signs that the conversion has started
+            if grep -q "Processing verkle conversion starting at" log.txt; then
+              break
+            fi
+          done
+
+      - name: Wait for the transition to end
+        run: |
+          start_time=$(date +%s)
+          while true; do
+            sleep 5
+            current_time=$(date +%s)
+            elapsed_time=$((current_time - start_time))
+
+            # 10 minute timeout
+            if [ $elapsed_time -ge 300 ]; then
+              cat log.txt
+              kill -9 $(pgrep -f geth)
+              exit 1
+            fi
+
+            # Check for signs that the conversion has started
+            if egrep -q "at block.*performing transition\? false" log.txt; then
+              kill -9 $(pgrep -f geth)
+              break
+            fi
+          done

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -175,6 +175,10 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		v := ctx.Uint64(utils.OverridePrague.Name)
 		cfg.Eth.OverridePrague = &v
 	}
+	if ctx.IsSet(utils.OverrideProofInBlock.Name) {
+		v := ctx.Bool(utils.OverrideProofInBlock.Name)
+		cfg.Eth.OverrideProofInBlock = &v
+	}
 	backend, eth := utils.RegisterEthService(stack, &cfg.Eth)
 
 	// Configure log filter RPC API.

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -183,6 +183,9 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		v := ctx.Uint64(utils.OverrideOverlayStride.Name)
 		cfg.Eth.OverrideOverlayStride = &v
 	}
+	if ctx.IsSet(utils.ClearVerkleCosts.Name) {
+		params.ClearVerkleWitnessCosts()
+	}
 	backend, eth := utils.RegisterEthService(stack, &cfg.Eth)
 
 	// Configure log filter RPC API.

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -179,6 +179,10 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		v := ctx.Bool(utils.OverrideProofInBlock.Name)
 		cfg.Eth.OverrideProofInBlock = &v
 	}
+	if ctx.IsSet(utils.OverrideOverlayStride.Name) {
+		v := ctx.Uint64(utils.OverrideOverlayStride.Name)
+		cfg.Eth.OverrideOverlayStride = &v
+	}
 	backend, eth := utils.RegisterEthService(stack, &cfg.Eth)
 
 	// Configure log filter RPC API.

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -69,6 +69,7 @@ var (
 		utils.SmartCardDaemonPathFlag,
 		utils.OverrideCancun,
 		utils.OverridePrague,
+		utils.OverrideProofInBlock,
 		utils.EnablePersonal,
 		utils.TxPoolLocalsFlag,
 		utils.TxPoolNoLocalsFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -67,6 +67,7 @@ var (
 		utils.NoUSBFlag,
 		utils.USBFlag,
 		utils.SmartCardDaemonPathFlag,
+		utils.OverrideOverlayStride,
 		utils.OverrideCancun,
 		utils.OverridePrague,
 		utils.OverrideProofInBlock,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -71,6 +71,7 @@ var (
 		utils.OverrideCancun,
 		utils.OverridePrague,
 		utils.OverrideProofInBlock,
+		utils.ClearVerkleCosts,
 		utils.EnablePersonal,
 		utils.TxPoolLocalsFlag,
 		utils.TxPoolNoLocalsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -273,6 +273,11 @@ var (
 		Usage:    "Manually specify the Verkle fork timestamp, overriding the bundled setting",
 		Category: flags.EthCategory,
 	}
+	OverrideProofInBlock = &cli.BoolFlag{
+		Name:     "override.blockproof",
+		Usage:    "Manually specify the proof-in-block setting",
+		Category: flags.EthCategory,
+	}
 	// Light server and client settings
 	LightServeFlag = &cli.IntFlag{
 		Name:     "light.serve",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -263,6 +263,12 @@ var (
 		Value:    2048,
 		Category: flags.EthCategory,
 	}
+	OverrideOverlayStride = &cli.Uint64Flag{
+		Name:     "override.overlay-stride",
+		Usage:    "Manually specify the stride of the overlay transition, overriding the bundled setting",
+		Value:    10000,
+		Category: flags.EthCategory,
+	}
 	OverrideCancun = &cli.Uint64Flag{
 		Name:     "override.cancun",
 		Usage:    "Manually specify the Cancun fork timestamp, overriding the bundled setting",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -284,6 +284,11 @@ var (
 		Usage:    "Manually specify the proof-in-block setting",
 		Category: flags.EthCategory,
 	}
+	ClearVerkleCosts = &cli.BoolFlag{
+		Name:     "clear.verkle.costs",
+		Usage:    "Clear verkle costs (for shadow forks)",
+		Category: flags.EthCategory,
+	}
 	// Light server and client settings
 	LightServeFlag = &cli.IntFlag{
 		Name:     "light.serve",

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/overlay"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
@@ -368,7 +369,9 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 	if chain.Config().IsPrague(header.Number, header.Time) {
 		fmt.Println("at block", header.Number, "performing transition?", state.Database().InTransition())
 		parent := chain.GetHeaderByHash(header.ParentHash)
-		overlay.OverlayVerkleTransition(state, parent.Root, chain.Config().OverlayStride)
+		if err := overlay.OverlayVerkleTransition(state, parent.Root, chain.Config().OverlayStride); err != nil {
+			log.Error("error performing the transition", "err", err)
+		}
 	}
 }
 
@@ -394,63 +397,68 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 
 	// Assign the final state root to header.
 	header.Root = state.IntermediateRoot(true)
+	state.Database().SaveTransitionState(header.Root)
 
 	var (
 		p    *verkle.VerkleProof
 		k    verkle.StateDiff
 		keys = state.Witness().Keys()
 	)
-	if chain.Config().IsPrague(header.Number, header.Time) && chain.Config().ProofInBlocks {
+	if chain.Config().IsPrague(header.Number, header.Time) {
 		// Open the pre-tree to prove the pre-state against
 		parent := chain.GetHeaderByNumber(header.Number.Uint64() - 1)
 		if parent == nil {
 			return nil, fmt.Errorf("nil parent header for block %d", header.Number)
 		}
 
-		preTrie, err := state.Database().OpenTrie(parent.Root)
-		if err != nil {
-			return nil, fmt.Errorf("error opening pre-state tree root: %w", err)
-		}
+		state.Database().LoadTransitionState(parent.Root)
 
-		var okpre, okpost bool
-		var vtrpre, vtrpost *trie.VerkleTrie
-		switch pre := preTrie.(type) {
-		case *trie.VerkleTrie:
-			vtrpre, okpre = preTrie.(*trie.VerkleTrie)
-			switch tr := state.GetTrie().(type) {
+		if chain.Config().ProofInBlocks {
+			preTrie, err := state.Database().OpenTrie(parent.Root)
+			if err != nil {
+				return nil, fmt.Errorf("error opening pre-state tree root: %w", err)
+			}
+
+			var okpre, okpost bool
+			var vtrpre, vtrpost *trie.VerkleTrie
+			switch pre := preTrie.(type) {
 			case *trie.VerkleTrie:
-				vtrpost = tr
-				okpost = true
-			// This is to handle a situation right at the start of the conversion:
-			// the post trie is a transition tree when the pre tree is an empty
-			// verkle tree.
+				vtrpre, okpre = preTrie.(*trie.VerkleTrie)
+				switch tr := state.GetTrie().(type) {
+				case *trie.VerkleTrie:
+					vtrpost = tr
+					okpost = true
+				// This is to handle a situation right at the start of the conversion:
+				// the post trie is a transition tree when the pre tree is an empty
+				// verkle tree.
+				case *trie.TransitionTrie:
+					vtrpost = tr.Overlay()
+					okpost = true
+				default:
+					okpost = false
+				}
 			case *trie.TransitionTrie:
-				vtrpost = tr.Overlay()
+				vtrpre = pre.Overlay()
+				okpre = true
+				post, _ := state.GetTrie().(*trie.TransitionTrie)
+				vtrpost = post.Overlay()
 				okpost = true
 			default:
-				okpost = false
+				// This should only happen for the first block of the
+				// conversion, when the previous tree is a merkle tree.
+				//  Logically, the "previous" verkle tree is an empty tree.
+				okpre = true
+				vtrpre = trie.NewVerkleTrie(verkle.New(), state.Database().TrieDB(), utils.NewPointCache(), false)
+				post := state.GetTrie().(*trie.TransitionTrie)
+				vtrpost = post.Overlay()
+				okpost = true
 			}
-		case *trie.TransitionTrie:
-			vtrpre = pre.Overlay()
-			okpre = true
-			post, _ := state.GetTrie().(*trie.TransitionTrie)
-			vtrpost = post.Overlay()
-			okpost = true
-		default:
-			// This should only happen for the first block of the
-			// conversion, when the previous tree is a merkle tree.
-			//  Logically, the "previous" verkle tree is an empty tree.
-			okpre = true
-			vtrpre = trie.NewVerkleTrie(verkle.New(), state.Database().TrieDB(), utils.NewPointCache(), false)
-			post := state.GetTrie().(*trie.TransitionTrie)
-			vtrpost = post.Overlay()
-			okpost = true
-		}
-		if okpre && okpost {
-			if len(keys) > 0 {
-				p, k, err = trie.ProveAndSerialize(vtrpre, vtrpost, keys, vtrpre.FlatdbNodeResolver)
-				if err != nil {
-					return nil, fmt.Errorf("error generating verkle proof for block %d: %w", header.Number, err)
+			if okpre && okpost {
+				if len(keys) > 0 {
+					p, k, err = trie.ProveAndSerialize(vtrpre, vtrpost, keys, vtrpre.FlatdbNodeResolver)
+					if err != nil {
+						return nil, fmt.Errorf("error generating verkle proof for block %d: %w", header.Number, err)
+					}
 				}
 			}
 		}

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -410,7 +410,19 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 		switch pre := preTrie.(type) {
 		case *trie.VerkleTrie:
 			vtrpre, okpre = preTrie.(*trie.VerkleTrie)
-			vtrpost, okpost = state.GetTrie().(*trie.VerkleTrie)
+			switch tr := state.GetTrie().(type) {
+			case *trie.VerkleTrie:
+				vtrpost = tr
+				okpost = true
+			// This is to handle a situation right at the start of the conversion:
+			// the post trie is a transition tree when the pre tree is an empty
+			// verkle tree.
+			case *trie.TransitionTrie:
+				vtrpost = tr.Overlay()
+				okpost = true
+			default:
+				okpost = false
+			}
 		case *trie.TransitionTrie:
 			vtrpre = pre.Overlay()
 			okpre = true

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -368,7 +368,7 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 	if chain.Config().IsPrague(header.Number, header.Time) {
 		fmt.Println("at block", header.Number, "performing transition?", state.Database().InTransition())
 		parent := chain.GetHeaderByHash(header.ParentHash)
-		overlay.OverlayVerkleTransition(state, parent.Root)
+		overlay.OverlayVerkleTransition(state, parent.Root, chain.Config().OverlayStride)
 	}
 }
 

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
+	"github.com/ethereum/go-ethereum/core/overlay"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -362,6 +363,12 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 		state.Witness().TouchAddressOnWriteAndComputeGas(w.Address[:], uint256.Int{}, utils.NonceLeafKey)
 		state.Witness().TouchAddressOnWriteAndComputeGas(w.Address[:], uint256.Int{}, utils.CodeKeccakLeafKey)
 		state.Witness().TouchAddressOnWriteAndComputeGas(w.Address[:], uint256.Int{}, utils.CodeSizeLeafKey)
+	}
+
+	if chain.Config().IsPrague(header.Number, header.Time) {
+		fmt.Println("at block", header.Number, "performing transition?", state.Database().InTransition())
+		parent := chain.GetHeaderByHash(header.ParentHash)
+		overlay.OverlayVerkleTransition(state, parent.Root)
 	}
 }
 

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -411,6 +411,8 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 			return nil, fmt.Errorf("nil parent header for block %d", header.Number)
 		}
 
+		// Load transition state at beginning of block, because
+		// OpenTrie needs to know what the conversion status is.
 		state.Database().LoadTransitionState(parent.Root)
 
 		if chain.Config().ProofInBlocks {

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -131,6 +131,7 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 	if root := statedb.IntermediateRoot(v.config.IsEIP158(header.Number)); header.Root != root {
 		return fmt.Errorf("invalid merkle root (remote: %x local: %x) dberr: %w", header.Root, root, statedb.Error())
 	}
+	statedb.Database().SaveTransitionState(header.Root)
 	return nil
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -251,11 +251,13 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr
 	}
-	if overrides.OverrideProofInBlock != nil {
-		chainConfig.ProofInBlocks = *overrides.OverrideProofInBlock
-	}
-	if overrides.OverrideOverlayStride != nil {
-		chainConfig.OverlayStride = *overrides.OverrideOverlayStride
+	if overrides != nil {
+		if overrides.OverrideProofInBlock != nil {
+			chainConfig.ProofInBlocks = *overrides.OverrideProofInBlock
+		}
+		if overrides.OverrideOverlayStride != nil {
+			chainConfig.OverlayStride = *overrides.OverrideOverlayStride
+		}
 	}
 	log.Info("")
 	log.Info(strings.Repeat("-", 153))

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1767,6 +1767,8 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			// is the fork block and that the conversion needs to be marked at started.
 			if !bc.stateCache.InTransition() && !bc.stateCache.Transitioned() {
 				bc.stateCache.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), bc.Config().PragueTime, parent.Root)
+			} else {
+				log.Debug("skipped initialization")
 			}
 		}
 		if parent.Number.Uint64() == conversionBlock {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1767,8 +1767,6 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			// is the fork block and that the conversion needs to be marked at started.
 			if !bc.stateCache.InTransition() && !bc.stateCache.Transitioned() {
 				bc.stateCache.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), bc.Config().PragueTime, parent.Root)
-			} else {
-				log.Debug("skipped initialization")
 			}
 		}
 		if parent.Number.Uint64() == conversionBlock {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -251,6 +251,9 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr
 	}
+	if overrides.OverrideProofInBlock != nil {
+		chainConfig.ProofInBlocks = *overrides.OverrideProofInBlock
+	}
 	log.Info("")
 	log.Info(strings.Repeat("-", 153))
 	for _, line := range strings.Split(chainConfig.Description(), "\n") {
@@ -316,8 +319,8 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		// TODO this only works when resuming a chain that has already gone
 		// through the conversion. All pointers should be saved to the DB
 		// for it to be able to recover if interrupted during the transition
-   // but that's left out to a later PR since there's not really a need
-   // right now.
+		// but that's left out to a later PR since there's not really a need
+		// right now.
 		bc.stateCache.InitTransitionStatus(true, true)
 		bc.stateCache.EndVerkleTransition()
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -313,6 +313,12 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 
 	// Declare the end of the verkle transition if need be
 	if bc.chainConfig.Rules(head.Number, false /* XXX */, head.Time).IsPrague {
+		// TODO this only works when resuming a chain that has already gone
+		// through the conversion. All pointers should be saved to the DB
+		// for it to be able to recover if interrupted during the transition
+   // but that's left out to a later PR since there's not really a need
+   // right now.
+		bc.stateCache.InitTransitionStatus(true, true)
 		bc.stateCache.EndVerkleTransition()
 	}
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1747,7 +1747,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		}
 
 		if parent.Number.Uint64() == conversionBlock {
-			bc.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), &parent.Time)
+			bc.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), &parent.Time, parent.Root)
 			bc.stateCache.SetLastMerkleRoot(parent.Root)
 		}
 		statedb, err := state.New(parent.Root, bc.stateCache, bc.snaps)
@@ -2533,8 +2533,8 @@ func (bc *BlockChain) GetTrieFlushInterval() time.Duration {
 	return time.Duration(bc.flushInterval.Load())
 }
 
-func (bc *BlockChain) StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, pragueTime *uint64) {
-	bc.stateCache.StartVerkleTransition(originalRoot, translatedRoot, chainConfig, pragueTime)
+func (bc *BlockChain) StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, pragueTime *uint64, root common.Hash) {
+	bc.stateCache.StartVerkleTransition(originalRoot, translatedRoot, chainConfig, pragueTime, root)
 }
 func (bc *BlockChain) ReorgThroughVerkleTransition() {
 	bc.stateCache.ReorgThroughVerkleTransition()

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1768,6 +1768,11 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			if !bc.stateCache.InTransition() && !bc.stateCache.Transitioned() {
 				bc.stateCache.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), bc.Config().PragueTime, parent.Root)
 			}
+		} else {
+			// If the verkle activation time hasn't started, declare it as "not started".
+			// This is so that if the miner activates the conversion, the insertion happens
+			// in the correct mode.
+			bc.stateCache.InitTransitionStatus(false, false)
 		}
 		if parent.Number.Uint64() == conversionBlock {
 			bc.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), &parent.Time, parent.Root)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -254,6 +254,9 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	if overrides.OverrideProofInBlock != nil {
 		chainConfig.ProofInBlocks = *overrides.OverrideProofInBlock
 	}
+	if overrides.OverrideOverlayStride != nil {
+		chainConfig.OverlayStride = *overrides.OverrideOverlayStride
+	}
 	log.Info("")
 	log.Info(strings.Repeat("-", 153))
 	for _, line := range strings.Split(chainConfig.Description(), "\n") {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1758,6 +1758,15 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			parent = bc.GetHeader(block.ParentHash(), block.NumberU64()-1)
 		}
 
+		if bc.Config().IsPrague(block.Number(), block.Time()) {
+			bc.stateCache.LoadTransitionState(parent.Root)
+
+			// pragueTime has been reached. If the transition isn't active, it means this
+			// is the fork block and that the conversion needs to be marked at started.
+			if !bc.stateCache.InTransition() && !bc.stateCache.Transitioned() {
+				bc.stateCache.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), bc.Config().PragueTime, parent.Root)
+			}
+		}
 		if parent.Number.Uint64() == conversionBlock {
 			bc.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), &parent.Time, parent.Root)
 			bc.stateCache.SetLastMerkleRoot(parent.Root)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -103,7 +103,7 @@ const (
 	txLookupCacheLimit  = 1024
 	maxFutureBlocks     = 256
 	maxTimeFutureBlocks = 30
-	TriesInMemory       = 128
+	TriesInMemory       = 8192
 
 	// BlockChainVersion ensures that an incompatible database forces a resync from scratch.
 	//
@@ -2010,7 +2010,7 @@ func (bc *BlockChain) insertSideChain(block *types.Block, it *insertIterator) (i
 		parent = bc.GetHeader(parent.ParentHash, parent.Number.Uint64()-1)
 	}
 	if parent == nil {
-		return it.index, errors.New("missing parent")
+		return it.index, fmt.Errorf("missing parent: hash=%x, number=%d", current.Hash(), current.Number)
 	}
 	// Import all the pruned blocks to make the state available
 	var (
@@ -2071,7 +2071,7 @@ func (bc *BlockChain) recoverAncestors(block *types.Block) (common.Hash, error) 
 		}
 	}
 	if parent == nil {
-		return common.Hash{}, errors.New("missing parent")
+		return common.Hash{}, fmt.Errorf("missing parent during ancestor recovery: hash=%x, number=%d", block.ParentHash(), block.Number())
 	}
 	// Import all the pruned blocks to make the state available
 	for i := len(hashes) - 1; i >= 0; i-- {
@@ -2309,6 +2309,7 @@ func (bc *BlockChain) SetCanonical(head *types.Block) (common.Hash, error) {
 	defer bc.chainmu.Unlock()
 
 	// Re-execute the reorged chain in case the head state is missing.
+	log.Trace("looking for state", "root", head.Root(), "has state", bc.HasState(head.Root()))
 	if !bc.HasState(head.Root()) {
 		if latestValidHash, err := bc.recoverAncestors(head); err != nil {
 			return latestValidHash, err

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -435,8 +435,15 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 	}
 	var snaps *snapshot.Tree
 	triedb := state.NewDatabaseWithConfig(db, nil)
+	triedb.StartVerkleTransition(common.Hash{}, common.Hash{}, config, config.PragueTime, common.Hash{})
 	triedb.EndVerkleTransition()
+	//statedb, err := state.New(parent.Root(), triedb, snaps)
+	//if err != nil {
+	//	panic(fmt.Sprintf("could not find state for block %d: err=%v, parent root=%x", parent.NumberU64(), err, parent.Root()))
+	//}
+	statedb.Database().SaveTransitionState(parent.Root())
 	for i := 0; i < n; i++ {
+		// XXX merge uncommment
 		statedb, err := state.New(parent.Root(), triedb, snaps)
 		if err != nil {
 			panic(fmt.Sprintf("could not find state for block %d: err=%v, parent root=%x", i, err, parent.Root()))

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -365,7 +365,7 @@ func GenerateChainWithGenesis(genesis *Genesis, engine consensus.Engine, n int, 
 	return db, blocks, receipts
 }
 
-func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine consensus.Engine, db ethdb.Database, n int, gen func(int, *BlockGen)) ([]*types.Block, []types.Receipts, []*verkle.VerkleProof, []verkle.StateDiff) {
+func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine consensus.Engine, diskdb ethdb.Database, n int, gen func(int, *BlockGen)) ([]*types.Block, []types.Receipts, []*verkle.VerkleProof, []verkle.StateDiff) {
 	if config == nil {
 		config = params.TestChainConfig
 	}
@@ -434,20 +434,16 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 		return nil, nil
 	}
 	var snaps *snapshot.Tree
-	triedb := state.NewDatabaseWithConfig(db, nil)
-	triedb.StartVerkleTransition(common.Hash{}, common.Hash{}, config, config.PragueTime, common.Hash{})
-	triedb.EndVerkleTransition()
-	//statedb, err := state.New(parent.Root(), triedb, snaps)
-	//if err != nil {
-	//	panic(fmt.Sprintf("could not find state for block %d: err=%v, parent root=%x", parent.NumberU64(), err, parent.Root()))
-	//}
-	statedb.Database().SaveTransitionState(parent.Root())
+	db := state.NewDatabaseWithConfig(diskdb, nil)
+	db.StartVerkleTransition(common.Hash{}, common.Hash{}, config, config.PragueTime, common.Hash{})
+	db.EndVerkleTransition()
+	db.SaveTransitionState(parent.Root())
 	for i := 0; i < n; i++ {
-		// XXX merge uncommment
-		statedb, err := state.New(parent.Root(), triedb, snaps)
+		statedb, err := state.New(parent.Root(), db, snaps)
 		if err != nil {
 			panic(fmt.Sprintf("could not find state for block %d: err=%v, parent root=%x", i, err, parent.Root()))
 		}
+		statedb.NewAccessWitness()
 		block, receipt := genblock(i, parent, statedb)
 		blocks[i] = block
 		receipts[i] = receipt

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -291,8 +291,9 @@ func (e *GenesisMismatchError) Error() string {
 
 // ChainOverrides contains the changes to chain config.
 type ChainOverrides struct {
-	OverrideCancun *uint64
-	OverridePrague *uint64
+	OverrideCancun       *uint64
+	OverridePrague       *uint64
+	OverrideProofInBlock *bool
 }
 
 // SetupGenesisBlock writes or updates the genesis block in db.

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -291,9 +291,10 @@ func (e *GenesisMismatchError) Error() string {
 
 // ChainOverrides contains the changes to chain config.
 type ChainOverrides struct {
-	OverrideCancun       *uint64
-	OverridePrague       *uint64
-	OverrideProofInBlock *bool
+	OverrideCancun        *uint64
+	OverridePrague        *uint64
+	OverrideProofInBlock  *bool
+	OverrideOverlayStride *uint64
 }
 
 // SetupGenesisBlock writes or updates the genesis block in db.

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -126,6 +126,7 @@ func (ga *GenesisAlloc) deriveHash(cfg *params.ChainConfig, timestamp uint64) (c
 	// all the derived states will be discarded to not pollute disk.
 	db := state.NewDatabase(rawdb.NewMemoryDatabase())
 	if cfg.IsPrague(big.NewInt(int64(0)), timestamp) {
+		db.StartVerkleTransition(common.Hash{}, common.Hash{}, cfg, &timestamp, common.Hash{})
 		db.EndVerkleTransition()
 	}
 	statedb, err := state.New(types.EmptyRootHash, db, nil)
@@ -146,15 +147,17 @@ func (ga *GenesisAlloc) deriveHash(cfg *params.ChainConfig, timestamp uint64) (c
 // flush is very similar with deriveHash, but the main difference is
 // all the generated states will be persisted into the given database.
 // Also, the genesis state specification will be flushed as well.
-func (ga *GenesisAlloc) flush(db ethdb.Database, triedb *trie.Database, blockhash common.Hash, cfg *params.ChainConfig) error {
-	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseWithNodeDB(db, triedb), nil)
-	if err != nil {
-		return err
+func (ga *GenesisAlloc) flush(db ethdb.Database, triedb *trie.Database, blockhash common.Hash, cfg *params.ChainConfig, timestamp *uint64) error {
+	database := state.NewDatabaseWithNodeDB(db, triedb)
+	// End the verkle conversion at genesis if the fork block is 0
+	if timestamp != nil && cfg.IsPrague(big.NewInt(int64(0)), *timestamp) {
+		database.StartVerkleTransition(common.Hash{}, common.Hash{}, cfg, timestamp, common.Hash{})
+		database.EndVerkleTransition()
 	}
 
-	// End the verkle conversion at genesis if the fork block is 0
-	if triedb.IsVerkle() {
-		statedb.Database().EndVerkleTransition()
+	statedb, err := state.New(types.EmptyRootHash, database, nil)
+	if err != nil {
+		return err
 	}
 
 	for addr, account := range *ga {
@@ -221,7 +224,7 @@ func CommitGenesisState(db ethdb.Database, triedb *trie.Database, blockhash comm
 			return errors.New("not found")
 		}
 	}
-	return alloc.flush(db, triedb, blockhash, config)
+	return alloc.flush(db, triedb, blockhash, config, nil)
 }
 
 // GenesisAccount is an account in the state of the genesis block.
@@ -536,7 +539,7 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *trie.Database) (*types.Block
 	// All the checks has passed, flush the states derived from the genesis
 	// specification as well as the specification itself into the provided
 	// database.
-	if err := g.Alloc.flush(db, triedb, block.Hash(), g.Config); err != nil {
+	if err := g.Alloc.flush(db, triedb, block.Hash(), g.Config, &g.Timestamp); err != nil {
 		return nil, err
 	}
 	rawdb.WriteTd(db, block.Hash(), block.NumberU64(), block.Difficulty())

--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -36,7 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/utils"
-	"github.com/gballet/go-verkle"
+	"github.com/ethereum/go-verkle"
 	"github.com/holiman/uint256"
 )
 

--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -223,6 +223,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 	// verkle transition: if the conversion process is in progress, move
 	// N values from the MPT into the verkle tree.
 	if migrdb.InTransition() {
+		fmt.Printf("Processing verkle conversion starting at %x %x, building on top of %x\n", migrdb.GetCurrentAccountHash(), migrdb.GetCurrentSlotHash(), root)
 		var (
 			now             = time.Now()
 			tt              = statedb.GetTrie().(*trie.TransitionTrie)

--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -217,7 +217,7 @@ func (kvm *keyValueMigrator) migrateCollectedKeyValues(tree *trie.VerkleTrie) er
 }
 
 // OverlayVerkleTransition contains the overlay conversion logic
-func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash) error {
+func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedCount uint64) error {
 	migrdb := statedb.Database()
 
 	// verkle transition: if the conversion process is in progress, move
@@ -274,14 +274,13 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash) error {
 			preimageSeek += int64(len(addr))
 		}
 
-		const maxMovedCount = 10000
 		// mkv will be assiting in the collection of up to maxMovedCount key values to be migrated to the VKT.
 		// It has internal caches to do efficient MPT->VKT key calculations, which will be discarded after
 		// this function.
 		mkv := newKeyValueMigrator()
 		// move maxCount accounts into the verkle tree, starting with the
 		// slots from the previous account.
-		count := 0
+		count := uint64(0)
 
 		// if less than maxCount slots were moved, move to the next account
 		for count < maxMovedCount {

--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -405,7 +405,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 		}
 		migrdb.SetCurrentPreimageOffset(preimageSeek)
 
-		log.Info("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account", statedb.Database().GetCurrentAccountHash())
+		log.Info("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account", statedb.Database().GetCurrentAccountHash(), "storage processed", statedb.Database().GetStorageProcessed(), "last storage", statedb.Database().GetCurrentSlotHash())
 
 		// Take all the collected key-values and prepare the new leaf values.
 		// This fires a background routine that will start doing the work that

--- a/core/rawdb/accessors_overlay.go
+++ b/core/rawdb/accessors_overlay.go
@@ -1,0 +1,30 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+func ReadVerkleTransitionState(db ethdb.KeyValueReader, hash common.Hash) ([]byte, error) {
+	return db.Get(transitionStateKey(hash))
+}
+
+func WriteVerkleTransitionState(db ethdb.KeyValueWriter, hash common.Hash, state []byte) error {
+	return db.Put(transitionStateKey(hash), state)
+}

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -122,6 +122,8 @@ var (
 
 	CliqueSnapshotPrefix = []byte("clique-")
 
+	VerkleTransitionStatePrefix = []byte("verkle-transition-state-")
+
 	preimageCounter    = metrics.NewRegisteredCounter("db/preimage/total", nil)
 	preimageHitCounter = metrics.NewRegisteredCounter("db/preimage/hits", nil)
 )
@@ -248,6 +250,11 @@ func accountTrieNodeKey(path []byte) []byte {
 // storageTrieNodeKey = trieNodeStoragePrefix + accountHash + nodePath.
 func storageTrieNodeKey(accountHash common.Hash, path []byte) []byte {
 	return append(append(trieNodeStoragePrefix, accountHash.Bytes()...), path...)
+}
+
+// transitionStateKey = transitionStatusKey + hash
+func transitionStateKey(hash common.Hash) []byte {
+	return append(VerkleTransitionStatePrefix, hash.Bytes()...)
 }
 
 // IsLegacyTrieNode reports whether a provided database entry is a legacy trie

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -19,7 +19,6 @@ package state
 import (
 	"errors"
 	"fmt"
-	"runtime/debug"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
@@ -238,7 +237,6 @@ func (db *cachingDB) StartVerkleTransition(originalRoot, translatedRoot common.H
 	if pragueTime != nil {
 		chainConfig.PragueTime = pragueTime
 	}
-	debug.PrintStack()
 }
 
 func (db *cachingDB) ReorgThroughVerkleTransition() {
@@ -357,7 +355,6 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 		// If the verkle conversion has ended, return a single
 		// verkle trie.
 		if db.CurrentTransitionState.ended {
-			debug.PrintStack()
 			log.Debug("transition ended, returning a simple verkle tree")
 			return vkt, nil
 		}
@@ -570,9 +567,8 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 	ts, ok := db.TransitionStatePerRoot[root]
 	if !ok || ts == nil {
 		log.Debug("could not find any transition state, starting with a fresh state", "is verkle", db.triedb.IsVerkle())
-		debug.PrintStack()
 		// Start with a fresh state
-		ts = &TransitionState{ended: db.triedb.IsVerkle()}
+		ts = &TransitionState{ended: false}
 	}
 
 	// Copy so that the CurrentAddress pointer in the map

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -401,6 +401,7 @@ func (db *cachingDB) OpenStorageTrie(stateRoot common.Hash, address common.Addre
 		}
 	}
 	if db.InTransition() {
+		fmt.Printf("OpenStorageTrie during transition, state root=%x root=%x\n", stateRoot, root)
 		mpt, err := db.openStorageMPTrie(db.LastMerkleRoot, address, root, nil)
 		if err != nil {
 			return nil, err

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -182,11 +182,11 @@ func NewDatabase(db ethdb.Database) Database {
 // large memory cache.
 func NewDatabaseWithConfig(db ethdb.Database, config *trie.Config) Database {
 	return &cachingDB{
-		disk:          db,
-		codeSizeCache: lru.NewCache[common.Hash, int](codeSizeCacheSize),
-		codeCache:     lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
-		triedb:        trie.NewDatabaseWithConfig(db, config),
-		addrToPoint:   utils.NewPointCache(),
+		disk:                  db,
+		codeSizeCache:         lru.NewCache[common.Hash, int](codeSizeCacheSize),
+		codeCache:             lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
+		triedb:                trie.NewDatabaseWithConfig(db, config),
+		addrToPoint:           utils.NewPointCache(),
 		StorageProcessed:      map[common.Hash]bool{},
 		CurrentAccountAddress: map[common.Hash]*common.Address{},
 		CurrentSlotHash:       map[common.Hash]common.Hash{},
@@ -197,12 +197,12 @@ func NewDatabaseWithConfig(db ethdb.Database, config *trie.Config) Database {
 // NewDatabaseWithNodeDB creates a state database with an already initialized node database.
 func NewDatabaseWithNodeDB(db ethdb.Database, triedb *trie.Database) Database {
 	return &cachingDB{
-		disk:          db,
-		codeSizeCache: lru.NewCache[common.Hash, int](codeSizeCacheSize),
-		codeCache:     lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
-		triedb:        triedb,
-		addrToPoint:   utils.NewPointCache(),
-		ended:         triedb.IsVerkle(),
+		disk:                  db,
+		codeSizeCache:         lru.NewCache[common.Hash, int](codeSizeCacheSize),
+		codeCache:             lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
+		triedb:                triedb,
+		addrToPoint:           utils.NewPointCache(),
+		ended:                 triedb.IsVerkle(),
 		StorageProcessed:      map[common.Hash]bool{},
 		CurrentAccountAddress: map[common.Hash]*common.Address{},
 		CurrentSlotHash:       map[common.Hash]common.Hash{},
@@ -275,7 +275,7 @@ type cachingDB struct {
 
 	addrToPoint *utils.PointCache
 
-	baseRoot              common.Hash     // hash of the read-only base tree
+	baseRoot              common.Hash                     // hash of the read-only base tree
 	CurrentAccountAddress map[common.Hash]*common.Address // addresss of the last translated account
 	CurrentSlotHash       map[common.Hash]common.Hash     // hash of the last translated storage slot
 	CurrentPreimageOffset map[common.Hash]int64           // next byte to read from the preimage file

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -552,7 +552,7 @@ func (db *cachingDB) SaveTransitionState(root common.Hash) {
 		// it has been saved.
 		db.TransitionStatePerRoot[root] = db.CurrentTransitionState.Copy()
 
-		log.Debug("saving transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
+		fmt.Println("saving transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
 	}
 }
 
@@ -566,7 +566,7 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 	// as a verkle database.
 	ts, ok := db.TransitionStatePerRoot[root]
 	if !ok || ts == nil {
-		log.Debug("could not find any transition state, starting with a fresh state", "is verkle", db.triedb.IsVerkle())
+		fmt.Println("could not find any transition state, starting with a fresh state", "is verkle", db.triedb.IsVerkle())
 		// Start with a fresh state
 		ts = &TransitionState{ended: false}
 	}
@@ -575,5 +575,5 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 	// doesn't get overwritten.
 	db.CurrentTransitionState = ts.Copy()
 
-	log.Debug("loaded transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
+	fmt.Println("loaded transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -413,7 +413,7 @@ func (db *cachingDB) OpenStorageTrie(stateRoot common.Hash, address common.Addre
 		case *trie.TransitionTrie:
 			return trie.NewTransitionTree(mpt.(*trie.SecureTrie), self.Overlay(), true), nil
 		default:
-			panic("unexpected trie type")
+			return nil, errors.New("expected a verkle account tree, and found another type")
 		}
 	}
 	mpt, err := db.openStorageMPTrie(stateRoot, address, root, nil)

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -284,6 +284,7 @@ func (ts *TransitionState) Copy() *TransitionState {
 		ended:                 ts.ended,
 		CurrentSlotHash:       ts.CurrentSlotHash,
 		CurrentPreimageOffset: ts.CurrentPreimageOffset,
+		StorageProcessed:      ts.StorageProcessed,
 	}
 
 	if ts.CurrentAccountAddress != nil {
@@ -563,4 +564,6 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 	// Copy so that the CurrentAddress pointer in the map
 	// doesn't get overwritten.
 	db.CurrentTransitionState = ts.Copy()
+
+	fmt.Println("loaded transition state", db.CurrentTransitionState.StorageProcessed)
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -19,6 +19,7 @@ package state
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
@@ -237,6 +238,7 @@ func (db *cachingDB) StartVerkleTransition(originalRoot, translatedRoot common.H
 	if pragueTime != nil {
 		chainConfig.PragueTime = pragueTime
 	}
+	debug.PrintStack()
 }
 
 func (db *cachingDB) ReorgThroughVerkleTransition() {
@@ -355,6 +357,7 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 		// If the verkle conversion has ended, return a single
 		// verkle trie.
 		if db.CurrentTransitionState.ended {
+			debug.PrintStack()
 			log.Debug("transition ended, returning a simple verkle tree")
 			return vkt, nil
 		}
@@ -566,6 +569,8 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 	// as a verkle database.
 	ts, ok := db.TransitionStatePerRoot[root]
 	if !ok || ts == nil {
+		log.Debug("could not find any transition state, starting with a fresh state", "is verkle", db.triedb.IsVerkle())
+		debug.PrintStack()
 		// Start with a fresh state
 		ts = &TransitionState{ended: db.triedb.IsVerkle()}
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1318,7 +1318,7 @@ func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, er
 			// - head layer is paired with HEAD state
 			// - head-1 layer is paired with HEAD-1 state
 			// - head-127 layer(bottom-most diff layer) is paired with HEAD-127 state
-			if err := s.snaps.Cap(root, 128); err != nil {
+			if err := s.snaps.Cap(root, 8192); err != nil {
 				log.Warn("Failed to cap snapshot tree", "root", root, "layers", 128, "err", err)
 			}
 		}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -176,10 +176,11 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 	if tr.IsVerkle() {
 		sdb.witness = sdb.NewAccessWitness()
 	}
-	// if sdb.snaps != nil {
-	// 	if sdb.snap = sdb.snaps.Snapshot(root); sdb.snap == nil {
-	// 	}
-	// }
+	if sdb.snaps != nil {
+		// 	if sdb.snap = sdb.snaps.Snapshot(root); sdb.snap == nil {
+		// 	}
+		sdb.snap = sdb.snaps.Snapshot(root)
+	}
 	return sdb, nil
 }
 

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -302,7 +302,7 @@ func (sf *subfetcher) loop() {
 		}
 		sf.trie = trie
 	} else {
-		trie, err := sf.db.OpenStorageTrie(sf.state, sf.addr, sf.root, nil /* safe to set to nil for now, as there is no prefetcher for verkle */)
+		trie, err := sf.db.OpenStorageTrie(sf.state, sf.addr, sf.root, sf.trie)
 		if err != nil {
 			log.Warn("Trie prefetcher failed opening trie", "root", sf.root, "err", err)
 			return

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -107,12 +107,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		return nil, nil, 0, errors.New("withdrawals before shanghai")
 	}
 
-	// Perform the overlay transition, if relevant
-	//parent := p.bc.GetHeaderByHash(header.ParentHash)
-	//if err := OverlayVerkleTransition(statedb, parent.Root); err != nil {
-	//	return nil, nil, 0, fmt.Errorf("error performing verkle overlay transition: %w", err)
-	//}
-
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.engine.Finalize(p.bc, header, statedb, block.Transactions(), block.Uncles(), withdrawals)
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -21,9 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"runtime"
-	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -34,11 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/trie"
-	"github.com/ethereum/go-ethereum/trie/utils"
-	tutils "github.com/ethereum/go-ethereum/trie/utils"
-	"github.com/ethereum/go-verkle"
-	"github.com/holiman/uint256"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -115,10 +107,10 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 
 	// Perform the overlay transition, if relevant
-	parent := p.bc.GetHeaderByHash(header.ParentHash)
-	if err := OverlayVerkleTransition(statedb, parent.Root); err != nil {
-		return nil, nil, 0, fmt.Errorf("error performing verkle overlay transition: %w", err)
-	}
+	//parent := p.bc.GetHeaderByHash(header.ParentHash)
+	//if err := OverlayVerkleTransition(statedb, parent.Root); err != nil {
+	//	return nil, nil, 0, fmt.Errorf("error performing verkle overlay transition: %w", err)
+	//}
 
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.engine.Finalize(p.bc, header, statedb, block.Transactions(), block.Uncles(), withdrawals)
@@ -192,190 +184,6 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	blockContext := NewEVMBlockContext(header, bc, author)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{BlobHashes: tx.BlobHashes()}, statedb, config, cfg)
 	return applyTransaction(msg, config, gp, statedb, header.Number, header.Hash(), tx, usedGas, vmenv)
-}
-
-var zeroTreeIndex uint256.Int
-
-// keyValueMigrator is a helper module that collects key-values from the overlay-tree migration for Verkle Trees.
-// It assumes that the walk of the base tree is done in address-order, so it exploit that fact to
-// collect the key-values in a way that is efficient.
-type keyValueMigrator struct {
-	// leafData contains the values for the future leaf for a particular VKT branch.
-	leafData []migratedKeyValue
-
-	// When prepare() is called, it will start a background routine that will process the leafData
-	// saving the result in newLeaves to be used by migrateCollectedKeyValues(). The background
-	// routine signals that it is done by closing processingReady.
-	processingReady chan struct{}
-	newLeaves       []verkle.LeafNode
-	prepareErr      error
-}
-
-func newKeyValueMigrator() *keyValueMigrator {
-	// We do initialize the VKT config since prepare() might indirectly make multiple GetConfig() calls
-	// in different goroutines when we never called GetConfig() before, causing a race considering the way
-	// that `config` is designed in go-verkle.
-	// TODO: jsign as a fix for this in the PR where we move to a file-less precomp, since it allows safe
-	//       concurrent calls to GetConfig(). When that gets merged, we can remove this line.
-	_ = verkle.GetConfig()
-	return &keyValueMigrator{
-		processingReady: make(chan struct{}),
-		leafData:        make([]migratedKeyValue, 0, 10_000),
-	}
-}
-
-type migratedKeyValue struct {
-	branchKey    branchKey
-	leafNodeData verkle.BatchNewLeafNodeData
-}
-type branchKey struct {
-	addr      common.Address
-	treeIndex uint256.Int
-}
-
-func newBranchKey(addr []byte, treeIndex *uint256.Int) branchKey {
-	var sk branchKey
-	copy(sk.addr[:], addr)
-	sk.treeIndex = *treeIndex
-	return sk
-}
-
-func (kvm *keyValueMigrator) addStorageSlot(addr []byte, slotNumber []byte, slotValue []byte) {
-	treeIndex, subIndex := tutils.GetTreeKeyStorageSlotTreeIndexes(slotNumber)
-	leafNodeData := kvm.getOrInitLeafNodeData(newBranchKey(addr, treeIndex))
-	leafNodeData.Values[subIndex] = slotValue
-}
-
-func (kvm *keyValueMigrator) addAccount(addr []byte, acc *types.StateAccount) {
-	leafNodeData := kvm.getOrInitLeafNodeData(newBranchKey(addr, &zeroTreeIndex))
-
-	var version [verkle.LeafValueSize]byte
-	leafNodeData.Values[tutils.VersionLeafKey] = version[:]
-
-	var balance [verkle.LeafValueSize]byte
-	for i, b := range acc.Balance.Bytes() {
-		balance[len(acc.Balance.Bytes())-1-i] = b
-	}
-	leafNodeData.Values[tutils.BalanceLeafKey] = balance[:]
-
-	var nonce [verkle.LeafValueSize]byte
-	binary.LittleEndian.PutUint64(nonce[:8], acc.Nonce)
-	leafNodeData.Values[tutils.NonceLeafKey] = nonce[:]
-
-	leafNodeData.Values[tutils.CodeKeccakLeafKey] = acc.CodeHash[:]
-}
-
-func (kvm *keyValueMigrator) addAccountCode(addr []byte, codeSize uint64, chunks []byte) {
-	leafNodeData := kvm.getOrInitLeafNodeData(newBranchKey(addr, &zeroTreeIndex))
-
-	// Save the code size.
-	var codeSizeBytes [verkle.LeafValueSize]byte
-	binary.LittleEndian.PutUint64(codeSizeBytes[:8], codeSize)
-	leafNodeData.Values[tutils.CodeSizeLeafKey] = codeSizeBytes[:]
-
-	// The first 128 chunks are stored in the account header leaf.
-	for i := 0; i < 128 && i < len(chunks)/32; i++ {
-		leafNodeData.Values[byte(128+i)] = chunks[32*i : 32*(i+1)]
-	}
-
-	// Potential further chunks, have their own leaf nodes.
-	for i := 128; i < len(chunks)/32; {
-		treeIndex, _ := tutils.GetTreeKeyCodeChunkIndices(uint256.NewInt(uint64(i)))
-		leafNodeData := kvm.getOrInitLeafNodeData(newBranchKey(addr, treeIndex))
-
-		j := i
-		for ; (j-i) < 256 && j < len(chunks)/32; j++ {
-			leafNodeData.Values[byte((j-128)%256)] = chunks[32*j : 32*(j+1)]
-		}
-		i = j
-	}
-}
-
-func (kvm *keyValueMigrator) getOrInitLeafNodeData(bk branchKey) *verkle.BatchNewLeafNodeData {
-	// Remember that keyValueMigration receives actions ordered by (address, subtreeIndex).
-	// This means that we can assume that the last element of leafData is the one that we
-	// are looking for, or that we need to create a new one.
-	if len(kvm.leafData) == 0 || kvm.leafData[len(kvm.leafData)-1].branchKey != bk {
-		kvm.leafData = append(kvm.leafData, migratedKeyValue{
-			branchKey: bk,
-			leafNodeData: verkle.BatchNewLeafNodeData{
-				Stem:   nil, // It will be calculated in the prepare() phase, since it's CPU heavy.
-				Values: make(map[byte][]byte),
-			},
-		})
-	}
-	return &kvm.leafData[len(kvm.leafData)-1].leafNodeData
-}
-
-func (kvm *keyValueMigrator) prepare() {
-	// We fire a background routine to process the leafData and save the result in newLeaves.
-	// The background routine signals that it is done by closing processingReady.
-	go func() {
-		// Step 1: We split kvm.leafData in numBatches batches, and we process each batch in a separate goroutine.
-		//         This fills each leafNodeData.Stem with the correct value.
-		var wg sync.WaitGroup
-		batchNum := runtime.NumCPU()
-		batchSize := (len(kvm.leafData) + batchNum - 1) / batchNum
-		for i := 0; i < len(kvm.leafData); i += batchSize {
-			start := i
-			end := i + batchSize
-			if end > len(kvm.leafData) {
-				end = len(kvm.leafData)
-			}
-			wg.Add(1)
-
-			batch := kvm.leafData[start:end]
-			go func() {
-				defer wg.Done()
-				var currAddr common.Address
-				var currPoint *verkle.Point
-				for i := range batch {
-					if batch[i].branchKey.addr != currAddr || currAddr == (common.Address{}) {
-						currAddr = batch[i].branchKey.addr
-						currPoint = tutils.EvaluateAddressPoint(currAddr[:])
-					}
-					stem := tutils.GetTreeKeyWithEvaluatedAddess(currPoint, &batch[i].branchKey.treeIndex, 0)
-					stem = stem[:verkle.StemSize]
-					batch[i].leafNodeData.Stem = stem
-				}
-			}()
-		}
-		wg.Wait()
-
-		// Step 2: Now that we have all stems (i.e: tree keys) calculated, we can create the new leaves.
-		nodeValues := make([]verkle.BatchNewLeafNodeData, len(kvm.leafData))
-		for i := range kvm.leafData {
-			nodeValues[i] = kvm.leafData[i].leafNodeData
-		}
-
-		// Create all leaves in batch mode so we can optimize cryptography operations.
-		kvm.newLeaves, kvm.prepareErr = verkle.BatchNewLeafNode(nodeValues)
-		close(kvm.processingReady)
-	}()
-}
-
-func (kvm *keyValueMigrator) migrateCollectedKeyValues(tree *trie.VerkleTrie) error {
-	now := time.Now()
-	<-kvm.processingReady
-	if kvm.prepareErr != nil {
-		return fmt.Errorf("failed to prepare key values: %w", kvm.prepareErr)
-	}
-	log.Info("Prepared key values from base tree", "duration", time.Since(now))
-
-	// Insert into the tree.
-	if err := tree.InsertMigratedLeaves(kvm.newLeaves); err != nil {
-		return fmt.Errorf("failed to insert migrated leaves: %w", err)
-	}
-
-	return nil
-}
-
-func InsertBlockHashHistoryAtEip2935Fork(statedb *state.StateDB, prevNumber uint64, prevHash common.Hash, chain consensus.ChainHeaderReader) {
-	ancestor := chain.GetHeader(prevHash, prevNumber)
-	for i := prevNumber; i > 0 && i >= prevNumber-256; i-- {
-		ProcessParentBlockHash(statedb, i, ancestor.Hash())
-		ancestor = chain.GetHeader(ancestor.ParentHash, ancestor.Number.Uint64()-1)
-	}
 }
 
 func ProcessParentBlockHash(statedb *state.StateDB, prevNumber uint64, prevHash common.Hash) {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -115,7 +115,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 
 	// Perform the overlay transition, if relevant
-	if err := OverlayVerkleTransition(statedb); err != nil {
+	parent := p.bc.GetHeaderByHash(header.ParentHash)
+	if err := OverlayVerkleTransition(statedb, parent.Root); err != nil {
 		return nil, nil, 0, fmt.Errorf("error performing verkle overlay transition: %w", err)
 	}
 
@@ -329,7 +330,7 @@ func (kvm *keyValueMigrator) prepare() {
 				var currAddr common.Address
 				var currPoint *verkle.Point
 				for i := range batch {
-					if batch[i].branchKey.addr != currAddr {
+					if batch[i].branchKey.addr != currAddr || currAddr == (common.Address{}) {
 						currAddr = batch[i].branchKey.addr
 						currPoint = tutils.EvaluateAddressPoint(currAddr[:])
 					}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -508,6 +508,10 @@ func (st *StateTransition) refundGas(refundQuotient uint64) {
 	remaining := new(big.Int).Mul(new(big.Int).SetUint64(st.gasRemaining), st.msg.GasPrice)
 	st.state.AddBalance(st.msg.From, remaining)
 
+	if st.gp.Gas() > math.MaxUint64-st.gasRemaining {
+		fmt.Println(st.gp.Gas(), refund, refundQuotient, st.gasUsed(), st.initialGas, st.gasUsed(), st.evm.Accesses, st.msg)
+	}
+
 	// Also return remaining gas to the block gas counter so it is
 	// available for the next transaction.
 	st.gp.AddGas(st.gasRemaining)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -204,6 +204,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if config.OverrideProofInBlock != nil {
 		overrides.OverrideProofInBlock = config.OverrideProofInBlock
 	}
+	if config.OverrideOverlayStride != nil {
+		overrides.OverrideOverlayStride = config.OverrideOverlayStride
+	}
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, eth.shouldPreserve, &config.TxLookupLimit)
 	if err != nil {
 		return nil, err

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -201,6 +201,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if config.OverridePrague != nil {
 		overrides.OverridePrague = config.OverridePrague
 	}
+	if config.OverrideProofInBlock != nil {
+		overrides.OverrideProofInBlock = config.OverrideProofInBlock
+	}
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, eth.shouldPreserve, &config.TxLookupLimit)
 	if err != nil {
 		return nil, err

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -532,7 +532,7 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 	if api.eth.BlockChain().Config().IsPrague(block.Number(), block.Time()) && !api.eth.BlockChain().Config().IsPrague(parent.Number(), parent.Time()) {
 		parent := api.eth.BlockChain().GetHeaderByNumber(block.NumberU64() - 1)
 		if !api.eth.BlockChain().Config().IsPrague(parent.Number, parent.Time) {
-			api.eth.BlockChain().StartVerkleTransition(parent.Root, common.Hash{}, api.eth.BlockChain().Config(), nil)
+			api.eth.BlockChain().StartVerkleTransition(parent.Root, common.Hash{}, api.eth.BlockChain().Config(), nil, parent.Root)
 		}
 	}
 	// Reset db merge state in case of a reorg

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -535,10 +535,6 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 			api.eth.BlockChain().StartVerkleTransition(parent.Root, common.Hash{}, api.eth.BlockChain().Config(), nil, parent.Root)
 		}
 	}
-	// // Reset db merge state in case of a reorg
-	// if !api.eth.BlockChain().Config().IsPrague(block.Number(), block.Time()) {
-	// 	api.eth.BlockChain().ReorgThroughVerkleTransition()
-	// }
 	// Another cornercase: if the node is in snap sync mode, but the CL client
 	// tries to make it import a block. That should be denied as pushing something
 	// into the database directly will conflict with the assumptions of snap sync

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -535,10 +535,10 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 			api.eth.BlockChain().StartVerkleTransition(parent.Root, common.Hash{}, api.eth.BlockChain().Config(), nil, parent.Root)
 		}
 	}
-	// Reset db merge state in case of a reorg
-	if !api.eth.BlockChain().Config().IsPrague(block.Number(), block.Time()) {
-		api.eth.BlockChain().ReorgThroughVerkleTransition()
-	}
+	// // Reset db merge state in case of a reorg
+	// if !api.eth.BlockChain().Config().IsPrague(block.Number(), block.Time()) {
+	// 	api.eth.BlockChain().ReorgThroughVerkleTransition()
+	// }
 	// Another cornercase: if the node is in snap sync mode, but the CL client
 	// tries to make it import a block. That should be denied as pushing something
 	// into the database directly will conflict with the assumptions of snap sync

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -158,6 +158,9 @@ type Config struct {
 
 	// OverrideVerkle (TODO: remove after the fork)
 	OverridePrague *uint64 `toml:",omitempty"`
+
+	// OverrideProofInBlock
+	OverrideProofInBlock *bool `toml:",omitempty"`
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -161,6 +161,9 @@ type Config struct {
 
 	// OverrideProofInBlock
 	OverrideProofInBlock *bool `toml:",omitempty"`
+
+	// OverrideOverlayStride
+	OverrideOverlayStride *uint64 `toml:",omitempty"`
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.

--- a/light/trie.go
+++ b/light/trie.go
@@ -101,7 +101,7 @@ func (db *odrDatabase) DiskDB() ethdb.KeyValueStore {
 	panic("not implemented")
 }
 
-func (db *odrDatabase) StartVerkleTransition(originalRoot common.Hash, translatedRoot common.Hash, chainConfig *params.ChainConfig, _ *uint64) {
+func (db *odrDatabase) StartVerkleTransition(originalRoot common.Hash, translatedRoot common.Hash, chainConfig *params.ChainConfig, _ *uint64, _ common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
@@ -121,47 +121,47 @@ func (db *odrDatabase) Transitioned() bool {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetCurrentSlotHash(hash common.Hash) {
+func (db *odrDatabase) SetCurrentSlotHash(common.Hash, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentAccountAddress() *common.Address {
+func (db *odrDatabase) GetCurrentAccountAddress(common.Hash) *common.Address {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetCurrentAccountAddress(_ common.Address) {
+func (db *odrDatabase) SetCurrentAccountAddress(common.Address, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentAccountHash() common.Hash {
+func (db *odrDatabase) GetCurrentAccountHash(common.Hash) common.Hash {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentSlotHash() common.Hash {
+func (db *odrDatabase) GetCurrentSlotHash(common.Hash) common.Hash {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetStorageProcessed(_ bool) {
+func (db *odrDatabase) SetStorageProcessed(bool, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetStorageProcessed() bool {
+func (db *odrDatabase) GetStorageProcessed(common.Hash) bool {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentPreimageOffset() int64 {
+func (db *odrDatabase) GetCurrentPreimageOffset(common.Hash) int64 {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetCurrentPreimageOffset(_ int64) {
+func (db *odrDatabase) SetCurrentPreimageOffset(int64, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) AddRootTranslation(originalRoot common.Hash, translatedRoot common.Hash) {
+func (db *odrDatabase) AddRootTranslation(common.Hash, common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetLastMerkleRoot(root common.Hash) {
+func (db *odrDatabase) SetLastMerkleRoot(common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/light/trie.go
+++ b/light/trie.go
@@ -177,6 +177,13 @@ func (db *odrDatabase) LoadTransitionState(common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
+func (db *odrDatabase) LockCurrentTransitionState() {
+	panic("not implemented") // TODO: Implement
+}
+func (db *odrDatabase) UnLockCurrentTransitionState() {
+	panic("not implemented") // TODO: Implement
+}
+
 type odrTrie struct {
 	db   *odrDatabase
 	id   *TrieID

--- a/light/trie.go
+++ b/light/trie.go
@@ -121,39 +121,43 @@ func (db *odrDatabase) Transitioned() bool {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetCurrentSlotHash(common.Hash, common.Hash) {
+func (db *odrDatabase) InitTransitionStatus(bool, bool) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentAccountAddress(common.Hash) *common.Address {
+func (db *odrDatabase) SetCurrentSlotHash(common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetCurrentAccountAddress(common.Address, common.Hash) {
+func (db *odrDatabase) GetCurrentAccountAddress() *common.Address {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentAccountHash(common.Hash) common.Hash {
+func (db *odrDatabase) SetCurrentAccountAddress(common.Address) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentSlotHash(common.Hash) common.Hash {
+func (db *odrDatabase) GetCurrentAccountHash() common.Hash {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetStorageProcessed(bool, common.Hash) {
+func (db *odrDatabase) GetCurrentSlotHash() common.Hash {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetStorageProcessed(common.Hash) bool {
+func (db *odrDatabase) SetStorageProcessed(bool) {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) GetCurrentPreimageOffset(common.Hash) int64 {
+func (db *odrDatabase) GetStorageProcessed() bool {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) SetCurrentPreimageOffset(int64, common.Hash) {
+func (db *odrDatabase) GetCurrentPreimageOffset() int64 {
+	panic("not implemented") // TODO: Implement
+}
+
+func (db *odrDatabase) SetCurrentPreimageOffset(int64) {
 	panic("not implemented") // TODO: Implement
 }
 
@@ -162,6 +166,14 @@ func (db *odrDatabase) AddRootTranslation(common.Hash, common.Hash) {
 }
 
 func (db *odrDatabase) SetLastMerkleRoot(common.Hash) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (db *odrDatabase) SaveTransitionState(common.Hash) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (db *odrDatabase) LoadTransitionState(common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -852,7 +852,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	if genParams.parentHash != (common.Hash{}) {
 		block := w.chain.GetBlockByHash(genParams.parentHash)
 		if block == nil {
-			return nil, fmt.Errorf("missing parent")
+			return nil, fmt.Errorf("missing parent: %x", genParams.parentHash)
 		}
 		parent = block.Header()
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -904,9 +904,6 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	if err != nil {
 		return nil, err
 	}
-	if w.chain.Config().IsPrague(header.Number, header.Time) {
-		core.OverlayVerkleTransition(state, parent.Root)
-	}
 	// Run the consensus preparation with the default or customized consensus engine.
 	if err := w.engine.Prepare(w.chain, header); err != nil {
 		log.Error("Failed to prepare header for sealing", "err", err)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -894,7 +894,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	if w.chain.Config().IsPrague(header.Number, header.Time) {
 		parent := w.chain.GetHeaderByNumber(header.Number.Uint64() - 1)
 		if !w.chain.Config().IsPrague(parent.Number, parent.Time) {
-			w.chain.StartVerkleTransition(parent.Root, common.Hash{}, w.chain.Config(), nil)
+			w.chain.StartVerkleTransition(parent.Root, common.Hash{}, w.chain.Config(), w.chain.Config().PragueTime, parent.Root)
 		}
 	}
 
@@ -905,7 +905,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 		return nil, err
 	}
 	if w.chain.Config().IsPrague(header.Number, header.Time) {
-		core.OverlayVerkleTransition(state)
+		core.OverlayVerkleTransition(state, parent.Root)
 	}
 	// Run the consensus preparation with the default or customized consensus engine.
 	if err := w.engine.Prepare(w.chain, header); err != nil {

--- a/params/config.go
+++ b/params/config.go
@@ -301,7 +301,8 @@ type ChainConfig struct {
 	IsDevMode bool          `json:"isDev,omitempty"`
 
 	// Proof in block
-	ProofInBlocks bool `json:"proofInBlocks,omitempty"`
+	ProofInBlocks bool   `json:"proofInBlocks,omitempty"`
+	OverlayStride uint64 `json:"overlayStride,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.

--- a/trie/transition.go
+++ b/trie/transition.go
@@ -17,6 +17,8 @@
 package trie
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -62,7 +64,11 @@ func (t *TransitionTrie) GetKey(key []byte) []byte {
 // not be modified by the caller. If a node was not found in the database, a
 // trie.MissingNodeError is returned.
 func (t *TransitionTrie) GetStorage(addr common.Address, key []byte) ([]byte, error) {
-	if val, err := t.overlay.GetStorage(addr, key); len(val) != 0 || err != nil {
+	val, err := t.overlay.GetStorage(addr, key)
+	if err != nil {
+		return nil, fmt.Errorf("get storage from overlay: %s", err)
+	}
+	if len(val) != 0 {
 		return val, nil
 	}
 	// TODO also insert value into overlay


### PR DESCRIPTION
Reactivate a post-genesis transition for a kaustinen-like testnet that goes through the conversion.

- [x] use a LRU list instead of an ever-growing map
 - [ ] so far there needs to be a `TransitionState` for every block past the fork. It would be better if this system could be jettisoned after the conversion.
 - [x] check this works in kurtosis -> https://github.com/kurtosis-tech/ethereum-package/tree/main/examples
 - [x] fix #316 before merging
 - [x] figure out a way to merge into `kaustinen-with-shapella`