### PR TITLE
cmd/{geth, utils}: add a command to clear verkle costs

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -183,6 +183,9 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		v := ctx.Uint64(utils.OverrideOverlayStride.Name)
 		cfg.Eth.OverrideOverlayStride = &v
 	}
+	if ctx.IsSet(utils.ClearVerkleCosts.Name) {
+		params.ClearVerkleWitnessCosts()
+	}
 	backend, eth := utils.RegisterEthService(stack, &cfg.Eth)
 
 	// Configure log filter RPC API.

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -71,6 +71,7 @@ var (
 		utils.OverrideCancun,
 		utils.OverridePrague,
 		utils.OverrideProofInBlock,
+		utils.ClearVerkleCosts,
 		utils.EnablePersonal,
 		utils.TxPoolLocalsFlag,
 		utils.TxPoolNoLocalsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -284,6 +284,11 @@ var (
 		Usage:    "Manually specify the proof-in-block setting",
 		Category: flags.EthCategory,
 	}
+	ClearVerkleCosts = &cli.BoolFlag{
+		Name:     "clear.verkle.costs",
+		Usage:    "Clear verkle costs (for shadow forks)",
+		Category: flags.EthCategory,
+	}
 	// Light server and client settings
 	LightServeFlag = &cli.IntFlag{
 		Name:     "light.serve",

--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -47,7 +47,7 @@ var zeroTreeIndex uint256.Int
 // collect the key-values in a way that is efficient.
 type keyValueMigrator struct {
 	// leafData contains the values for the future leaf for a particular VKT branch.
-	leafData []migratedKeyValue
+	leafData map[branchKey]*migratedKeyValue
 
 	// When prepare() is called, it will start a background routine that will process the leafData
 	// saving the result in newLeaves to be used by migrateCollectedKeyValues(). The background
@@ -66,7 +66,7 @@ func newKeyValueMigrator() *keyValueMigrator {
 	_ = verkle.GetConfig()
 	return &keyValueMigrator{
 		processingReady: make(chan struct{}),
-		leafData:        make([]migratedKeyValue, 0, 10_000),
+		leafData:        make(map[branchKey]*migratedKeyValue, 10_000),
 	}
 }
 
@@ -138,19 +138,17 @@ func (kvm *keyValueMigrator) addAccountCode(addr []byte, codeSize uint64, chunks
 }
 
 func (kvm *keyValueMigrator) getOrInitLeafNodeData(bk branchKey) *verkle.BatchNewLeafNodeData {
-	// Remember that keyValueMigration receives actions ordered by (address, subtreeIndex).
-	// This means that we can assume that the last element of leafData is the one that we
-	// are looking for, or that we need to create a new one.
-	if len(kvm.leafData) == 0 || kvm.leafData[len(kvm.leafData)-1].branchKey != bk {
-		kvm.leafData = append(kvm.leafData, migratedKeyValue{
-			branchKey: bk,
-			leafNodeData: verkle.BatchNewLeafNodeData{
-				Stem:   nil, // It will be calculated in the prepare() phase, since it's CPU heavy.
-				Values: make(map[byte][]byte),
-			},
-		})
+	if ld, ok := kvm.leafData[bk]; ok {
+		return &ld.leafNodeData
 	}
-	return &kvm.leafData[len(kvm.leafData)-1].leafNodeData
+	kvm.leafData[bk] = &migratedKeyValue{
+		branchKey: bk,
+		leafNodeData: verkle.BatchNewLeafNodeData{
+			Stem:   nil, // It will be calculated in the prepare() phase, since it's CPU heavy.
+			Values: make(map[byte][]byte, 256),
+		},
+	}
+	return &kvm.leafData[bk].leafNodeData
 }
 
 func (kvm *keyValueMigrator) prepare() {
@@ -159,6 +157,10 @@ func (kvm *keyValueMigrator) prepare() {
 	go func() {
 		// Step 1: We split kvm.leafData in numBatches batches, and we process each batch in a separate goroutine.
 		//         This fills each leafNodeData.Stem with the correct value.
+		leafData := make([]migratedKeyValue, 0, len(kvm.leafData))
+		for _, v := range kvm.leafData {
+			leafData = append(leafData, *v)
+		}
 		var wg sync.WaitGroup
 		batchNum := runtime.NumCPU()
 		batchSize := (len(kvm.leafData) + batchNum - 1) / batchNum
@@ -170,7 +172,7 @@ func (kvm *keyValueMigrator) prepare() {
 			}
 			wg.Add(1)
 
-			batch := kvm.leafData[start:end]
+			batch := leafData[start:end]
 			go func() {
 				defer wg.Done()
 				var currAddr common.Address
@@ -190,8 +192,8 @@ func (kvm *keyValueMigrator) prepare() {
 
 		// Step 2: Now that we have all stems (i.e: tree keys) calculated, we can create the new leaves.
 		nodeValues := make([]verkle.BatchNewLeafNodeData, len(kvm.leafData))
-		for i := range kvm.leafData {
-			nodeValues[i] = kvm.leafData[i].leafNodeData
+		for i := range leafData {
+			nodeValues[i] = leafData[i].leafNodeData
 		}
 
 		// Create all leaves in batch mode so we can optimize cryptography operations.

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -340,6 +340,7 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 		mpt Trie
 		err error
 	)
+	fmt.Printf("opening trie with root %x, %v %v\n", root, db.InTransition(), db.Transitioned())
 
 	// TODO separate both cases when I can be certain that it won't
 	// find a Verkle trie where is expects a Transitoion trie.
@@ -347,12 +348,14 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 		// NOTE this is a kaustinen-only change, it will break replay
 		vkt, err := db.openVKTrie(root)
 		if err != nil {
+			fmt.Println("failed to open the vkt", err)
 			return nil, err
 		}
 
 		// If the verkle conversion has ended, return a single
 		// verkle trie.
 		if db.CurrentTransitionState.ended {
+			fmt.Println("vkt only")
 			return vkt, nil
 		}
 
@@ -360,6 +363,7 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 		// trie and an overlay, verkle trie.
 		mpt, err = db.openMPTTrie(db.baseRoot)
 		if err != nil {
+			log.Error("failed to open the mpt", "err", err, "root", db.baseRoot)
 			return nil, err
 		}
 
@@ -547,6 +551,8 @@ func (db *cachingDB) SaveTransitionState(root common.Hash) {
 		// Copy so that the address pointer isn't updated after
 		// it has been saved.
 		db.TransitionStatePerRoot[root] = db.CurrentTransitionState.Copy()
+
+		log.Debug("saving transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
 	}
 }
 
@@ -555,6 +561,9 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 		db.TransitionStatePerRoot = make(map[common.Hash]*TransitionState)
 	}
 
+	// Initialize the first transition state, with the "ended"
+	// field set to true if the database was created
+	// as a verkle database.
 	ts, ok := db.TransitionStatePerRoot[root]
 	if !ok || ts == nil {
 		// Start with a fresh state
@@ -565,5 +574,5 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 	// doesn't get overwritten.
 	db.CurrentTransitionState = ts.Copy()
 
-	fmt.Println("loaded transition state", db.CurrentTransitionState.StorageProcessed)
+	log.Debug("loaded transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -348,14 +348,14 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 		// NOTE this is a kaustinen-only change, it will break replay
 		vkt, err := db.openVKTrie(root)
 		if err != nil {
-			fmt.Println("failed to open the vkt", err)
+			log.Error("failed to open the vkt", "err", err)
 			return nil, err
 		}
 
 		// If the verkle conversion has ended, return a single
 		// verkle trie.
 		if db.CurrentTransitionState.ended {
-			fmt.Println("vkt only")
+			log.Debug("transition ended, returning a simple verkle tree")
 			return vkt, nil
 		}
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1310,7 +1310,7 @@ func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, er
 			// - head layer is paired with HEAD state
 			// - head-1 layer is paired with HEAD-1 state
 			// - head-127 layer(bottom-most diff layer) is paired with HEAD-127 state
-			if err := s.snaps.Cap(root, 128); err != nil {
+			if err := s.snaps.Cap(root, 8192); err != nil {
 				log.Warn("Failed to cap snapshot tree", "root", root, "layers", 128, "err", err)
 			}
 		}

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -17,6 +17,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -651,6 +653,7 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 		input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
 		gas          = scope.Contract.Gas
 	)
+	fmt.Println("CREATE", input, value)
 	if interpreter.evm.chainRules.IsPrague {
 		contractAddress := crypto.CreateAddress(scope.Contract.Address(), interpreter.evm.StateDB.GetNonce(scope.Contract.Address()))
 		statelessGas := interpreter.evm.Accesses.TouchAndChargeContractCreateInit(contractAddress.Bytes()[:], value.Sign() != 0)
@@ -705,6 +708,7 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 		input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
 		gas          = scope.Contract.Gas
 	)
+	fmt.Println("CREATE2", salt, input, endowment)
 	if interpreter.evm.chainRules.IsPrague {
 		codeAndHash := &codeAndHash{code: input}
 		contractAddress := crypto.CreateAddress2(scope.Contract.Address(), salt.Bytes32(), codeAndHash.Hash().Bytes())
@@ -903,6 +907,7 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 		return nil, ErrWriteProtection
 	}
 	beneficiary := scope.Stack.pop()
+	fmt.Println("SELFDESTRUCT", beneficiary)
 	balance := interpreter.evm.StateDB.GetBalance(scope.Contract.Address())
 	interpreter.evm.StateDB.AddBalance(beneficiary.Bytes20(), balance)
 	interpreter.evm.StateDB.SelfDestruct(scope.Contract.Address())

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -17,8 +17,6 @@
 package vm
 
 import (
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -653,7 +651,6 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 		input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
 		gas          = scope.Contract.Gas
 	)
-	fmt.Println("CREATE", input, value)
 	if interpreter.evm.chainRules.IsPrague {
 		contractAddress := crypto.CreateAddress(scope.Contract.Address(), interpreter.evm.StateDB.GetNonce(scope.Contract.Address()))
 		statelessGas := interpreter.evm.Accesses.TouchAndChargeContractCreateInit(contractAddress.Bytes()[:], value.Sign() != 0)
@@ -708,7 +705,6 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 		input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
 		gas          = scope.Contract.Gas
 	)
-	fmt.Println("CREATE2", salt, input, endowment)
 	if interpreter.evm.chainRules.IsPrague {
 		codeAndHash := &codeAndHash{code: input}
 		contractAddress := crypto.CreateAddress2(scope.Contract.Address(), salt.Bytes32(), codeAndHash.Hash().Bytes())
@@ -907,7 +903,6 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 		return nil, ErrWriteProtection
 	}
 	beneficiary := scope.Stack.pop()
-	fmt.Println("SELFDESTRUCT", beneficiary)
 	balance := interpreter.evm.StateDB.GetBalance(scope.Contract.Address())
 	interpreter.evm.StateDB.AddBalance(beneficiary.Bytes20(), balance)
 	interpreter.evm.StateDB.SelfDestruct(scope.Contract.Address())

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -852,7 +852,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	if genParams.parentHash != (common.Hash{}) {
 		block := w.chain.GetBlockByHash(genParams.parentHash)
 		if block == nil {
-			return nil, fmt.Errorf("missing parent")
+			return nil, fmt.Errorf("missing parent: %x", genParams.parentHash)
 		}
 		parent = block.Header()
 	}

--- a/trie/transition.go
+++ b/trie/transition.go
@@ -17,6 +17,8 @@
 package trie
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -62,7 +64,11 @@ func (t *TransitionTrie) GetKey(key []byte) []byte {
 // not be modified by the caller. If a node was not found in the database, a
 // trie.MissingNodeError is returned.
 func (t *TransitionTrie) GetStorage(addr common.Address, key []byte) ([]byte, error) {
-	if val, err := t.overlay.GetStorage(addr, key); len(val) != 0 || err != nil {
+	val, err := t.overlay.GetStorage(addr, key)
+	if err != nil {
+		return nil, fmt.Errorf("get storage from overlay: %s", err)
+	}
+	if len(val) != 0 {
 		return val, nil
 	}
 	// TODO also insert value into overlay


### PR DESCRIPTION
This is meant for shadow forks, in order to ignore the witness costs so that transactions are not failing as much.

This branch has received a lot of updates that have nothing to do with the initial command, and needs cleanup.