### PR TITLE
persist conversion state to db and use an LRU cache for active transition states

### DIFF
--- a/.github/workflows/conversion.yml
+++ b/.github/workflows/conversion.yml
@@ -1,0 +1,75 @@
+name: Overlay conversion
+
+on:
+  push:
+    branches: [ master, transition-post-genesis, store-transition-state-in-db ]
+  pull_request:
+    branches: [ master, kaustinen-with-shapella, transition-post-genesis, store-transition-state-in-db, lock-overlay-transition  ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.21.1
+
+      - name: Cleanup from previous runs
+        run: |
+          rm -f log.txt
+          rm -rf .shadowfork
+          rm -f genesis.json
+
+      - name: Download genesis file
+        run: wget https://gist.githubusercontent.com/gballet/0b02a025428aa0e7b67941864d54716c/raw/bfb4e158bca5217b356a19b2ec55c4a45a7b2bad/genesis.json
+
+      - name: Init data
+        run: go run ./cmd/geth --dev --cache.preimages init genesis.json
+
+      - name: Run geth in devmode
+        run: go run ./cmd/geth --dev --dev.period=5 --cache.preimages --http --datadir=.shadowfork --override.overlay-stride=10 --override.prague=$(($(date +%s) + 45)) > log.txt &
+
+      - name: Wait for the transition to start
+        run: |
+          start_time=$(date +%s)
+          while true; do
+            sleep 5
+            current_time=$(date +%s)
+            elapsed_time=$((current_time - start_time))
+
+            # 2 minute timeout
+            if [ $elapsed_time -ge 120 ]; then
+              kill -9 $(pgrep -f geth)
+              exit 1
+            fi
+
+            # Check for signs that the conversion has started
+            if grep -q "Processing verkle conversion starting at" log.txt; then
+              break
+            fi
+          done
+
+      - name: Wait for the transition to end
+        run: |
+          start_time=$(date +%s)
+          while true; do
+            sleep 5
+            current_time=$(date +%s)
+            elapsed_time=$((current_time - start_time))
+
+            # 10 minute timeout
+            if [ $elapsed_time -ge 300 ]; then
+              cat log.txt
+              kill -9 $(pgrep -f geth)
+              exit 1
+            fi
+
+            # Check for signs that the conversion has started
+            if egrep -q "at block.*performing transition\? false" log.txt; then
+              kill -9 $(pgrep -f geth)
+              break
+            fi
+          done

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -411,6 +411,8 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 			return nil, fmt.Errorf("nil parent header for block %d", header.Number)
 		}
 
+		// Load transition state at beginning of block, because
+		// OpenTrie needs to know what the conversion status is.
 		state.Database().LoadTransitionState(parent.Root)
 
 		if chain.Config().ProofInBlocks {

--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -208,7 +208,7 @@ func (kvm *keyValueMigrator) migrateCollectedKeyValues(tree *trie.VerkleTrie) er
 	if kvm.prepareErr != nil {
 		return fmt.Errorf("failed to prepare key values: %w", kvm.prepareErr)
 	}
-	log.Info("Prepared key values from base tree", "duration", time.Since(now))
+	fmt.Println("Prepared key values from base tree", "duration", time.Since(now))
 
 	// Insert into the tree.
 	if err := tree.InsertMigratedLeaves(kvm.newLeaves); err != nil {
@@ -289,7 +289,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 		for count < maxMovedCount {
 			acc, err := types.FullAccount(accIt.Account())
 			if err != nil {
-				log.Error("Invalid account encountered during traversal", "error", err)
+				fmt.Println("Invalid account encountered during traversal", "error", err)
 				return err
 			}
 			vkt.SetStorageRootConversion(*migrdb.GetCurrentAccountAddress(), acc.Root)
@@ -416,7 +416,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 		}
 		migrdb.SetCurrentPreimageOffset(preimageSeek)
 
-		log.Info("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account", statedb.Database().GetCurrentAccountHash(), "storage processed", statedb.Database().GetStorageProcessed(), "last storage", statedb.Database().GetCurrentSlotHash())
+		fmt.Println("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account", statedb.Database().GetCurrentAccountHash(), "storage processed", statedb.Database().GetStorageProcessed(), "last storage", statedb.Database().GetCurrentSlotHash())
 
 		// Take all the collected key-values and prepare the new leaf values.
 		// This fires a background routine that will start doing the work that
@@ -431,7 +431,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 		if err := mkv.migrateCollectedKeyValues(tt.Overlay()); err != nil {
 			return fmt.Errorf("could not migrate key values: %w", err)
 		}
-		log.Info("Inserted key values in overlay tree", "count", count, "duration", time.Since(now))
+		fmt.Println("Inserted key values in overlay tree", "count", count, "duration", time.Since(now))
 	}
 
 	return nil

--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -399,11 +399,10 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 							return fmt.Errorf("account address len is zero is not 20: %d", len(addr))
 						}
 					}
