### PR TITLE
fix: ensure address point is initialized in conversion

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -320,7 +320,7 @@ func (kvm *keyValueMigrator) prepare() {
 				var currAddr common.Address
 				var currPoint *verkle.Point
 				for i := range batch {
-					if batch[i].branchKey.addr != currAddr {
+					if batch[i].branchKey.addr != currAddr || currAddr == (common.Address{}) {
 						currAddr = batch[i].branchKey.addr
 						currPoint = tutils.EvaluateAddressPoint(currAddr[:])
 					}


### PR DESCRIPTION
`currPoint` needs to be initialized the first time the transaction starts, otherwise the conversion will panic right off the bat.