### PR TITLE
Resumable replays & fix precompile fork ordering

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -320,7 +320,6 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		// but that's left out to a later PR since there's not really a need
 		// right now.
 		bc.stateCache.InitTransitionStatus(true, true)
-		bc.stateCache.EndVerkleTransition()
 	}
 
 	if !bc.stateCache.Transitioned() && !bc.HasState(head.Root) {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -323,7 +323,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		bc.stateCache.EndVerkleTransition()
 	}
 
-	if !bc.HasState(head.Root) {
+	if !bc.stateCache.Transitioned() && !bc.HasState(head.Root) {
 		// Head state is missing, before the state recovery, find out the
 		// disk layer point of snapshot(if it's enabled). Make sure the
 		// rewound point is lower than disk layer.

--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -225,7 +225,6 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 	// verkle transition: if the conversion process is in progress, move
 	// N values from the MPT into the verkle tree.
 	if migrdb.InTransition() {
-		fmt.Printf("Processing verkle conversion starting at %x %x, building on top of %x\n", migrdb.GetCurrentAccountHash(), migrdb.GetCurrentSlotHash(), root)
 		var (
 			now             = time.Now()
 			tt              = statedb.GetTrie().(*trie.TransitionTrie)

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -230,6 +230,7 @@ func (db *cachingDB) StartVerkleTransition(originalRoot, translatedRoot common.H
                                                     |__|`)
 	db.CurrentTransitionState = &TransitionState{
 		started: true,
+		ended:   false,
 		// initialize so that the first storage-less accounts are processed
 		StorageProcessed: true,
 	}
@@ -577,10 +578,7 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 	// as a verkle database.
 	ts, ok := db.TransitionStatePerRoot[root]
 	if !ok || ts == nil {
-		transitionEnded, err := db.disk.Get(keyVerkleTransitionEnded)
-		if err != nil {
-			panic(err) // This is fine since this branch is only used for replay
-		}
+		transitionEnded, _ := db.disk.Get(keyVerkleTransitionEnded)
 		ended := db.triedb.IsVerkle() || bytes.Equal(transitionEnded, []byte{0x1})
 		// Start with a fresh state
 		ts = &TransitionState{ended: ended}

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -240,6 +240,9 @@ func (db *cachingDB) StartVerkleTransition(originalRoot, translatedRoot common.H
 	if pragueTime != nil {
 		chainConfig.PragueTime = pragueTime
 	}
+	if err := db.disk.Put(keyVerkleTransitionEnded, []byte{0}); err != nil {
+		panic(err) // This is fine since this branch is only used for replay
+	}
 }
 
 func (db *cachingDB) ReorgThroughVerkleTransition() {
@@ -578,7 +581,7 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 		if err != nil {
 			panic(err) // This is fine since this branch is only used for replay
 		}
-		ended := db.triedb.IsVerkle() || bytes.Equal(transitionEnded, []byte("1"))
+		ended := db.triedb.IsVerkle() || bytes.Equal(transitionEnded, []byte{0x1})
 		// Start with a fresh state
 		ts = &TransitionState{ended: ended}
 	}

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -151,7 +151,7 @@ func init() {
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
 	case rules.IsPrague:
-		return PrecompiledAddressesBerlin
+		return PrecompiledAddressesByzantium
 	case rules.IsCancun:
 		return PrecompiledAddressesCancun
 	case rules.IsBerlin:

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -42,7 +42,7 @@ func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
 	case evm.chainRules.IsPrague:
-		precompiles = PrecompiledContractsBerlin
+		precompiles = PrecompiledContractsByzantium
 	case evm.chainRules.IsCancun:
 		precompiles = PrecompiledContractsCancun
 	case evm.chainRules.IsBerlin:


### PR DESCRIPTION
This PR:
- Does some changes such that a replay run can be Ctrl+Ced after the transition has finished, and allow to run the replay again moving forward from the saved state. This doesn't require any flag, or extra consideration.
- Fixes the Prague precompile configuration, which caused an invalid gas problem due to a precompile related to a bn256 operation changing the gas costs between forks.