### PR TITLE
fix OpenStorageTrie: return an error instead of panicking if the account tree not a verkle tree

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -413,7 +413,7 @@ func (db *cachingDB) OpenStorageTrie(stateRoot common.Hash, address common.Addre
 		case *trie.TransitionTrie:
 			return trie.NewTransitionTree(mpt.(*trie.SecureTrie), self.Overlay(), true), nil
 		default:
-			panic("unexpected trie type")
+			return nil, errors.New("expected a verkle account tree, and found another type")
 		}
 	}
 	mpt, err := db.openStorageMPTrie(stateRoot, address, root, nil)

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -302,7 +302,7 @@ func (sf *subfetcher) loop() {
 		}
 		sf.trie = trie
 	} else {
-		trie, err := sf.db.OpenStorageTrie(sf.state, sf.addr, sf.root, nil /* safe to set to nil for now, as there is no prefetcher for verkle */)
+		trie, err := sf.db.OpenStorageTrie(sf.state, sf.addr, sf.root, sf.trie)
 		if err != nil {
 			log.Warn("Trie prefetcher failed opening trie", "root", sf.root, "err", err)
 			return


### PR DESCRIPTION
It seems that the prefetcher activates itself while not supposed to. This was a problem because the account trie was set to `nil` by default in this case.

In order not to crash, we just return an error if the tree is of the wrong type, and also we pass the actual account trie just in case.