### PR TITLE
add witness costs as tracer parameter

### DIFF
--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -38,6 +38,6 @@ type EVMLogger interface {
 	CaptureEnter(typ OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int)
 	CaptureExit(output []byte, gasUsed uint64, err error)
 	// Opcode level
-	CaptureState(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, rData []byte, depth int, err error)
-	CaptureFault(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error)
+	CaptureState(pc uint64, op OpCode, gas, cost, witness uint64, scope *ScopeContext, rData []byte, depth int, err error)
+	CaptureFault(pc uint64, op OpCode, gas, cost, witness uint64, scope *ScopeContext, depth int, err error)
 }

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -250,7 +250,7 @@ func (t *jsTracer) CaptureStart(env *vm.EVM, from common.Address, to common.Addr
 }
 
 // CaptureState implements the Tracer interface to trace a single step of VM execution.
-func (t *jsTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+func (t *jsTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost, _ uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 	if !t.traceStep {
 		return
 	}
@@ -275,7 +275,7 @@ func (t *jsTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope
 }
 
 // CaptureFault implements the Tracer interface to trace an execution fault
-func (t *jsTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
+func (t *jsTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost, _ uint64, scope *vm.ScopeContext, depth int, err error) {
 	if t.err != nil {
 		return
 	}

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -136,7 +136,7 @@ func (a *AccessListTracer) CaptureStart(env *vm.EVM, from common.Address, to com
 }
 
 // CaptureState captures all opcodes that touch storage or addresses and adds them to the accesslist.
-func (a *AccessListTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+func (a *AccessListTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost, _ uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 	stack := scope.Stack
 	stackData := stack.Data()
 	stackLen := len(stackData)
@@ -158,7 +158,7 @@ func (a *AccessListTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint6
 	}
 }
 
-func (*AccessListTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
+func (*AccessListTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost, _ uint64, scope *vm.ScopeContext, depth int, err error) {
 }
 
 func (*AccessListTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {}

--- a/eth/tracers/logger/gen_structlog.go
+++ b/eth/tracers/logger/gen_structlog.go
@@ -21,6 +21,7 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 		Op            vm.OpCode                   `json:"op"`
 		Gas           math.HexOrDecimal64         `json:"gas"`
 		GasCost       math.HexOrDecimal64         `json:"gasCost"`
+		WitnessCost   math.HexOrDecimal64         `json:"witnessCost"`
 		Memory        hexutil.Bytes               `json:"memory,omitempty"`
 		MemorySize    int                         `json:"memSize"`
 		Stack         []uint256.Int               `json:"stack"`
@@ -37,6 +38,7 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 	enc.Op = s.Op
 	enc.Gas = math.HexOrDecimal64(s.Gas)
 	enc.GasCost = math.HexOrDecimal64(s.GasCost)
+	enc.WitnessCost = math.HexOrDecimal64(s.WitnessCost)
 	enc.Memory = s.Memory
 	enc.MemorySize = s.MemorySize
 	enc.Stack = s.Stack
@@ -57,6 +59,7 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 		Op            *vm.OpCode                  `json:"op"`
 		Gas           *math.HexOrDecimal64        `json:"gas"`
 		GasCost       *math.HexOrDecimal64        `json:"gasCost"`
+		WitnessCost   *math.HexOrDecimal64        `json:"witnessCost"`
 		Memory        *hexutil.Bytes              `json:"memory,omitempty"`
 		MemorySize    *int                        `json:"memSize"`
 		Stack         []uint256.Int               `json:"stack"`
@@ -81,6 +84,9 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 	}
 	if dec.GasCost != nil {
 		s.GasCost = uint64(*dec.GasCost)
+	}
+	if dec.WitnessCost != nil {
+		s.WitnessCost = uint64(*dec.WitnessCost)
 	}
 	if dec.Memory != nil {
 		s.Memory = *dec.Memory

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -46,13 +46,13 @@ func (l *JSONLogger) CaptureStart(env *vm.EVM, from, to common.Address, create b
 	l.env = env
 }
 
-func (l *JSONLogger) CaptureFault(pc uint64, op vm.OpCode, gas uint64, cost uint64, scope *vm.ScopeContext, depth int, err error) {
+func (l *JSONLogger) CaptureFault(pc uint64, op vm.OpCode, gas uint64, cost, witness uint64, scope *vm.ScopeContext, depth int, err error) {
 	// TODO: Add rData to this interface as well
-	l.CaptureState(pc, op, gas, cost, scope, nil, depth, err)
+	l.CaptureState(pc, op, gas, cost, witness, scope, nil, depth, err)
 }
 
 // CaptureState outputs state information on the logger.
-func (l *JSONLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+func (l *JSONLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost, witness uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 	memory := scope.Memory
 	stack := scope.Stack
 
@@ -61,6 +61,7 @@ func (l *JSONLogger) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, sco
 		Op:            op,
 		Gas:           gas,
 		GasCost:       cost,
+		WitnessCost:   witness,
 		MemorySize:    memory.Len(),
 		Depth:         depth,
 		RefundCounter: l.env.StateDB.GetRefund(),

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -148,7 +148,7 @@ func (t *callTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
 }
 
 // CaptureState implements the EVMLogger interface to trace a single step of VM execution.
-func (t *callTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+func (t *callTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost, _ uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 	// skip if the previous op caused an error
 	if err != nil {
 		return

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -157,13 +157,13 @@ func (t *flatCallTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
 }
 
 // CaptureState implements the EVMLogger interface to trace a single step of VM execution.
-func (t *flatCallTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
-	t.tracer.CaptureState(pc, op, gas, cost, scope, rData, depth, err)
+func (t *flatCallTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost, witness uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+	t.tracer.CaptureState(pc, op, gas, cost, witness, scope, rData, depth, err)
 }
 
 // CaptureFault implements the EVMLogger interface to trace an execution fault.
-func (t *flatCallTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
-	t.tracer.CaptureFault(pc, op, gas, cost, scope, depth, err)
+func (t *flatCallTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost, witness uint64, scope *vm.ScopeContext, depth int, err error) {
+	t.tracer.CaptureFault(pc, op, gas, cost, witness, scope, depth, err)
 }
 
 // CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -73,16 +73,16 @@ func (t *muxTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
 }
 
 // CaptureState implements the EVMLogger interface to trace a single step of VM execution.
-func (t *muxTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+func (t *muxTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost, witness uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 	for _, t := range t.tracers {
-		t.CaptureState(pc, op, gas, cost, scope, rData, depth, err)
+		t.CaptureState(pc, op, gas, cost, witness, scope, rData, depth, err)
 	}
 }
 
 // CaptureFault implements the EVMLogger interface to trace an execution fault.
-func (t *muxTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
+func (t *muxTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost, witness uint64, scope *vm.ScopeContext, depth int, err error) {
 	for _, t := range t.tracers {
-		t.CaptureFault(pc, op, gas, cost, scope, depth, err)
+		t.CaptureFault(pc, op, gas, cost, witness, scope, depth, err)
 	}
 }
 

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -47,11 +47,11 @@ func (t *noopTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
 }
 
 // CaptureState implements the EVMLogger interface to trace a single step of VM execution.
-func (t *noopTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+func (t *noopTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost, witness uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 }
 
 // CaptureFault implements the EVMLogger interface to trace an execution fault.
-func (t *noopTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, _ *vm.ScopeContext, depth int, err error) {
+func (t *noopTracer) CaptureFault(pc uint64, op vm.OpCode, gas, cost, _ uint64, _ *vm.ScopeContext, depth int, err error) {
 }
 
 // CaptureEnter is called when EVM enters a new scope (via call, create or selfdestruct).

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -133,7 +133,7 @@ func (t *prestateTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
 }
 
 // CaptureState implements the EVMLogger interface to trace a single step of VM execution.
-func (t *prestateTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
+func (t *prestateTracer) CaptureState(pc uint64, op vm.OpCode, gas, cost, _ uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
With verkle, gas consumption extends beyond the naked cost of calling an operation: depending on what areas of memory get touched, there is a potential extra gas charged.

This PR is still in draft, because there are several tweaks that need to be considered: for one, extracting gas data from the witness implies to change the signature of the return function to also include the witness.

It might be easier to change the signature of `dynamicGas` to accept the `pc` from the interpreter and just bulk the witness gas with the consumed gas. And we might combine both to report the witness gas while bulking both.