### PR TITLE
state: make EIP-158 ignore history block hash contract address

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -937,7 +937,7 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 			// Thus, we can safely ignore it here
 			continue
 		}
-		if obj.selfDestructed || (deleteEmptyObjects && obj.empty()) {
+		if (obj.selfDestructed || (deleteEmptyObjects && obj.empty())) && addr != params.HistoryStorageAddress {
 			obj.deleted = true
 
 			// We need to maintain account deletions explicitly (will remain

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -544,7 +544,7 @@ func TestProcessVerkle(t *testing.T) {
 	}
 }
 
-func TestProcessVerkleiInvalidContractCreation(t *testing.T) {
+func TestProcessVerkleInvalidContractCreation(t *testing.T) {
 	var (
 		config = &params.ChainConfig{
 			ChainID:                       big.NewInt(69420),
@@ -681,6 +681,12 @@ func TestProcessVerkleiInvalidContractCreation(t *testing.T) {
 				}
 				if stemStateDiff.SuffixDiffs[0].Suffix != 65 {
 					t.Fatalf("invalid suffix diff value found for BLOCKHASH contract at block #2: %d != 65", stemStateDiff.SuffixDiffs[0].Suffix)
+				}
+				if stemStateDiff.SuffixDiffs[0].NewValue == nil {
+					t.Fatalf("missing post state value for BLOCKHASH contract at block #2")
+				}
+				if *stemStateDiff.SuffixDiffs[0].NewValue != common.HexToHash("53abcdfb284720ea59efe923d3dc774bbb7e787d829599f8ec7a81d344dd3d17") {
+					t.Fatalf("invalid post state value for BLOCKHASH contract at block #2: %x != ", (*stemStateDiff.SuffixDiffs[0].NewValue)[:])
 				}
 			} else if suffixDiff.Suffix > 4 {
 				t.Fatalf("invalid suffix diff found for %x in block #2: %d\n", stemStateDiff.Stem, suffixDiff.Suffix)


### PR DESCRIPTION
This PR fixes a bug regarding the post-value of the history block hash contract being `unchanged`.

The reason is that EIP-158 was (correctly) deleting the account for this address since the code, balance, and nonce are zero.

I've confirmed this reproduced in the current test and added extra checks to enforce that it can't happen again (since the tests assertions where checking that the key was in the witness, but not the post-state value expectation).