### PR TITLE
[DON'T MERGE] core: State processor: Set nonce of `HistoryStorageAddress` to 1

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -367,6 +367,10 @@ func (kvm *keyValueMigrator) migrateCollectedKeyValues(tree *trie.VerkleTrie) er
 func ProcessParentBlockHash(statedb *state.StateDB, prevNumber uint64, prevHash common.Hash) {
 	var key common.Hash
 	binary.BigEndian.PutUint64(key[24:], prevNumber)
+	if !statedb.Exist(params.HistoryStorageAddress) {
+		statedb.CreateAccount(params.HistoryStorageAddress)
+		statedb.SetNonce(params.HistoryStorageAddress, 1)
+	}
 	statedb.SetState(params.HistoryStorageAddress, key, prevHash)
 	index, suffix := utils.GetTreeKeyStorageSlotTreeIndexes(key[:])
 	statedb.Witness().TouchAddressOnWriteAndComputeGas(params.HistoryStorageAddress[:], *index, suffix)


### PR DESCRIPTION
I was playing around with t8n on the execution spec tests to generate fixtures for EIP-2935, and I found out that the storage was not actually being set, or rather it was being set and then deleted because the account was code-less and its nonce was zero.

This is the same issue found during the stateful-precompile phase of 4788, when we decided to make a normal smart-contract account to save the storage.

I don't think we should merge this, and rather the EIP should be modified to take this into account, so I just wanted to point out the issue with this PR and share the hack I'm using to generate the tests.

cc @gballet 