### PR TITLE
move the overlay transition to Finalize

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -105,11 +105,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		return nil, nil, 0, errors.New("withdrawals before shanghai")
 	}
 
-	// Perform the overlay transition, if relevant
-	if err := OverlayVerkleTransition(statedb); err != nil {
-		return nil, nil, 0, fmt.Errorf("error performing verkle overlay transition: %w", err)
-	}
-
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.engine.Finalize(p.bc, header, statedb, block.Transactions(), block.Uncles(), withdrawals)
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -904,9 +904,6 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	if err != nil {
 		return nil, err
 	}
-	if w.chain.Config().IsPrague(header.Number, header.Time) {
-		core.OverlayVerkleTransition(state)
-	}
 	// Run the consensus preparation with the default or customized consensus engine.
 	if err := w.engine.Prepare(w.chain, header); err != nil {
 		log.Error("Failed to prepare header for sealing", "err", err)


### PR DESCRIPTION
After a review with Gary. we came to the conclusion that the overlay transition should be moved to finalize for the moment. This isn't as easy at it looks, because we need to ensure that the transition is activated _before_ the fork block is executed. But the overlay copy itself could be done in prepare or Finalize.

This works fine on kaustinen since the transition is done at genesis time and doesn't use that function. But in order to go further, this needs to be tested with a post-genesis transition.