### PR TITLE
fix: reactivate snapshot in kaustinen

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -176,10 +176,9 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 	if tr.IsVerkle() {
 		sdb.witness = sdb.NewAccessWitness()
 	}
-	// if sdb.snaps != nil {
-	// 	if sdb.snap = sdb.snaps.Snapshot(root); sdb.snap == nil {
-	// 	}
-	// }
+	if sdb.snaps != nil {
+		sdb.snap = sdb.snaps.Snapshot(root)
+	}
 	return sdb, nil
 }
 


### PR DESCRIPTION
This is necessary for the post-genesis verge testnet to work.

I make it a separate PR as it's also affecting kaustinen and I need a reminder to test it by syncing kaustinen before I merge it.