### PR TITLE
instruction: fix integer underflow that causes an infinite loop

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -401,10 +401,12 @@ func touchCodeChunksRangeOnReadAndChargeGas(contractAddr []byte, startPC, size u
 		return 0
 	}
 
-	// endPC is the last PC that must be touched.
-	endPC := startPC + size - 1
-	if startPC+size > codeLen {
+	endPC := startPC + size
+	if endPC > codeLen {
 		endPC = codeLen
+	}
+	if endPC > 0 {
+		endPC -= 1 // endPC is the last bytecode that will be touched.
 	}
 
 	var statelessGasCharged uint64


### PR DESCRIPTION
This PR fixes a bug in the `endPC` calculation when touching code that caused an infinite loop (and thus OOM situation).