### PR TITLE
fix: a branch that can verge at genesis or post genesis

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -214,6 +214,7 @@ func initGenesis(ctx *cli.Context) error {
 		}
 		triedb := trie.NewDatabaseWithConfig(chaindb, &trie.Config{
 			Preimages: ctx.Bool(utils.CachePreimagesFlag.Name),
+			Verkle:    genesis.IsVerkle(),
 		})
 		_, hash, err := core.SetupGenesisBlockWithOverride(chaindb, triedb, genesis, &overrides)
 		if err != nil {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -312,6 +312,12 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 
 	// Declare the end of the verkle transition if need be
 	if bc.chainConfig.Rules(head.Number, false /* XXX */, head.Time).IsPrague {
+		// TODO this only works when resuming a chain that has already gone
+		// through the conversion. All pointers should be saved to the DB
+		// for it to be able to recover if interrupted during the transition
+   // but that's left out to a later PR since there's not really a need
+   // right now.
+		bc.stateCache.InitTransitionStatus(true, true)
 		bc.stateCache.EndVerkleTransition()
 	}
 

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -75,6 +75,8 @@ type Database interface {
 
 	Transitioned() bool
 
+	InitTransitionStatus(bool, bool)
+
 	SetCurrentSlotHash(common.Hash)
 
 	GetCurrentAccountAddress() *common.Address
@@ -239,6 +241,14 @@ func (db *cachingDB) StartVerkleTransition(originalRoot, translatedRoot common.H
 
 func (db *cachingDB) ReorgThroughVerkleTransition() {
 	log.Warn("trying to reorg through the transition, which makes no sense at this point")
+}
+
+func (db *cachingDB) InitTransitionStatus(started, ended bool) {
+	db.CurrentTransitionState = &TransitionState{
+		ended:   ended,
+		started: started,
+		// TODO add other fields when we handle mid-transition interrupts
+	}
 }
 
 func (db *cachingDB) EndVerkleTransition() {

--- a/light/trie.go
+++ b/light/trie.go
@@ -121,6 +121,10 @@ func (db *odrDatabase) Transitioned() bool {
 	panic("not implemented") // TODO: Implement
 }
 
+func (db *odrDatabase) InitTransitionStatus(bool, bool) {
+	panic("not implemented") // TODO: Implement
+}
+
 func (db *odrDatabase) SetCurrentSlotHash(common.Hash) {
 	panic("not implemented") // TODO: Implement
 }


### PR DESCRIPTION
This is the list of changes to that #311 can also follow the testnet. It ensures that `flush` and `deriveHash` initialize `(*StateDB).CurrentTransitionState` properly, and also sketch out what is needed to be able to resume mid-conversion.