### PR TITLE
cmd/evm: fixes

### DIFF
--- a/cmd/evm/internal/t8ntool/flags.go
+++ b/cmd/evm/internal/t8ntool/flags.go
@@ -91,6 +91,10 @@ var (
 		Usage: "`stdin` or file name of where to find the prestate alloc to use.",
 		Value: "alloc.json",
 	}
+	InputAllocMPTFlag = &cli.StringFlag{
+		Name:  "input.allocMPT",
+		Usage: "`stdin` or file name of where to find the prestate alloc of the MPT to use.",
+	}
 	InputEnvFlag = &cli.StringFlag{
 		Name:  "input.env",
 		Usage: "`stdin` or file name of where to find the prestate env to use.",

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -500,18 +500,25 @@ func (db *cachingDB) SetCurrentAccountAddress(addr common.Address) {
 
 func (db *cachingDB) GetCurrentAccountHash() common.Hash {
 	var addrHash common.Hash
-	if db.CurrentTransitionState.CurrentAccountAddress != nil {
+	if db.CurrentTransitionState != nil && db.CurrentTransitionState.CurrentAccountAddress != nil {
 		addrHash = crypto.Keccak256Hash(db.CurrentTransitionState.CurrentAccountAddress[:])
 	}
 	return addrHash
 }
 
 func (db *cachingDB) GetCurrentAccountAddress() *common.Address {
+	if db.CurrentTransitionState == nil {
+		return nil
+	}
 	return db.CurrentTransitionState.CurrentAccountAddress
 }
 
 func (db *cachingDB) GetCurrentPreimageOffset() int64 {
-	return db.CurrentTransitionState.CurrentPreimageOffset
+	var offset int64
+	if db.CurrentTransitionState != nil {
+		offset = db.CurrentTransitionState.CurrentPreimageOffset
+	}
+	return offset
 }
 
 func (db *cachingDB) SetCurrentPreimageOffset(offset int64) {
@@ -523,7 +530,11 @@ func (db *cachingDB) SetCurrentSlotHash(hash common.Hash) {
 }
 
 func (db *cachingDB) GetCurrentSlotHash() common.Hash {
-	return db.CurrentTransitionState.CurrentSlotHash
+	var slotHash common.Hash
+	if db.CurrentTransitionState != nil {
+		slotHash = db.CurrentTransitionState.CurrentSlotHash
+	}
+	return slotHash
 }
 
 func (db *cachingDB) SetStorageProcessed(processed bool) {
@@ -531,7 +542,11 @@ func (db *cachingDB) SetStorageProcessed(processed bool) {
 }
 
 func (db *cachingDB) GetStorageProcessed() bool {
-	return db.CurrentTransitionState.StorageProcessed
+	var processed bool
+	if db.CurrentTransitionState != nil {
+		processed = db.CurrentTransitionState.StorageProcessed
+	}
+	return processed
 }
 
 func (db *cachingDB) AddRootTranslation(originalRoot, translatedRoot common.Hash) {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -339,7 +339,7 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 		mpt Trie
 		err error
 	)
-	log.Info("opening trie with root %x, %v %v\n", root, db.InTransition(), db.Transitioned())
+	log.Info("opening trie", "root", root, "InTransition", db.InTransition(), "Transitioned", db.Transitioned())
 
 	// TODO separate both cases when I can be certain that it won't
 	// find a Verkle trie where is expects a Transitoion trie.
@@ -405,7 +405,7 @@ func (db *cachingDB) OpenStorageTrie(stateRoot common.Hash, address common.Addre
 		}
 	}
 	if db.InTransition() {
-		log.Info("OpenStorageTrie during transition, state root=%x root=%x\n", stateRoot, root)
+		log.Info("OpenStorageTrie during transition", "stateRoot", stateRoot, "root", root)
 		mpt, err := db.openStorageMPTrie(db.LastMerkleRoot, address, root, nil)
 		if err != nil {
 			return nil, err

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -507,18 +507,11 @@ func (db *cachingDB) GetCurrentAccountHash() common.Hash {
 }
 
 func (db *cachingDB) GetCurrentAccountAddress() *common.Address {
-	if db.CurrentTransitionState == nil {
-		return nil
-	}
 	return db.CurrentTransitionState.CurrentAccountAddress
 }
 
 func (db *cachingDB) GetCurrentPreimageOffset() int64 {
-	var offset int64
-	if db.CurrentTransitionState != nil {
-		offset = db.CurrentTransitionState.CurrentPreimageOffset
-	}
-	return offset
+return db.CurrentTransitionState.CurrentPreimageOffset
 }
 
 func (db *cachingDB) SetCurrentPreimageOffset(offset int64) {
@@ -530,11 +523,7 @@ func (db *cachingDB) SetCurrentSlotHash(hash common.Hash) {
 }
 
 func (db *cachingDB) GetCurrentSlotHash() common.Hash {
-	var slotHash common.Hash
-	if db.CurrentTransitionState != nil {
-		slotHash = db.CurrentTransitionState.CurrentSlotHash
-	}
-	return slotHash
+	return db.CurrentTransitionState.CurrentSlotHash
 }
 
 func (db *cachingDB) SetStorageProcessed(processed bool) {
@@ -542,11 +531,7 @@ func (db *cachingDB) SetStorageProcessed(processed bool) {
 }
 
 func (db *cachingDB) GetStorageProcessed() bool {
-	var processed bool
-	if db.CurrentTransitionState != nil {
-		processed = db.CurrentTransitionState.StorageProcessed
-	}
-	return processed
+	return db.CurrentTransitionState.StorageProcessed
 }
 
 func (db *cachingDB) AddRootTranslation(originalRoot, translatedRoot common.Hash) {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -500,7 +500,7 @@ func (db *cachingDB) SetCurrentAccountAddress(addr common.Address) {
 
 func (db *cachingDB) GetCurrentAccountHash() common.Hash {
 	var addrHash common.Hash
-	if db.CurrentTransitionState != nil && db.CurrentTransitionState.CurrentAccountAddress != nil {
+	if db.CurrentTransitionState.CurrentAccountAddress != nil {
 		addrHash = crypto.Keccak256Hash(db.CurrentTransitionState.CurrentAccountAddress[:])
 	}
 	return addrHash
@@ -511,7 +511,7 @@ func (db *cachingDB) GetCurrentAccountAddress() *common.Address {
 }
 
 func (db *cachingDB) GetCurrentPreimageOffset() int64 {
-return db.CurrentTransitionState.CurrentPreimageOffset
+	return db.CurrentTransitionState.CurrentPreimageOffset
 }
 
 func (db *cachingDB) SetCurrentPreimageOffset(offset int64) {


### PR DESCRIPTION
Includes the following fixes:
- Really fix logging this time
- Add `--input.allocMPT` to the `evm` command, which can be used to supply the MPT during verkle transition
- Nil checks in `core/state/database.go` because we were getting some nil pointer exceptions when filling before verkle

Filling currently fails when the verkle transition is supposed to start due to `snapshot.New` returning a nil snapshot, possibly related to this? https://github.com/gballet/go-ethereum/blob/c3fc3b83ca1eeee246bf98e26bbcf441daeeba9f/core/state/snapshot/snapshot.go#L218-L228

Attached a zip to reproduce the issue, which is the current input we are producing using a Prague tests in execution-spec-tests.

[t8n_verkle_repro.zip](https://github.com/gballet/go-ethereum/files/14272477/t8n_verkle_repro.zip)