### PR TITLE
use github actions to run 32-bit linux tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,23 @@
+name: i386 linux tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.21.4
+      - name: Run tests
+        run: go test ./...
+        env:
+          GOOS: linux
+          GOARCH: 386


### PR DESCRIPTION
same thing as ethereum/go-ethereum#28549 but against my own master so that it can run on selfhosted