### PR TITLE
Add eip2935 256th ancestor stem to witness

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
+	"github.com/ethereum/go-ethereum/trie/utils"
 	tutils "github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/ethereum/go-verkle"
 	"github.com/holiman/uint256"
@@ -367,4 +368,6 @@ func ProcessParentBlockHash(statedb *state.StateDB, prevNumber uint64, prevHash 
 	var key common.Hash
 	binary.BigEndian.PutUint64(key[24:], prevNumber)
 	statedb.SetState(params.HistoryStorageAddress, key, prevHash)
+	index, suffix := utils.GetTreeKeyStorageSlotTreeIndexes(key[:])
+	statedb.Witness().TouchAddressOnWriteAndComputeGas(params.HistoryStorageAddress[:], *index, suffix)
 }

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -653,6 +653,14 @@ func TestProcessVerkleiInvalidContractCreation(t *testing.T) {
 					t.Fatalf("invalid suffix diff found for %x in block #1: %d\n", stemStateDiff.Stem, suffixDiff.Suffix)
 				}
 			}
+		} else if bytes.Equal(stemStateDiff.Stem[:], common.Hex2Bytes("97f2911f5efe08b74c28727d004e36d260225e73525fe2a300c8f58c7ffd76")) {
+			// BLOCKHASH contract stem
+			if len(stemStateDiff.SuffixDiffs) > 1 {
+				t.Fatalf("invalid suffix diff count found for BLOCKHASH contract: %d != 1", len(stemStateDiff.SuffixDiffs))
+			}
+			if stemStateDiff.SuffixDiffs[0].Suffix != 64 {
+				t.Fatalf("invalid suffix diff value found for BLOCKHASH contract: %d != 64", stemStateDiff.SuffixDiffs[0].Suffix)
+			}
 		} else {
 			for _, suffixDiff := range stemStateDiff.SuffixDiffs {
 				if suffixDiff.Suffix > 4 {
@@ -666,9 +674,18 @@ func TestProcessVerkleiInvalidContractCreation(t *testing.T) {
 	// code should make it to the witness.
 	for _, stemStateDiff := range statediff[1] {
 		for _, suffixDiff := range stemStateDiff.SuffixDiffs {
-			if suffixDiff.Suffix > 4 {
+			if bytes.Equal(stemStateDiff.Stem[:], common.Hex2Bytes("97f2911f5efe08b74c28727d004e36d260225e73525fe2a300c8f58c7ffd76")) {
+				// BLOCKHASH contract stem
+				if len(stemStateDiff.SuffixDiffs) > 1 {
+					t.Fatalf("invalid suffix diff count found for BLOCKHASH contract at block #2: %d != 1", len(stemStateDiff.SuffixDiffs))
+				}
+				if stemStateDiff.SuffixDiffs[0].Suffix != 65 {
+					t.Fatalf("invalid suffix diff value found for BLOCKHASH contract at block #2: %d != 65", stemStateDiff.SuffixDiffs[0].Suffix)
+				}
+			} else if suffixDiff.Suffix > 4 {
 				t.Fatalf("invalid suffix diff found for %x in block #2: %d\n", stemStateDiff.Stem, suffixDiff.Suffix)
 			}
+
 		}
 	}
 }

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -685,7 +685,6 @@ func TestProcessVerkleiInvalidContractCreation(t *testing.T) {
 			} else if suffixDiff.Suffix > 4 {
 				t.Fatalf("invalid suffix diff found for %x in block #2: %d\n", stemStateDiff.Stem, suffixDiff.Suffix)
 			}
-
 		}
 	}
 }


### PR DESCRIPTION
Adding this stem is necessary for the stateless execution to be able to determine if the block height is at least 256 blocks past the fork block, and therefore if it needs to activate.