### PR TITLE
force activation of EIP-6780

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -59,6 +59,9 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	case evm.chainRules.IsPrague:
 		// TODO replace with prooper instruction set when fork is specified
 		table = &shanghaiInstructionSet
+		if err := EnableEIP(6780, table); err != nil {
+			panic(err)
+		}
 	case evm.chainRules.IsCancun:
 		table = &cancunInstructionSet
 	case evm.chainRules.IsShanghai:

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -58,10 +58,7 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	switch {
 	case evm.chainRules.IsPrague:
 		// TODO replace with prooper instruction set when fork is specified
-		table = &shanghaiInstructionSet
-		if err := EnableEIP(6780, table); err != nil {
-			panic(err)
-		}
+		table = &pragueInstructionSet
 	case evm.chainRules.IsCancun:
 		table = &cancunInstructionSet
 	case evm.chainRules.IsShanghai:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -57,6 +57,7 @@ var (
 	mergeInstructionSet            = newMergeInstructionSet()
 	shanghaiInstructionSet         = newShanghaiInstructionSet()
 	cancunInstructionSet           = newCancunInstructionSet()
+	pragueInstructionSet           = newPragueInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -78,6 +79,12 @@ func validate(jt JumpTable) JumpTable {
 		}
 	}
 	return jt
+}
+
+func newPragueInstructionSet() JumpTable {
+	instructionSet := newShanghaiInstructionSet()
+	enable6780(&instructionSet)
+	return validate(instructionSet)
 }
 
 func newCancunInstructionSet() JumpTable {


### PR DESCRIPTION
Selfdestruct was reactivated when I did the rebase, since it is now activated in `cancunInstructionSet`. Create a `pragueInstructionSet` that does exactly the same thing.