### PR TITLE
fix: support a verkle pre-tree at the conversion block

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -431,7 +431,6 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 			post := state.GetTrie().(*trie.TransitionTrie)
 			vtrpost = post.Overlay()
 			okpost = true
-
 		}
 		if okpre && okpost {
 			if len(keys) > 0 {

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -423,7 +423,15 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 			vtrpost = post.Overlay()
 			okpost = true
 		default:
-			panic("invalid tree type")
+			// This should only happen for the first block of the
+			// conversion, when the previous tree is a merkle tree.
+			//  Logically, the "previous" verkle tree is an empty tree.
+			okpre = true
+			vtrpre = trie.NewVerkleTrie(verkle.New(), state.Database().TrieDB(), utils.NewPointCache(), false)
+			post := state.GetTrie().(*trie.TransitionTrie)
+			vtrpost = post.Overlay()
+			okpost = true
+
 		}
 		if okpre && okpost {
 			if len(keys) > 0 {


### PR DESCRIPTION
The current conversion code panics if it tries to create a proof at the first block. This is because the previous tree is a MPT and no verkle proof can be made against the MPT.

As a result, this PR swaps the MPT with an empty verkle tree, so the proof will be against an empty verkle tree, which is the correct interpretation of a transition proof.