### PR TITLE
add switch to override the stride of the overlay conversion

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -179,6 +179,10 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		v := ctx.Bool(utils.OverrideProofInBlock.Name)
 		cfg.Eth.OverrideProofInBlock = &v
 	}
+	if ctx.IsSet(utils.OverrideOverlayStride.Name) {
+		v := ctx.Uint64(utils.OverrideOverlayStride.Name)
+		cfg.Eth.OverrideOverlayStride = &v
+	}
 	backend, eth := utils.RegisterEthService(stack, &cfg.Eth)
 
 	// Configure log filter RPC API.

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -67,6 +67,7 @@ var (
 		utils.NoUSBFlag,
 		utils.USBFlag,
 		utils.SmartCardDaemonPathFlag,
+		utils.OverrideOverlayStride,
 		utils.OverrideCancun,
 		utils.OverridePrague,
 		utils.OverrideProofInBlock,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -263,6 +263,11 @@ var (
 		Value:    2048,
 		Category: flags.EthCategory,
 	}
+	OverrideOverlayStride = &cli.Uint64Flag{
+		Name:     "override.overlay-stride",
+		Usage:    "Manually specify the stride of the overlay transition, overriding the bundled setting",
+		Category: flags.EthCategory,
+	}
 	OverrideCancun = &cli.Uint64Flag{
 		Name:     "override.cancun",
 		Usage:    "Manually specify the Cancun fork timestamp, overriding the bundled setting",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -266,6 +266,7 @@ var (
 	OverrideOverlayStride = &cli.Uint64Flag{
 		Name:     "override.overlay-stride",
 		Usage:    "Manually specify the stride of the overlay transition, overriding the bundled setting",
+		Value:    10000,
 		Category: flags.EthCategory,
 	}
 	OverrideCancun = &cli.Uint64Flag{

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -373,7 +373,7 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 	if chain.Config().IsPrague(header.Number, header.Time) {
 		fmt.Println("at block", header.Number, "performing transition?", state.Database().InTransition())
 		parent := chain.GetHeaderByHash(header.ParentHash)
-		overlay.OverlayVerkleTransition(state, parent.Root)
+		overlay.OverlayVerkleTransition(state, parent.Root, chain.Config().OverlayStride)
 	}
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -253,6 +253,9 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	if overrides.OverrideProofInBlock != nil {
 		chainConfig.ProofInBlocks = *overrides.OverrideProofInBlock
 	}
+	if overrides.OverrideOverlayStride != nil {
+		chainConfig.OverlayStride = *overrides.OverrideOverlayStride
+	}
 	log.Info("")
 	log.Info(strings.Repeat("-", 153))
 	for _, line := range strings.Split(chainConfig.Description(), "\n") {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -291,9 +291,10 @@ func (e *GenesisMismatchError) Error() string {
 
 // ChainOverrides contains the changes to chain config.
 type ChainOverrides struct {
-	OverrideCancun       *uint64
-	OverridePrague       *uint64
-	OverrideProofInBlock *bool
+	OverrideCancun        *uint64
+	OverridePrague        *uint64
+	OverrideProofInBlock  *bool
+	OverrideOverlayStride *uint64
 }
 
 // SetupGenesisBlock writes or updates the genesis block in db.

--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -217,7 +217,7 @@ func (kvm *keyValueMigrator) migrateCollectedKeyValues(tree *trie.VerkleTrie) er
 }
 
 // OverlayVerkleTransition contains the overlay conversion logic
-func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash) error {
+func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedCount uint64) error {
 	migrdb := statedb.Database()
 
 	// verkle transition: if the conversion process is in progress, move
@@ -274,14 +274,13 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash) error {
 			preimageSeek += int64(len(addr))
 		}
 
-		const maxMovedCount = 10000
 		// mkv will be assiting in the collection of up to maxMovedCount key values to be migrated to the VKT.
 		// It has internal caches to do efficient MPT->VKT key calculations, which will be discarded after
 		// this function.
 		mkv := newKeyValueMigrator()
 		// move maxCount accounts into the verkle tree, starting with the
 		// slots from the previous account.
-		count := 0
+		count := uint64(0)
 
 		// if less than maxCount slots were moved, move to the next account
 		for count < maxMovedCount {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -161,6 +161,9 @@ type Config struct {
 
 	// OverrideProofInBlock
 	OverrideProofInBlock *bool `toml:",omitempty"`
+
+	// OverrideOverlayStride
+	OverrideOverlayStride *uint64 `toml:",omitempty"`
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.

--- a/params/config.go
+++ b/params/config.go
@@ -301,7 +301,8 @@ type ChainConfig struct {
 	IsDevMode bool          `json:"isDev,omitempty"`
 
 	// Proof in block
-	ProofInBlocks bool `json:"proofInBlocks,omitempty"`
+	ProofInBlocks bool   `json:"proofInBlocks,omitempty"`
+	OverlayStride uint64 `json:"overlayStride,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.


### PR DESCRIPTION
For easier testing, make the stride of the overlay snapshot iterator an external parameter. This is so that we can try the transition over many blocks with a smaller set of leaves in the tree.

The issue of this PR is that now, the switch needs to be set manually or `OverlayStride` needs to be set in the genesis file. Otherwise, we effectively have the "state expiry method"