### PR TITLE
fix: add proof of absence for chunks when contract creation reverts

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -529,10 +529,12 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		}
 	}
 
-	if err == nil && evm.chainRules.IsPrague {
-		if !contract.UseGas(evm.Accesses.TouchAndChargeContractCreateCompleted(address.Bytes()[:])) {
-			evm.StateDB.RevertToSnapshot(snapshot)
-			err = ErrOutOfGas
+	if evm.chainRules.IsPrague {
+		if err == nil || err == ErrExecutionReverted {
+			if !contract.UseGas(evm.Accesses.TouchAndChargeContractCreateCompleted(address.Bytes()[:])) {
+				evm.StateDB.RevertToSnapshot(snapshot)
+				err = ErrOutOfGas
+			}
 		}
 	}
 


### PR DESCRIPTION
Adding contract chunks to the witness only occurred when the creation transaction was a success.

The question that arises is: do we need to add the address to the witness, knowing that it's not created? At first, I thought that this was the case, but actually since the creation isn't executed, it should not be the case. This needs to be though through further.