### PR TITLE
set verkle mode from genesis with override

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/big"
 	"os"
 	"runtime"
 	"strconv"

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -214,7 +214,7 @@ func initGenesis(ctx *cli.Context) error {
 		}
 		triedb := trie.NewDatabaseWithConfig(chaindb, &trie.Config{
 			Preimages: ctx.Bool(utils.CachePreimagesFlag.Name),
-			Verkle:    true,
+			Verkle:    genesis.IsVerkle(),
 		})
 		_, hash, err := core.SetupGenesisBlockWithOverride(chaindb, triedb, genesis, &overrides)
 		if err != nil {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -456,6 +456,12 @@ func (g *Genesis) configOrDefault(ghash common.Hash) *params.ChainConfig {
 	}
 }
 
+// IsVerkle indicates whether the state is already stored in a verkle
+// tree at genesis time.
+func (g *Genesis) IsVerkle() bool {
+	return g.Config.IsPrague(new(big.Int).SetUint64(g.Number), g.Timestamp)
+}
+
 // ToBlock returns the genesis block according to genesis specification.
 func (g *Genesis) ToBlock() *types.Block {
 	root, err := g.Alloc.deriveHash(g.Config, g.Timestamp)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math/big"
 	"runtime"
 	"sync"
 	"time"

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -20,7 +20,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"math/big"
 	"runtime"
 	"sync"
 	"time"


### PR DESCRIPTION
This is porting the verkle activation from geth master. Now, `geth init` should work in verkle mode by just specifying `--override.prage=<genesis timestamp>`.