-					// fmt.Printf("account switch: %s != %s\n", crypto.Keccak256Hash(addr[:]), accIt.Hash())
 					if crypto.Keccak256Hash(addr[:]) != accIt.Hash() {
 						return fmt.Errorf("preimage file does not match account hash: %s != %s", crypto.Keccak256Hash(addr[:]), accIt.Hash())
 					}
-					log.Trace("Converting account address", "hash", accIt.Hash(), "addr", addr)
+					fmt.Printf("Converting account address hash=%x addr=%x", accIt.Hash(), addr)
 					preimageSeek += int64(len(addr))
 					migrdb.SetCurrentAccountAddress(addr)
 				} else {
@@ -416,7 +415,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 		}
 		migrdb.SetCurrentPreimageOffset(preimageSeek)
 
-		fmt.Println("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account", statedb.Database().GetCurrentAccountHash(), "storage processed", statedb.Database().GetStorageProcessed(), "last storage", statedb.Database().GetCurrentSlotHash())
+		fmt.Println("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account hash", statedb.Database().GetCurrentAccountHash(), "last account address", statedb.Database().GetCurrentAccountAddress(), "storage processed", statedb.Database().GetStorageProcessed(), "last storage", statedb.Database().GetCurrentSlotHash())
 
 		// Take all the collected key-values and prepare the new leaf values.
 		// This fires a background routine that will start doing the work that

--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -208,7 +208,7 @@ func (kvm *keyValueMigrator) migrateCollectedKeyValues(tree *trie.VerkleTrie) er
 	if kvm.prepareErr != nil {
 		return fmt.Errorf("failed to prepare key values: %w", kvm.prepareErr)
 	}
-	fmt.Println("Prepared key values from base tree", "duration", time.Since(now))
+	log.Info("Prepared key values from base tree", "duration", time.Since(now))
 
 	// Insert into the tree.
 	if err := tree.InsertMigratedLeaves(kvm.newLeaves); err != nil {
@@ -404,9 +404,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 					if crypto.Keccak256Hash(addr[:]) != accIt.Hash() {
 						return fmt.Errorf("preimage file does not match account hash: %s != %s", crypto.Keccak256Hash(addr[:]), accIt.Hash())
 					}
-					if count%100 == 0 {
-						fmt.Printf("Converting account address hash=%x addr=%x\n", accIt.Hash(), addr)
-					}
+					log.Trace("Converting account address", "hash", accIt.Hash(), "addr", addr)
 					preimageSeek += int64(len(addr))
 					migrdb.SetCurrentAccountAddress(addr)
 				} else {
@@ -419,7 +417,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 		}
 		migrdb.SetCurrentPreimageOffset(preimageSeek)
 
-		fmt.Println("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account hash", statedb.Database().GetCurrentAccountHash(), "last account address", statedb.Database().GetCurrentAccountAddress(), "storage processed", statedb.Database().GetStorageProcessed(), "last storage", statedb.Database().GetCurrentSlotHash())
+		log.Info("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account hash", statedb.Database().GetCurrentAccountHash(), "last account address", statedb.Database().GetCurrentAccountAddress(), "storage processed", statedb.Database().GetStorageProcessed(), "last storage", statedb.Database().GetCurrentSlotHash())
 
 		// Take all the collected key-values and prepare the new leaf values.
 		// This fires a background routine that will start doing the work that
@@ -434,7 +432,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 		if err := mkv.migrateCollectedKeyValues(tt.Overlay()); err != nil {
 			return fmt.Errorf("could not migrate key values: %w", err)
 		}
