### PR TITLE
fix addr alignment in witness

### DIFF
--- a/core/state/access_witness.go
+++ b/core/state/access_witness.go
@@ -244,7 +244,7 @@ type branchAccessKey struct {
 
 func newBranchAccessKey(addr []byte, treeIndex uint256.Int) branchAccessKey {
 	var sk branchAccessKey
-	copy(sk.addr[:], addr)
+	copy(sk.addr[20-len(addr):], addr)
 	sk.treeIndex = treeIndex
 	return sk
 }


### PR DESCRIPTION
This PR fixes a problem in EXTCODESIZE when the slot value had a value <20 bytes.