### PR TITLE
cmd/evm: Changes to the verkle activation/conversion logic

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -65,11 +65,11 @@ type ExecutionResult struct {
 	CurrentBlobGasUsed   *math.HexOrDecimal64  `json:"currentBlobGasUsed,omitempty"`
 
 	// Values to test the verkle conversion
-	CurrentAccountAddress *common.Address `json:"currentConversionAddress" gencodec:"optional"`
-	CurrentSlotHash       common.Hash     `json:"currentConversionSlotHash" gencodec:"optional"`
-	Started               bool            `json:"currentConversionStarted" gencodec:"optional"`
-	Ended                 bool            `json:"currentConversionEnded" gencodec:"optional"`
-	StorageProcessed      bool            `json:"currentConversionStorageProcessed" gencodec:"optional"`
+	CurrentAccountAddress *common.Address `json:"currentConversionAddress,omitempty" gencodec:"optional"`
+	CurrentSlotHash       *common.Hash    `json:"currentConversionSlotHash,omitempty" gencodec:"optional"`
+	Started               *bool           `json:"currentConversionStarted,omitempty" gencodec:"optional"`
+	Ended                 *bool           `json:"currentConversionEnded,omitempty" gencodec:"optional"`
+	StorageProcessed      *bool           `json:"currentConversionStorageProcessed,omitempty" gencodec:"optional"`
 }
 
 type ommer struct {
@@ -333,20 +333,16 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 	}
 	sdb := statedb.Database()
 	execRs := &ExecutionResult{
-		StateRoot:             root,
-		TxRoot:                types.DeriveSha(includedTxs, trie.NewStackTrie(nil)),
-		ReceiptRoot:           types.DeriveSha(receipts, trie.NewStackTrie(nil)),
-		Bloom:                 types.CreateBloom(receipts),
-		LogsHash:              rlpHash(statedb.Logs()),
-		Receipts:              receipts,
-		Rejected:              rejectedTxs,
-		Difficulty:            (*math.HexOrDecimal256)(vmContext.Difficulty),
-		GasUsed:               (math.HexOrDecimal64)(gasUsed),
-		BaseFee:               (*math.HexOrDecimal256)(vmContext.BaseFee),
-		CurrentAccountAddress: sdb.GetCurrentAccountAddress(),
-		CurrentSlotHash:       sdb.GetCurrentSlotHash(),
-		Started:               sdb.InTransition() && sdb.Transitioned(),
-		Ended:                 sdb.Transitioned(),
+		StateRoot:   root,
+		TxRoot:      types.DeriveSha(includedTxs, trie.NewStackTrie(nil)),
+		ReceiptRoot: types.DeriveSha(receipts, trie.NewStackTrie(nil)),
+		Bloom:       types.CreateBloom(receipts),
+		LogsHash:    rlpHash(statedb.Logs()),
+		Receipts:    receipts,
+		Rejected:    rejectedTxs,
+		Difficulty:  (*math.HexOrDecimal256)(vmContext.Difficulty),
+		GasUsed:     (math.HexOrDecimal64)(gasUsed),
+		BaseFee:     (*math.HexOrDecimal256)(vmContext.BaseFee),
 	}
 	if pre.Env.Withdrawals != nil {
 		h := types.DeriveSha(types.Withdrawals(pre.Env.Withdrawals), trie.NewStackTrie(nil))
@@ -355,6 +351,19 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 	if vmContext.ExcessBlobGas != nil {
 		execRs.CurrentExcessBlobGas = (*math.HexOrDecimal64)(vmContext.ExcessBlobGas)
 		execRs.CurrentBlobGasUsed = (*math.HexOrDecimal64)(&blobGasUsed)
+	}
+	if chainConfig.IsPrague(big.NewInt(int64(pre.Env.Number)), pre.Env.Timestamp) {
+		ended := sdb.Transitioned()
+		if !ended {
+			var (
+				currentSlotHash = sdb.GetCurrentSlotHash()
+				started         = sdb.InTransition() && sdb.Transitioned() // This can't be true
+			)
+			execRs.CurrentAccountAddress = sdb.GetCurrentAccountAddress()
+			execRs.CurrentSlotHash = &currentSlotHash
+			execRs.Started = &started
+		}
+		execRs.Ended = &ended
 	}
 	// Re-create statedb instance with new root upon the updated database
 	// for accessing latest states.
@@ -370,15 +379,23 @@ func MakePreState(db ethdb.Database, chainConfig *params.ChainConfig, pre *Prest
 
 	// Did we pass the verkle fork?
 	if chainConfig.IsPrague(big.NewInt(int64(pre.Env.Number)), pre.Env.Timestamp) {
-		// is this the verkle fork block?
-		if pre.Env.Number == 0 || !chainConfig.IsPrague(big.NewInt(int64(pre.Env.Number)-1), pre.Env.ParentTimestamp) {
+		if pre.Env.Ended == nil {
+			panic("Conversion flag `ended` is nil")
+		}
+		// has the conversion ended?
+		if *pre.Env.Ended {
+			sdb.InitTransitionStatus(true, true)
+
+			// Fallthrough to the MPT/post-conversion case
+		} else if pre.MPTPre == nil {
+			// This is the first block of the conversion.
+
 			// generate the snapshot from the pre state and start with a fresh tree
-			if pre.MPTPre == nil {
-				panic("MPTPre is required for verkle transition")
-			}
 			mptSdb := state.NewDatabaseWithConfig(db, &trie.Config{Preimages: true, Verkle: false})
 			statedb, _ := state.New(types.EmptyRootHash, mptSdb, nil)
-			for addr, a := range *pre.MPTPre {
+
+			// MPT pre is the same as the pre state for first conversion block
+			for addr, a := range pre.Pre {
 				statedb.SetCode(addr, a.Code)
 				statedb.SetNonce(addr, a.Nonce)
 				statedb.SetBalance(addr, a.Balance)
@@ -406,46 +423,36 @@ func MakePreState(db ethdb.Database, chainConfig *params.ChainConfig, pre *Prest
 
 			return statedb
 		} else {
-			// has the conversion ended?
-			if *pre.Env.Ended {
-				sdb.InitTransitionStatus(true, true)
+			sdb.InitTransitionStatus(*pre.Env.Started, *pre.Env.Ended)
+			sdb.SetCurrentAccountAddress(*pre.Env.CurrentAccountAddress)
+			sdb.SetCurrentSlotHash(*pre.Env.CurrentSlotHash)
+			sdb.SetStorageProcessed(*pre.Env.StorageProcessed)
 
-				// Fallthrough to the MPT/post-conversion case
-			} else {
-				sdb.InitTransitionStatus(*pre.Env.Started, *pre.Env.Ended)
-				sdb.SetCurrentAccountAddress(*pre.Env.CurrentAccountAddress)
-				sdb.SetCurrentSlotHash(*pre.Env.CurrentSlotHash)
-				sdb.SetStorageProcessed(*pre.Env.StorageProcessed)
-
-				// ongoing conversion, generate the snapshot from the pre state but also
-				// the intermediate verkle tree.
-				if pre.MPTPre == nil {
-					panic("MPTPre is required for verkle transition")
+			// ongoing conversion, generate the snapshot from the pre state but also
+			// the intermediate verkle tree.
+			statedb, _ := state.New(types.EmptyRootHash, sdb, nil)
+			for addr, a := range *pre.MPTPre {
+				statedb.SetCode(addr, a.Code)
+				statedb.SetNonce(addr, a.Nonce)
+				statedb.SetBalance(addr, a.Balance)
+				for k, v := range a.Storage {
+					statedb.SetState(addr, k, v)
 				}
-				statedb, _ := state.New(types.EmptyRootHash, sdb, nil)
-				for addr, a := range *pre.MPTPre {
-					statedb.SetCode(addr, a.Code)
-					statedb.SetNonce(addr, a.Nonce)
-					statedb.SetBalance(addr, a.Balance)
-					for k, v := range a.Storage {
-						statedb.SetState(addr, k, v)
-					}
-				}
-				// Commit and re-open to start with a clean state.
-				mptRoot, _ := statedb.Commit(0, false)
-				snaps, err := snapshot.New(snapshot.Config{AsyncBuild: false, CacheSize: 10}, sdb.DiskDB(), sdb.TrieDB(), mptRoot)
-				if err != nil {
-					panic(err)
-				}
-				if snaps == nil {
-					panic("snapshot is nil")
-				}
-				snaps.Cap(mptRoot, 0)
-
-				// Fallthrough to the MPT/post-conversion case
-				// Note to self: the next state.New should not need snaps as a
-				// parameter, as long as it's available in the diskdb.
 			}
+			// Commit and re-open to start with a clean state.
+			mptRoot, _ := statedb.Commit(0, false)
+			snaps, err := snapshot.New(snapshot.Config{AsyncBuild: false, CacheSize: 10}, sdb.DiskDB(), sdb.TrieDB(), mptRoot)
+			if err != nil {
+				panic(err)
+			}
+			if snaps == nil {
+				panic("snapshot is nil")
+			}
+			snaps.Cap(mptRoot, 0)
+
+			// Fallthrough to the MPT/post-conversion case
+			// Note to self: the next state.New should not need snaps as a
+			// parameter, as long as it's available in the diskdb.
 		}
 	}
 

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -144,6 +144,7 @@ var stateTransitionCommand = &cli.Command{
 		t8ntool.OutputResultFlag,
 		t8ntool.OutputBodyFlag,
 		t8ntool.InputAllocFlag,
+		t8ntool.InputAllocMPTFlag,
 		t8ntool.InputEnvFlag,
 		t8ntool.InputTxsFlag,
 		t8ntool.ForknameFlag,


### PR DESCRIPTION
I noticed that the transition into the verkle fork was not being correctly detected by the `evm` tool using this logic:
https://github.com/gballet/go-ethereum/blob/19aac228111d0d539a103d88306836c83b5a81f3/cmd/evm/internal/t8ntool/execution.go#L374

And the reason is that, regardless of what type of test we are running, we never use a transition fork (such as `ShanghaiToPragueAtTime32`) as value for parameter `--state.fork`. We instead always pass the currently active fork (we go from `Shanghai` to `Prague` on the very next block), so `chainConfig.IsPrague(big.NewInt(int64(pre.Env.Number)-1), pre.Env.ParentTimestamp)` always returns `true`.

This PR proposes a new logic to follow to determine whether the conversion is ongoing or completed:
1) The tests will always pass `currentConversionEnded` environment value if `--state.fork=Prague` or later.
2) If `currentConversionEnded` is equal to true, it can be assumed that the supplied pre-alloc is meant to be represented as a full verkle tree. This could be the case if:
  a) Prague is active since genesis
  b) We transitioned to Prague but the conversion has been completed (`currentConversionEnded: true` was returned from one `evm t8n` execution at some point)
3) If `currentConversionEnded` is equal to false, we could detect whether this is the first conversion block in either of the following ways:
 a) `pre.MPTPre` is nil (Method implemented in this PR)
 b) `pre.Env.CurrentAccountAddress` or `pre.Env.CurrentSlotHash` or similar are nil

Caveat is that `evm t8n` needs to keep returning `currentConversionEnded=true` forever, but I think that should not be an issue.

I think (2a) should be a good because we can produce tests for after the verkle conversion, but open to any other ideas too.

After this PR we are still getting `panic: snapshot is nil`. Attached zip to repro [t8n_repro.zip](https://github.com/gballet/go-ethereum/files/14289327/t8n_repro.zip)
