### PR TITLE
fix: only disable HasLegacyNode call for verkle-at-genesis testnets

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -341,23 +341,23 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 	}
 	// We have the genesis block in database(perhaps in ancient database)
 	// but the corresponding state is missing.
-	// header := rawdb.ReadHeader(db, stored, 0)
-	// if header.Root != types.EmptyRootHash && !rawdb.HasLegacyTrieNode(db, header.Root) {
-	// 	if genesis == nil {
-	// 		genesis = DefaultGenesisBlock()
-	// 	}
-	// 	// Ensure the stored genesis matches with the given one.
-	// 	hash := genesis.ToBlock().Hash()
-	// 	if hash != stored {
-	// 		return genesis.Config, hash, &GenesisMismatchError{stored, hash}
-	// 	}
-	// 	block, err := genesis.Commit(db, triedb)
-	// 	if err != nil {
-	// 		return genesis.Config, hash, err
-	// 	}
-	// 	applyOverrides(genesis.Config)
-	// 	return genesis.Config, block.Hash(), nil
-	// }
+	header := rawdb.ReadHeader(db, stored, 0)
+	if !genesis.Config.IsPrague(big.NewInt(0), genesis.Timestamp) && header.Root != types.EmptyRootHash && !rawdb.HasLegacyTrieNode(db, header.Root) {
+		if genesis == nil {
+			genesis = DefaultGenesisBlock()
+		}
+		// Ensure the stored genesis matches with the given one.
+		hash := genesis.ToBlock().Hash()
+		if hash != stored {
+			return genesis.Config, hash, &GenesisMismatchError{stored, hash}
+		}
+		block, err := genesis.Commit(db, triedb)
+		if err != nil {
+			return genesis.Config, hash, err
+		}
+		applyOverrides(genesis.Config)
+		return genesis.Config, block.Hash(), nil
+	}
 	// Check whether the genesis block is already written.
 	if genesis != nil {
 		applyOverrides(genesis.Config)


### PR DESCRIPTION
#283 introduced a workaround in order not to call `HasLegacyNode`, which had no meaning in the verkle world and was causing a root comparison to fail.

Because the branch was meant to be temporary, this workaround made sense. But now that it has become somewhat official, it makes sense to make this workaround a bit more stable, since it creates a deadlock in tests.

This PR only activates the workaround in the case of a verkle-at-genesis testnet.