### PR TITLE
mod: update go-verkle

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,7 +42,5 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.21.1
-      - name: Download precomputed points
-        run: wget -nv https://github.com/gballet/go-verkle/releases/download/banderwagonv3/precomp -Otrie/utils/precomp
       - name: Test
-        run: go test ./...
+        run: go test ./... -timeout=10h

--- a/cmd/geth/verkle.go
+++ b/cmd/geth/verkle.go
@@ -202,7 +202,7 @@ func convertToVerkle(ctx *cli.Context) error {
 
 				// Otherwise, store the previous group in the tree with a
 				// stem insertion.
-				vRoot.InsertStem(chunkkey[:31], values, chaindb.Get)
+				vRoot.InsertValuesAtStem(chunkkey[:31], values, chaindb.Get)
 			}
 
 			// Write the code size in the account header group
@@ -267,7 +267,7 @@ func convertToVerkle(ctx *cli.Context) error {
 						copy(k[:], []byte(s))
 						// reminder that InsertStem will merge leaves
 						// if they exist.
-						vRoot.InsertStem(k[:31], vs, chaindb.Get)
+						vRoot.InsertValuesAtStem(k[:31], vs, chaindb.Get)
 					}
 					translatedStorage = make(map[string][][]byte)
 					vRoot.FlushAtDepth(2, saveverkle)
@@ -276,7 +276,7 @@ func convertToVerkle(ctx *cli.Context) error {
 			for s, vs := range translatedStorage {
 				var k [31]byte
 				copy(k[:], []byte(s))
-				vRoot.InsertStem(k[:31], vs, chaindb.Get)
+				vRoot.InsertValuesAtStem(k[:31], vs, chaindb.Get)
 			}
 			storageIt.Release()
 			if storageIt.Error() != nil {
@@ -285,7 +285,7 @@ func convertToVerkle(ctx *cli.Context) error {
 			}
 		}
 		// Finish with storing the complete account header group inside the tree.
-		vRoot.InsertStem(stem[:31], newValues, chaindb.Get)
+		vRoot.InsertValuesAtStem(stem[:31], newValues, chaindb.Get)
 
 		if time.Since(lastReport) > time.Second*8 {
 			log.Info("Traversing state", "accounts", accounts, "elapsed", common.PrettyDuration(time.Since(start)))

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
-	github.com/gballet/go-verkle v0.1.1-0.20231025151349-87337dd2894a
+	github.com/gballet/go-verkle v0.1.1-0.20231125115329-d193f0b46e01
 	github.com/go-stack/stack v1.8.1
 	github.com/gofrs/flock v0.8.1
 	github.com/golang-jwt/jwt/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILD
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
-github.com/gballet/go-verkle v0.1.1-0.20231025151349-87337dd2894a h1:UV5Et3Ab62e6hQ6vDZC0h0i9hmKm8KKtV78zDOzud08=
-github.com/gballet/go-verkle v0.1.1-0.20231025151349-87337dd2894a/go.mod h1:QNpY22eby74jVhqH4WhDLDwxc/vqsern6pW+u2kbkpc=
+github.com/gballet/go-verkle v0.1.1-0.20231125115329-d193f0b46e01 h1:Jm7DG6/BptrrNgOh9Jb6LPBbz75VJA5FkFKB4O/zbQw=
+github.com/gballet/go-verkle v0.1.1-0.20231125115329-d193f0b46e01/go.mod h1:OzHSBt37xRRHc27lb9PaCldBnJYQZP8KcMdYyOB2dtU=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getsentry/sentry-go v0.12.0/go.mod h1:NSap0JBYWzHND8oMbyi0+XZhUalc1TBdRL1M71JZW2c=

--- a/trie/transition.go
+++ b/trie/transition.go
@@ -174,7 +174,7 @@ func (t *TransitionTrie) UpdateStem(key []byte, values [][]byte) error {
 	trie := t.overlay
 	switch root := trie.root.(type) {
 	case *verkle.InternalNode:
-		return root.InsertStem(key, values, t.overlay.FlatdbNodeResolver)
+		return root.InsertValuesAtStem(key, values, t.overlay.FlatdbNodeResolver)
 	default:
 		panic("invalid root type")
 	}

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -107,7 +107,7 @@ func (t *VerkleTrie) GetAccount(addr common.Address) (*types.StateAccount, error
 	)
 	switch t.root.(type) {
 	case *verkle.InternalNode:
-		values, err = t.root.(*verkle.InternalNode).GetStem(versionkey[:31], t.FlatdbNodeResolver)
+		values, err = t.root.(*verkle.InternalNode).GetValuesAtStem(versionkey[:31], t.FlatdbNodeResolver)
 	default:
 		return nil, errInvalidRootType
 	}
@@ -176,7 +176,7 @@ func (t *VerkleTrie) UpdateAccount(addr common.Address, acc *types.StateAccount)
 
 	switch root := t.root.(type) {
 	case *verkle.InternalNode:
-		err = root.InsertStem(stem, values, t.FlatdbNodeResolver)
+		err = root.InsertValuesAtStem(stem, values, t.FlatdbNodeResolver)
 	default:
 		return errInvalidRootType
 	}
@@ -191,7 +191,7 @@ func (t *VerkleTrie) UpdateAccount(addr common.Address, acc *types.StateAccount)
 func (trie *VerkleTrie) UpdateStem(key []byte, values [][]byte) error {
 	switch root := trie.root.(type) {
 	case *verkle.InternalNode:
-		return root.InsertStem(key, values, trie.FlatdbNodeResolver)
+		return root.InsertValuesAtStem(key, values, trie.FlatdbNodeResolver)
 	default:
 		panic("invalid root type")
 	}
@@ -225,7 +225,7 @@ func (t *VerkleTrie) DeleteAccount(addr common.Address) error {
 
 	switch root := t.root.(type) {
 	case *verkle.InternalNode:
-		err = root.InsertStem(stem, values, t.FlatdbNodeResolver)
+		err = root.InsertValuesAtStem(stem, values, t.FlatdbNodeResolver)
 	default:
 		return errInvalidRootType
 	}


### PR DESCRIPTION
This PR updates `go-verkle` which includes the following merged PRs:
- https://github.com/ethereum/go-verkle/pull/410 (extra proof checks)
- https://github.com/ethereum/go-verkle/pull/411 (API changes)
- https://github.com/ethereum/go-verkle/pull/412 (very important proof format fixes)