-		fmt.Println("Inserted key values in overlay tree", "count", count, "duration", time.Since(now))
+		log.Info("Inserted key values in overlay tree", "count", count, "duration", time.Since(now))
 	}
 
 	return nil

--- a/core/rawdb/accessors_overlay.go
+++ b/core/rawdb/accessors_overlay.go
@@ -1,0 +1,30 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+func ReadVerkleTransitionState(db ethdb.KeyValueReader, hash common.Hash) ([]byte, error) {
+	return db.Get(transitionStateKey(hash))
+}
+
+func WriteVerkleTransitionState(db ethdb.KeyValueWriter, hash common.Hash, state []byte) error {
+	return db.Put(transitionStateKey(hash), state)
+}

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -122,6 +122,8 @@ var (
 
 	CliqueSnapshotPrefix = []byte("clique-")
 
+	VerkleTransitionStatePrefix = []byte("verkle-transition-state-")
+
 	preimageCounter    = metrics.NewRegisteredCounter("db/preimage/total", nil)
 	preimageHitCounter = metrics.NewRegisteredCounter("db/preimage/hits", nil)
 )
@@ -248,6 +250,11 @@ func accountTrieNodeKey(path []byte) []byte {
 // storageTrieNodeKey = trieNodeStoragePrefix + accountHash + nodePath.
 func storageTrieNodeKey(accountHash common.Hash, path []byte) []byte {
 	return append(append(trieNodeStoragePrefix, accountHash.Bytes()...), path...)
+}
+
+// transitionStateKey = transitionStatusKey + hash
+func transitionStateKey(hash common.Hash) []byte {
+	return append(VerkleTransitionStatePrefix, hash.Bytes()...)
 }
 
 // IsLegacyTrieNode reports whether a provided database entry is a legacy trie

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -21,6 +21,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
@@ -611,4 +612,5 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 	db.CurrentTransitionState = ts.Copy()
 
 	fmt.Println("loaded transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
+	debug.PrintStack()
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -560,7 +560,7 @@ func (db *cachingDB) SaveTransitionState(root common.Hash) {
 		enc := gob.NewEncoder(&buf)
 		err := enc.Encode(db.CurrentTransitionState)
 		if err != nil {
-			log.Crit("failed to encode transition state", "err", err)
+			log.Error("failed to encode transition state", "err", err)
 			return
 		}
 
@@ -572,7 +572,7 @@ func (db *cachingDB) SaveTransitionState(root common.Hash) {
 			rawdb.WriteVerkleTransitionState(db.DiskDB(), root, buf.Bytes())
 		}
 
-		fmt.Println("saving transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
+		log.Debug("saving transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
 	}
 }
 
@@ -590,6 +590,7 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 			return
 		}
 
+                // if a state could be read from the db, attempt to decode it
 		if len(data) > 0 {
 			var (
 				newts TransitionState
@@ -605,12 +606,12 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 			ts = &newts
 		}
 
-		// Fallback
+		// Fallback that should only happen before the transition
 		if ts == nil {
 			// Initialize the first transition state, with the "ended"
 			// field set to true if the database was created
 			// as a verkle database.
-			fmt.Println("no transition state found, starting fresh", "is verkle", db.triedb.IsVerkle())
+			log.Debug("no transition state found, starting fresh", "is verkle", db.triedb.IsVerkle())
 			// Start with a fresh state
 			ts = &TransitionState{ended: db.triedb.IsVerkle()}
 		}
@@ -620,7 +621,7 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 	// doesn't get overwritten.
 	db.CurrentTransitionState = ts.Copy()
 
-	fmt.Println("loaded transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
+	log.Debug("loaded transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
 	debug.PrintStack()
 }
 

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -569,8 +569,10 @@ func (db *cachingDB) SaveTransitionState(root common.Hash) {
 }
 
 func (db *cachingDB) LoadTransitionState(root common.Hash) {
-	var ts *TransitionState
-	if !db.TransitionStatePerRoot.Contains(root) {
+	// Try to get the transition state from the cache and
+	// the DB if it's not there.
+	ts, ok := db.TransitionStatePerRoot.Get(root)
+	if !ok {
 		// Not in the cache, try getting it from the DB
 		data, err := rawdb.ReadVerkleTransitionState(db.DiskDB(), root)
 		if err != nil {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -546,8 +546,6 @@ func (db *cachingDB) SetLastMerkleRoot(merkleRoot common.Hash) {
 }
 
 func (db *cachingDB) SaveTransitionState(root common.Hash) {
-	db.TransitionStatePerRoot = lru.NewBasicLRU[common.Hash, *TransitionState](100)
-
 	if db.CurrentTransitionState != nil {
 		encoded, err := rlp.EncodeToBytes(db.CurrentTransitionState)
 		if err != nil {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
@@ -105,6 +106,10 @@ type Database interface {
 	SaveTransitionState(common.Hash)
 
 	LoadTransitionState(common.Hash)
+
+	LockCurrentTransitionState()
+
+	UnLockCurrentTransitionState()
 }
 
 // Trie is a Ethereum Merkle Patricia trie.
@@ -311,11 +316,11 @@ type cachingDB struct {
 	LastMerkleRoot         common.Hash // root hash of the read-only base tree
 	CurrentTransitionState *TransitionState
 	TransitionStatePerRoot lru.BasicLRU[common.Hash, *TransitionState]
+	transitionStateLock    sync.Mutex
 
 	addrToPoint *utils.PointCache
 
 	baseRoot common.Hash // hash of the read-only base tree
-
 }
 
 func (db *cachingDB) openMPTTrie(root common.Hash) (Trie, error) {
@@ -548,6 +553,8 @@ func (db *cachingDB) SetLastMerkleRoot(merkleRoot common.Hash) {
 }
 
 func (db *cachingDB) SaveTransitionState(root common.Hash) {
+	db.transitionStateLock.Lock()
+	defer db.transitionStateLock.Unlock()
 	if db.CurrentTransitionState != nil {
 		var buf bytes.Buffer
 		enc := gob.NewEncoder(&buf)
@@ -570,6 +577,8 @@ func (db *cachingDB) SaveTransitionState(root common.Hash) {
 }
 
 func (db *cachingDB) LoadTransitionState(root common.Hash) {
+	db.transitionStateLock.Lock()
+	defer db.transitionStateLock.Unlock()
 	// Try to get the transition state from the cache and
 	// the DB if it's not there.
 	ts, ok := db.TransitionStatePerRoot.Get(root)
@@ -613,4 +622,12 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 
 	fmt.Println("loaded transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
 	debug.PrintStack()
+}
+
+func (db *cachingDB) LockCurrentTransitionState() {
+	db.transitionStateLock.Lock()
+}
+
+func (db *cachingDB) UnLockCurrentTransitionState() {
+	db.transitionStateLock.Unlock()
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -564,7 +564,7 @@ func (db *cachingDB) SaveTransitionState(root common.Hash) {
 			rawdb.WriteVerkleTransitionState(db.DiskDB(), root, buf.Bytes())
 		}
 
-		log.Debug("saving transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
+		fmt.Println("saving transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
 	}
 }
 
@@ -600,7 +600,7 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 			// Initialize the first transition state, with the "ended"
 			// field set to true if the database was created
 			// as a verkle database.
-			log.Debug("no transition state found, starting fresh", "is verkle", db.triedb.IsVerkle())
+			fmt.Println("no transition state found, starting fresh", "is verkle", db.triedb.IsVerkle())
 			// Start with a fresh state
 			ts = &TransitionState{ended: db.triedb.IsVerkle()}
 		}
@@ -610,5 +610,5 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 	// doesn't get overwritten.
 	db.CurrentTransitionState = ts.Copy()
 
-	log.Debug("loaded transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
+	fmt.Println("loaded transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -553,9 +553,11 @@ func (db *cachingDB) SaveTransitionState(root common.Hash) {
 			return
 		}
 
-		// Copy so that the address pointer isn't updated after
-		// it has been saved.
-		db.TransitionStatePerRoot.Add(root, db.CurrentTransitionState.Copy())
+		if !db.TransitionStatePerRoot.Contains(root) {
+			// Copy so that the address pointer isn't updated after
+			// it has been saved.
+			db.TransitionStatePerRoot.Add(root, db.CurrentTransitionState.Copy())
+		}
 
 		rawdb.WriteVerkleTransitionState(db.DiskDB(), root, encoded)
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -61,7 +61,7 @@ func NewStateProcessor(config *params.ChainConfig, bc *BlockChain, engine consen
 // returns the amount of gas that was used in the process. If any of the
 // transactions failed to execute due to insufficient gas it will return an error.
 func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, error) {
-	fmt.Println("process block", statedb.Database().GetCurrentAccountAddress(), statedb.Database().GetCurrentAccountHash())
+	fmt.Println("process block", block.NumberU64())
 	var (
 		receipts    types.Receipts
 		usedGas     = new(uint64)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -61,7 +61,6 @@ func NewStateProcessor(config *params.ChainConfig, bc *BlockChain, engine consen
 // returns the amount of gas that was used in the process. If any of the
 // transactions failed to execute due to insufficient gas it will return an error.
 func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, error) {
-	fmt.Println("process block", block.NumberU64())
 	var (
 		receipts    types.Receipts
 		usedGas     = new(uint64)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -108,12 +108,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		return nil, nil, 0, errors.New("withdrawals before shanghai")
 	}
 
-	// Perform the overlay transition, if relevant
-	//parent := p.bc.GetHeaderByHash(header.ParentHash)
-	//if err := OverlayVerkleTransition(statedb, parent.Root); err != nil {
-	//	return nil, nil, 0, fmt.Errorf("error performing verkle overlay transition: %w", err)
-	//}
-
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.engine.Finalize(p.bc, header, statedb, block.Transactions(), block.Uncles(), withdrawals)
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -61,6 +61,7 @@ func NewStateProcessor(config *params.ChainConfig, bc *BlockChain, engine consen
 // returns the amount of gas that was used in the process. If any of the
 // transactions failed to execute due to insufficient gas it will return an error.
 func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, error) {
+	fmt.Println("process block", statedb.Database().GetCurrentAccountAddress(), statedb.Database().GetCurrentAccountHash())
 	var (
 		receipts    types.Receipts
 		usedGas     = new(uint64)

--- a/light/trie.go
+++ b/light/trie.go
@@ -177,6 +177,13 @@ func (db *odrDatabase) LoadTransitionState(common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
+func (db *odrDatabase) LockCurrentTransitionState() {
+	panic("not implemented") // TODO: Implement
+}
+func (db *odrDatabase) UnLockCurrentTransitionState() {
+	panic("not implemented") // TODO: Implement
+}
+
 type odrTrie struct {
 	db   *odrDatabase
 	id   *TrieID


### PR DESCRIPTION
Some issue appeared in the shadowfork branch, due to the fact that when, for whatever reason, a new database is created, it will check if verkle was activated at genesis as a heuristic to determine if the transition has already happened. If so, it will declare `ended` as `true`.

When a block is inserted through the execution engine api, such a database is created, and it seems that it determines the activation of verkle the wrong way. This is because it uses the current time in order to see if verkle is active at genesis. This works at genesis, but if the database is created AFTER the verkle activation, it will assume that the transition has already completed. This creates a weird situation in which the miner produces a block whose conversion has started (and potentially completed) but the insertion into the blockchain when the produced block is passed via the engine api, says it's already completed, and thus it doesn't stop.

This is only one of many issues that stem from the fact that there is no disk storage of the conversion state, and therefore that it needs to either be centralized or "guessed". For example, it is impossible to stop geth during the conversion, to be resumed later. Another issue, not completely related, is that all the states were stored in a map that keeps growing.

In order to address all these problems, the conversion state at each block is now written to disk, and then put in an LRU list. If the conversion state for a given block root is not found in the LRU list, the database is searched for it. If it's not there, then the assumption that we are looking at a fresh database, and so the heuristc "was verkle active at genesis" is correct to determine if the conversion has ended.

There is still the question of whether there should be a way not to use the conversion state once the conversion has finalized. This is not a big problem anymore, as the LRU prevents the list from growing indefinitely. Nonetheless, it would be nice to cover than in a future PR.

This PR also includes a few "riders":
 - adding a CI test to perform the conversion on a simple network
 - adds a lock for the transition in order to avoid concurrency issues between the engine api handler and the miner.