### PR TITLE
fix: load conversion state in FinalizeAndAssemble

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -409,7 +409,7 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 		k    verkle.StateDiff
 		keys = state.Witness().Keys()
 	)
-	if chain.Config().IsPrague(header.Number, header.Time) && chain.Config().ProofInBlocks {
+	if chain.Config().IsPrague(header.Number, header.Time) {
 		// Open the pre-tree to prove the pre-state against
 		parent := chain.GetHeaderByNumber(header.Number.Uint64() - 1)
 		if parent == nil {
@@ -417,50 +417,53 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 		}
 
 		state.Database().LoadTransitionState(parent.Root)
-		preTrie, err := state.Database().OpenTrie(parent.Root)
-		if err != nil {
-			return nil, fmt.Errorf("error opening pre-state tree root: %w", err)
-		}
 
-		var okpre, okpost bool
-		var vtrpre, vtrpost *trie.VerkleTrie
-		switch pre := preTrie.(type) {
-		case *trie.VerkleTrie:
-			vtrpre, okpre = preTrie.(*trie.VerkleTrie)
-			switch tr := state.GetTrie().(type) {
+		if chain.Config().ProofInBlocks {
+			preTrie, err := state.Database().OpenTrie(parent.Root)
+			if err != nil {
+				return nil, fmt.Errorf("error opening pre-state tree root: %w", err)
+			}
+
+			var okpre, okpost bool
+			var vtrpre, vtrpost *trie.VerkleTrie
+			switch pre := preTrie.(type) {
 			case *trie.VerkleTrie:
-				vtrpost = tr
-				okpost = true
-			// This is to handle a situation right at the start of the conversion:
-			// the post trie is a transition tree when the pre tree is an empty
-			// verkle tree.
+				vtrpre, okpre = preTrie.(*trie.VerkleTrie)
+				switch tr := state.GetTrie().(type) {
+				case *trie.VerkleTrie:
+					vtrpost = tr
+					okpost = true
+				// This is to handle a situation right at the start of the conversion:
+				// the post trie is a transition tree when the pre tree is an empty
+				// verkle tree.
+				case *trie.TransitionTrie:
+					vtrpost = tr.Overlay()
+					okpost = true
+				default:
+					okpost = false
+				}
 			case *trie.TransitionTrie:
-				vtrpost = tr.Overlay()
+				vtrpre = pre.Overlay()
+				okpre = true
+				post, _ := state.GetTrie().(*trie.TransitionTrie)
+				vtrpost = post.Overlay()
 				okpost = true
 			default:
-				okpost = false
+				// This should only happen for the first block,
+				// so the previous tree is a merkle tree. Logically,
+				// the "previous" verkle tree is an empty tree.
+				okpre = true
+				vtrpre = trie.NewVerkleTrie(verkle.New(), state.Database().TrieDB(), utils.NewPointCache(), false)
+				post := state.GetTrie().(*trie.TransitionTrie)
+				vtrpost = post.Overlay()
+				okpost = true
 			}
-		case *trie.TransitionTrie:
-			vtrpre = pre.Overlay()
-			okpre = true
-			post, _ := state.GetTrie().(*trie.TransitionTrie)
-			vtrpost = post.Overlay()
-			okpost = true
-		default:
-			// This should only happen for the first block,
-			// so the previous tree is a merkle tree. Logically,
-			// the "previous" verkle tree is an empty tree.
-			okpre = true
-			vtrpre = trie.NewVerkleTrie(verkle.New(), state.Database().TrieDB(), utils.NewPointCache(), false)
-			post := state.GetTrie().(*trie.TransitionTrie)
-			vtrpost = post.Overlay()
-			okpost = true
-		}
-		if okpre && okpost {
-			if len(keys) > 0 {
-				p, k, err = trie.ProveAndSerialize(vtrpre, vtrpost, keys, vtrpre.FlatdbNodeResolver)
-				if err != nil {
-					return nil, fmt.Errorf("error generating verkle proof for block %d: %w", header.Number, err)
+			if okpre && okpost {
+				if len(keys) > 0 {
+					p, k, err = trie.ProveAndSerialize(vtrpre, vtrpost, keys, vtrpre.FlatdbNodeResolver)
+					if err != nil {
+						return nil, fmt.Errorf("error generating verkle proof for block %d: %w", header.Number, err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
`FinalizeAndAssemble` was not loading the conversion pointers unless `--override.blockproof` was set. This caused some issues on the shadowfork as the pointer would not be reinitialized when the client tries to produce the same block multiple times.