### PR TITLE
add a switch to force proof in blocks

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -175,6 +175,10 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		v := ctx.Uint64(utils.OverridePrague.Name)
 		cfg.Eth.OverridePrague = &v
 	}
+	if ctx.IsSet(utils.OverrideProofInBlock.Name) {
+		v := ctx.Bool(utils.OverrideProofInBlock.Name)
+		cfg.Eth.OverrideProofInBlock = &v
+	}
 	backend, eth := utils.RegisterEthService(stack, &cfg.Eth)
 
 	// Configure log filter RPC API.

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -69,6 +69,7 @@ var (
 		utils.SmartCardDaemonPathFlag,
 		utils.OverrideCancun,
 		utils.OverridePrague,
+		utils.OverrideProofInBlock,
 		utils.EnablePersonal,
 		utils.TxPoolLocalsFlag,
 		utils.TxPoolNoLocalsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -273,6 +273,11 @@ var (
 		Usage:    "Manually specify the Verkle fork timestamp, overriding the bundled setting",
 		Category: flags.EthCategory,
 	}
+	OverrideProofInBlock = &cli.Uint64Flag{
+		Name:     "override.blockproof",
+		Usage:    "Manually specify the proof-in-block setting",
+		Category: flags.EthCategory,
+	}
 	// Light server and client settings
 	LightServeFlag = &cli.IntFlag{
 		Name:     "light.serve",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -273,7 +273,7 @@ var (
 		Usage:    "Manually specify the Verkle fork timestamp, overriding the bundled setting",
 		Category: flags.EthCategory,
 	}
-	OverrideProofInBlock = &cli.Uint64Flag{
+	OverrideProofInBlock = &cli.BoolFlag{
 		Name:     "override.blockproof",
 		Usage:    "Manually specify the proof-in-block setting",
 		Category: flags.EthCategory,

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -250,6 +250,9 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr
 	}
+	if overrides.OverrideProofInBlock != nil {
+		chainConfig.ProofInBlocks = *overrides.OverrideProofInBlock
+	}
 	log.Info("")
 	log.Info(strings.Repeat("-", 153))
 	for _, line := range strings.Split(chainConfig.Description(), "\n") {
@@ -315,8 +318,8 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		// TODO this only works when resuming a chain that has already gone
 		// through the conversion. All pointers should be saved to the DB
 		// for it to be able to recover if interrupted during the transition
-   // but that's left out to a later PR since there's not really a need
-   // right now.
+		// but that's left out to a later PR since there's not really a need
+		// right now.
 		bc.stateCache.InitTransitionStatus(true, true)
 		bc.stateCache.EndVerkleTransition()
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -291,8 +291,9 @@ func (e *GenesisMismatchError) Error() string {
 
 // ChainOverrides contains the changes to chain config.
 type ChainOverrides struct {
-	OverrideCancun *uint64
-	OverridePrague *uint64
+	OverrideCancun       *uint64
+	OverridePrague       *uint64
+	OverrideProofInBlock *bool
 }
 
 // SetupGenesisBlock writes or updates the genesis block in db.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -201,6 +201,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if config.OverridePrague != nil {
 		overrides.OverridePrague = config.OverridePrague
 	}
+	if config.OverrideProofInBlock != nil {
+		overrides.OverrideProofInBlock = config.OverrideProofInBlock
+	}
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, eth.shouldPreserve, &config.TxLookupLimit)
 	if err != nil {
 		return nil, err

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -158,6 +158,9 @@ type Config struct {
 
 	// OverrideVerkle (TODO: remove after the fork)
 	OverridePrague *uint64 `toml:",omitempty"`
+
+	// OverrideProofInBlock
+	OverrideProofInBlock *bool `toml:",omitempty"`
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.


### PR DESCRIPTION
This is for the case of a shadow fork, when the genesis can no longer be used. It introduces a `--override.proof-in-block` flag that will act as if the config option was present in genesis.