### PR TITLE
fix: do not initialize CurrentAccountAddress in StartVerkleTransition

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -235,7 +235,7 @@ func (db *cachingDB) StartVerkleTransition(originalRoot, translatedRoot common.H
 	db.StorageProcessed[root] = true
 
 	// Reinitialize values in case of a reorg
-	db.CurrentAccountAddress[root] = &(common.Address{})
+	db.CurrentAccountAddress[root] = nil // force nil as overlay expects an uninitialized
 	db.CurrentSlotHash[root] = common.Hash{}
 	db.CurrentPreimageOffset[root] = 0
 	if pragueTime != nil {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -321,7 +321,7 @@ func (kvm *keyValueMigrator) prepare() {
 				var currAddr common.Address
 				var currPoint *verkle.Point
 				for i := range batch {
-					if batch[i].branchKey.addr != currAddr || currAddr == (common.Address{}) {
+					if batch[i].branchKey.addr != currAddr {
 						currAddr = batch[i].branchKey.addr
 						currPoint = tutils.EvaluateAddressPoint(currAddr[:])
 					}


### PR DESCRIPTION
The logic was initializing `CurrentAccountAddress[root]` to `common.Address` and, as it turns out, this should not be the case as a `nil` value is used to 

Not merging right away because I want to think if a corner case in which the 0 address is present in the state, and `keccak256(0_20)` is also the first value to be enumerated. It should be very unlikely and definitely impossible on mainnet, but it could happen.