### PR TITLE
fix: test for ExtStatus count when two missing stems collide

### DIFF
--- a/trie/verkle_test.go
+++ b/trie/verkle_test.go
@@ -313,8 +313,8 @@ func TestReproduceCondrieuStemAggregationInProofOfAbsence(t *testing.T) {
 	t.Logf("tree: %s\n%x\n", verkle.ToDot(root), root.Commitment().Bytes())
 
 	t.Logf("%d", len(proof.ExtStatus))
-	if len(proof.ExtStatus) != 5 {
-		t.Fatalf("invalid number of declared stems: %d != 5", len(proof.ExtStatus))
+	if len(proof.ExtStatus) != 6 {
+		t.Fatalf("invalid number of declared stems: %d != 6", len(proof.ExtStatus))
 	}
 }
 


### PR DESCRIPTION
A test was failing after we decided to introduce two extension stems when there is a collision of a proof-of-absence stem with another stem (absent or not). This only increases the proof size by one byte at a time, and it greatly simplified the code.