### PR TITLE
[wip] Merge access list and witness

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/ethereum/go-verkle"
-	"github.com/holiman/uint256"
 )
 
 // Proof-of-stake protocol constants.
@@ -359,11 +358,7 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 		state.AddBalance(w.Address, amount)
 
 		// The returned gas is not charged
-		state.Witness().TouchAddressOnWriteAndComputeGas(w.Address[:], uint256.Int{}, utils.VersionLeafKey)
-		state.Witness().TouchAddressOnWriteAndComputeGas(w.Address[:], uint256.Int{}, utils.BalanceLeafKey)
-		state.Witness().TouchAddressOnWriteAndComputeGas(w.Address[:], uint256.Int{}, utils.NonceLeafKey)
-		state.Witness().TouchAddressOnWriteAndComputeGas(w.Address[:], uint256.Int{}, utils.CodeKeccakLeafKey)
-		state.Witness().TouchAddressOnWriteAndComputeGas(w.Address[:], uint256.Int{}, utils.CodeSizeLeafKey)
+		state.Witness().TouchAndChargeContractCreateCompleted(w.Address[:])
 	}
 
 	if chain.Config().IsPrague(header.Number, header.Time) {

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -411,6 +411,8 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 			return nil, fmt.Errorf("nil parent header for block %d", header.Number)
 		}
 
+		// Load transition state at beginning of block, because
+		// OpenTrie needs to know what the conversion status is.
 		state.Database().LoadTransitionState(parent.Root)
 
 		if chain.Config().ProofInBlocks {

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/utils"
-	"github.com/holiman/uint256"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -569,7 +568,7 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 
 		// This should not happen, but it's useful for replay tests
 		if config.IsPrague(header.Number, header.Time) {
-			state.Witness().TouchAddressOnReadAndComputeGas(uncle.Coinbase.Bytes(), uint256.Int{}, utils.BalanceLeafKey)
+			state.Witness().TouchAddressOnReadAndComputeGas(uncle.Coinbase.Bytes(), common.Hash{}, utils.BalanceLeafKey)
 		}
 		state.AddBalance(uncle.Coinbase, r)
 
@@ -577,10 +576,7 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		reward.Add(reward, r)
 	}
 	if config.IsPrague(header.Number, header.Time) {
-		state.Witness().TouchAddressOnReadAndComputeGas(header.Coinbase.Bytes(), uint256.Int{}, utils.BalanceLeafKey)
-		state.Witness().TouchAddressOnReadAndComputeGas(header.Coinbase.Bytes(), uint256.Int{}, utils.VersionLeafKey)
-		state.Witness().TouchAddressOnReadAndComputeGas(header.Coinbase.Bytes(), uint256.Int{}, utils.NonceLeafKey)
-		state.Witness().TouchAddressOnReadAndComputeGas(header.Coinbase.Bytes(), uint256.Int{}, utils.CodeKeccakLeafKey)
+		state.Witness().TouchAndChargeProofOfAbsence(header.Coinbase[:])
 	}
 	state.AddBalance(header.Coinbase, reward)
 }

--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -208,7 +208,7 @@ func (kvm *keyValueMigrator) migrateCollectedKeyValues(tree *trie.VerkleTrie) er
 	if kvm.prepareErr != nil {
 		return fmt.Errorf("failed to prepare key values: %w", kvm.prepareErr)
 	}
-	log.Info("Prepared key values from base tree", "duration", time.Since(now))
+	fmt.Println("Prepared key values from base tree", "duration", time.Since(now))
 
 	// Insert into the tree.
 	if err := tree.InsertMigratedLeaves(kvm.newLeaves); err != nil {
@@ -289,7 +289,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 		for count < maxMovedCount {
 			acc, err := types.FullAccount(accIt.Account())
 			if err != nil {
-				log.Error("Invalid account encountered during traversal", "error", err)
+				fmt.Println("Invalid account encountered during traversal", "error", err)
 				return err
 			}
 			vkt.SetStorageRootConversion(*migrdb.GetCurrentAccountAddress(), acc.Root)
@@ -416,7 +416,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 		}
 		migrdb.SetCurrentPreimageOffset(preimageSeek)
 
-		log.Info("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account", statedb.Database().GetCurrentAccountHash(), "storage processed", statedb.Database().GetStorageProcessed(), "last storage", statedb.Database().GetCurrentSlotHash())
+		fmt.Println("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account", statedb.Database().GetCurrentAccountHash(), "storage processed", statedb.Database().GetStorageProcessed(), "last storage", statedb.Database().GetCurrentSlotHash())
 
 		// Take all the collected key-values and prepare the new leaf values.
 		// This fires a background routine that will start doing the work that
@@ -431,7 +431,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 		if err := mkv.migrateCollectedKeyValues(tt.Overlay()); err != nil {
 			return fmt.Errorf("could not migrate key values: %w", err)
 		}
-		log.Info("Inserted key values in overlay tree", "count", count, "duration", time.Since(now))
+		fmt.Println("Inserted key values in overlay tree", "count", count, "duration", time.Since(now))
 	}
 
 	return nil

--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -221,6 +221,8 @@ func (kvm *keyValueMigrator) migrateCollectedKeyValues(tree *trie.VerkleTrie) er
 // OverlayVerkleTransition contains the overlay conversion logic
 func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedCount uint64) error {
 	migrdb := statedb.Database()
+	migrdb.LockCurrentTransitionState()
+	defer migrdb.UnLockCurrentTransitionState()
 
 	// verkle transition: if the conversion process is in progress, move
 	// N values from the MPT into the verkle tree.

--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -399,11 +399,10 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 							return fmt.Errorf("account address len is zero is not 20: %d", len(addr))
 						}
 					}
-					// fmt.Printf("account switch: %s != %s\n", crypto.Keccak256Hash(addr[:]), accIt.Hash())
 					if crypto.Keccak256Hash(addr[:]) != accIt.Hash() {
 						return fmt.Errorf("preimage file does not match account hash: %s != %s", crypto.Keccak256Hash(addr[:]), accIt.Hash())
 					}
-					log.Trace("Converting account address", "hash", accIt.Hash(), "addr", addr)
+					fmt.Printf("Converting account address hash=%x addr=%x", accIt.Hash(), addr)
 					preimageSeek += int64(len(addr))
 					migrdb.SetCurrentAccountAddress(addr)
 				} else {
@@ -416,7 +415,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 		}
 		migrdb.SetCurrentPreimageOffset(preimageSeek)
 
-		fmt.Println("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account", statedb.Database().GetCurrentAccountHash(), "storage processed", statedb.Database().GetStorageProcessed(), "last storage", statedb.Database().GetCurrentSlotHash())
+		fmt.Println("Collected key values from base tree", "count", count, "duration", time.Since(now), "last account hash", statedb.Database().GetCurrentAccountHash(), "last account address", statedb.Database().GetCurrentAccountAddress(), "storage processed", statedb.Database().GetStorageProcessed(), "last storage", statedb.Database().GetCurrentSlotHash())
 
 		// Take all the collected key-values and prepare the new leaf values.
 		// This fires a background routine that will start doing the work that

--- a/core/rawdb/accessors_overlay.go
+++ b/core/rawdb/accessors_overlay.go
@@ -1,0 +1,30 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+func ReadVerkleTransitionState(db ethdb.KeyValueReader, hash common.Hash) ([]byte, error) {
+	return db.Get(transitionStateKey(hash))
+}
+
+func WriteVerkleTransitionState(db ethdb.KeyValueWriter, hash common.Hash, state []byte) error {
+	return db.Put(transitionStateKey(hash), state)
+}

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -122,6 +122,8 @@ var (
 
 	CliqueSnapshotPrefix = []byte("clique-")
 
+	VerkleTransitionStatePrefix = []byte("verkle-transition-state-")
+
 	preimageCounter    = metrics.NewRegisteredCounter("db/preimage/total", nil)
 	preimageHitCounter = metrics.NewRegisteredCounter("db/preimage/hits", nil)
 )
@@ -248,6 +250,11 @@ func accountTrieNodeKey(path []byte) []byte {
 // storageTrieNodeKey = trieNodeStoragePrefix + accountHash + nodePath.
 func storageTrieNodeKey(accountHash common.Hash, path []byte) []byte {
 	return append(append(trieNodeStoragePrefix, accountHash.Bytes()...), path...)
+}
+
+// transitionStateKey = transitionStatusKey + hash
+func transitionStateKey(hash common.Hash) []byte {
+	return append(VerkleTransitionStatePrefix, hash.Bytes()...)
 }
 
 // IsLegacyTrieNode reports whether a provided database entry is a legacy trie

--- a/core/state/access_list.go
+++ b/core/state/access_list.go
@@ -20,20 +20,40 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-type accessList struct {
+type accessList interface {
+	ContainsAddress(address common.Address) bool
+	Contains(address common.Address, slot common.Hash) (addressPresent bool, slotPresent bool)
+	Copy() accessList
+	AddAddress(address common.Address) bool
+	AddSlot(address common.Address, slot common.Hash) (addrChange bool, slotChange bool)
+	DeleteSlot(address common.Address, slot common.Hash)
+	DeleteAddress(address common.Address)
+
+	TouchAndChargeProofOfAbsence(addr []byte) uint64
+	TouchAndChargeMessageCall(addr []byte) uint64
+	TouchAndChargeValueTransfer(callerAddr, targetAddr []byte) uint64
+	TouchAndChargeContractCreateInit(addr []byte, createSendsValue bool) uint64
+	TouchAndChargeContractCreateCompleted(addr []byte) uint64
+	TouchTxOriginAndComputeGas(originAddr []byte) uint64
+	TouchTxExistingAndComputeGas(targetAddr []byte, sendsValue bool) uint64
+	TouchAddressOnWriteAndComputeGas(addr []byte, index common.Hash, suffix byte) uint64
+	TouchAddressOnReadAndComputeGas(addr []byte, index common.Hash, suffix byte) uint64
+}
+
+type accessList2929 struct {
 	addresses map[common.Address]int
 	slots     []map[common.Hash]struct{}
 }
 
 // ContainsAddress returns true if the address is in the access list.
-func (al *accessList) ContainsAddress(address common.Address) bool {
+func (al *accessList2929) ContainsAddress(address common.Address) bool {
 	_, ok := al.addresses[address]
 	return ok
 }
 
 // Contains checks if a slot within an account is present in the access list, returning
 // separate flags for the presence of the account and the slot respectively.
-func (al *accessList) Contains(address common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
+func (al *accessList2929) Contains(address common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
 	idx, ok := al.addresses[address]
 	if !ok {
 		// no such address (and hence zero slots)
@@ -48,15 +68,15 @@ func (al *accessList) Contains(address common.Address, slot common.Hash) (addres
 }
 
 // newAccessList creates a new accessList.
-func newAccessList() *accessList {
-	return &accessList{
+func newAccessList() accessList {
+	return &accessList2929{
 		addresses: make(map[common.Address]int),
 	}
 }
 
 // Copy creates an independent copy of an accessList.
-func (a *accessList) Copy() *accessList {
-	cp := newAccessList()
+func (a *accessList2929) Copy() accessList {
+	cp := newAccessList().(*accessList2929)
 	for k, v := range a.addresses {
 		cp.addresses[k] = v
 	}
@@ -73,7 +93,7 @@ func (a *accessList) Copy() *accessList {
 
 // AddAddress adds an address to the access list, and returns 'true' if the operation
 // caused a change (addr was not previously in the list).
-func (al *accessList) AddAddress(address common.Address) bool {
+func (al *accessList2929) AddAddress(address common.Address) bool {
 	if _, present := al.addresses[address]; present {
 		return false
 	}
@@ -86,7 +106,7 @@ func (al *accessList) AddAddress(address common.Address) bool {
 // - address added
 // - slot added
 // For any 'true' value returned, a corresponding journal entry must be made.
-func (al *accessList) AddSlot(address common.Address, slot common.Hash) (addrChange bool, slotChange bool) {
+func (al *accessList2929) AddSlot(address common.Address, slot common.Hash) (addrChange bool, slotChange bool) {
 	idx, addrPresent := al.addresses[address]
 	if !addrPresent || idx == -1 {
 		// Address not present, or addr present but no slots there
@@ -110,7 +130,7 @@ func (al *accessList) AddSlot(address common.Address, slot common.Hash) (addrCha
 // This operation needs to be performed in the same order as the addition happened.
 // This method is meant to be used  by the journal, which maintains ordering of
 // operations.
-func (al *accessList) DeleteSlot(address common.Address, slot common.Hash) {
+func (al *accessList2929) DeleteSlot(address common.Address, slot common.Hash) {
 	idx, addrOk := al.addresses[address]
 	// There are two ways this can fail
 	if !addrOk {
@@ -131,6 +151,42 @@ func (al *accessList) DeleteSlot(address common.Address, slot common.Hash) {
 // needs to be performed in the same order as the addition happened.
 // This method is meant to be used  by the journal, which maintains ordering of
 // operations.
-func (al *accessList) DeleteAddress(address common.Address) {
+func (al *accessList2929) DeleteAddress(address common.Address) {
 	delete(al.addresses, address)
+}
+
+func (al *accessList2929) TouchAndChargeProofOfAbsence(addr []byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchAndChargeMessageCall(addr []byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchAndChargeValueTransfer(callerAddr []byte, targetAddr []byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchAndChargeContractCreateInit(addr []byte, createSendsValue bool) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchAndChargeContractCreateCompleted(addr []byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchTxOriginAndComputeGas(originAddr []byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchTxExistingAndComputeGas(targetAddr []byte, sendsValue bool) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchAddressOnWriteAndComputeGas(addr []byte, index common.Hash, subIndex byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchAddressOnReadAndComputeGas(addr []byte, index common.Hash, subIndex byte) uint64 {
+	return 0
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -21,6 +21,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
@@ -611,4 +612,5 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 	db.CurrentTransitionState = ts.Copy()
 
 	fmt.Println("loaded transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
+	debug.PrintStack()
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -569,8 +569,10 @@ func (db *cachingDB) SaveTransitionState(root common.Hash) {
 }
 
 func (db *cachingDB) LoadTransitionState(root common.Hash) {
-	var ts *TransitionState
-	if !db.TransitionStatePerRoot.Contains(root) {
+	// Try to get the transition state from the cache and
+	// the DB if it's not there.
+	ts, ok := db.TransitionStatePerRoot.Get(root)
+	if !ok {
 		// Not in the cache, try getting it from the DB
 		data, err := rawdb.ReadVerkleTransitionState(db.DiskDB(), root)
 		if err != nil {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -546,8 +546,6 @@ func (db *cachingDB) SetLastMerkleRoot(merkleRoot common.Hash) {
 }
 
 func (db *cachingDB) SaveTransitionState(root common.Hash) {
-	db.TransitionStatePerRoot = lru.NewBasicLRU[common.Hash, *TransitionState](100)
-
 	if db.CurrentTransitionState != nil {
 		encoded, err := rlp.EncodeToBytes(db.CurrentTransitionState)
 		if err != nil {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -564,7 +564,7 @@ func (db *cachingDB) SaveTransitionState(root common.Hash) {
 			rawdb.WriteVerkleTransitionState(db.DiskDB(), root, buf.Bytes())
 		}
 
-		log.Debug("saving transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
+		fmt.Println("saving transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
 	}
 }
 
@@ -600,7 +600,7 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 			// Initialize the first transition state, with the "ended"
 			// field set to true if the database was created
 			// as a verkle database.
-			log.Debug("no transition state found, starting fresh", "is verkle", db.triedb.IsVerkle())
+			fmt.Println("no transition state found, starting fresh", "is verkle", db.triedb.IsVerkle())
 			// Start with a fresh state
 			ts = &TransitionState{ended: db.triedb.IsVerkle()}
 		}
@@ -610,5 +610,5 @@ func (db *cachingDB) LoadTransitionState(root common.Hash) {
 	// doesn't get overwritten.
 	db.CurrentTransitionState = ts.Copy()
 
-	log.Debug("loaded transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
+	fmt.Println("loaded transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -553,9 +553,11 @@ func (db *cachingDB) SaveTransitionState(root common.Hash) {
 			return
 		}
 
-		// Copy so that the address pointer isn't updated after
-		// it has been saved.
-		db.TransitionStatePerRoot.Add(root, db.CurrentTransitionState.Copy())
+		if !db.TransitionStatePerRoot.Contains(root) {
+			// Copy so that the address pointer isn't updated after
+			// it has been saved.
+			db.TransitionStatePerRoot.Add(root, db.CurrentTransitionState.Copy())
+		}
 
 		rawdb.WriteVerkleTransitionState(db.DiskDB(), root, encoded)
 

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/trienode"
 	"github.com/ethereum/go-ethereum/trie/utils"
@@ -189,22 +190,24 @@ func NewDatabase(db ethdb.Database) Database {
 // large memory cache.
 func NewDatabaseWithConfig(db ethdb.Database, config *trie.Config) Database {
 	return &cachingDB{
-		disk:          db,
-		codeSizeCache: lru.NewCache[common.Hash, int](codeSizeCacheSize),
-		codeCache:     lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
-		triedb:        trie.NewDatabaseWithConfig(db, config),
-		addrToPoint:   utils.NewPointCache(),
+		disk:                   db,
+		codeSizeCache:          lru.NewCache[common.Hash, int](codeSizeCacheSize),
+		codeCache:              lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
+		triedb:                 trie.NewDatabaseWithConfig(db, config),
+		addrToPoint:            utils.NewPointCache(),
+		TransitionStatePerRoot: lru.NewBasicLRU[common.Hash, *TransitionState](100),
 	}
 }
 
 // NewDatabaseWithNodeDB creates a state database with an already initialized node database.
 func NewDatabaseWithNodeDB(db ethdb.Database, triedb *trie.Database) Database {
 	return &cachingDB{
-		disk:          db,
-		codeSizeCache: lru.NewCache[common.Hash, int](codeSizeCacheSize),
-		codeCache:     lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
-		triedb:        triedb,
-		addrToPoint:   utils.NewPointCache(),
+		disk:                   db,
+		codeSizeCache:          lru.NewCache[common.Hash, int](codeSizeCacheSize),
+		codeCache:              lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
+		triedb:                 triedb,
+		addrToPoint:            utils.NewPointCache(),
+		TransitionStatePerRoot: lru.NewBasicLRU[common.Hash, *TransitionState](100),
 	}
 }
 
@@ -305,7 +308,7 @@ type cachingDB struct {
 	// TODO ensure that this info is in the DB
 	LastMerkleRoot         common.Hash // root hash of the read-only base tree
 	CurrentTransitionState *TransitionState
-	TransitionStatePerRoot map[common.Hash]*TransitionState
+	TransitionStatePerRoot lru.BasicLRU[common.Hash, *TransitionState]
 
 	addrToPoint *utils.PointCache
 
@@ -543,32 +546,55 @@ func (db *cachingDB) SetLastMerkleRoot(merkleRoot common.Hash) {
 }
 
 func (db *cachingDB) SaveTransitionState(root common.Hash) {
-	if db.TransitionStatePerRoot == nil {
-		db.TransitionStatePerRoot = make(map[common.Hash]*TransitionState)
-	}
+	db.TransitionStatePerRoot = lru.NewBasicLRU[common.Hash, *TransitionState](100)
 
 	if db.CurrentTransitionState != nil {
+		encoded, err := rlp.EncodeToBytes(db.CurrentTransitionState)
+		if err != nil {
+			log.Error("failed to encode transition state", "err", err)
+			return
+		}
+
 		// Copy so that the address pointer isn't updated after
 		// it has been saved.
-		db.TransitionStatePerRoot[root] = db.CurrentTransitionState.Copy()
+		db.TransitionStatePerRoot.Add(root, db.CurrentTransitionState.Copy())
+
+		rawdb.WriteVerkleTransitionState(db.DiskDB(), root, encoded)
 
 		log.Debug("saving transition state", "storage processed", db.CurrentTransitionState.StorageProcessed, "addr", db.CurrentTransitionState.CurrentAccountAddress, "slot hash", db.CurrentTransitionState.CurrentSlotHash, "root", root, "ended", db.CurrentTransitionState.ended, "started", db.CurrentTransitionState.started)
 	}
 }
 
 func (db *cachingDB) LoadTransitionState(root common.Hash) {
-	if db.TransitionStatePerRoot == nil {
-		db.TransitionStatePerRoot = make(map[common.Hash]*TransitionState)
-	}
+	var ts *TransitionState
+	if !db.TransitionStatePerRoot.Contains(root) {
+		// Not in the cache, try getting it from the DB
+		data, err := rawdb.ReadVerkleTransitionState(db.DiskDB(), root)
+		if err != nil {
+			log.Error("failed to read transition state", "err", err)
+			return
+		}
 
-	// Initialize the first transition state, with the "ended"
-	// field set to true if the database was created
-	// as a verkle database.
-	ts, ok := db.TransitionStatePerRoot[root]
-	if !ok || ts == nil {
-		log.Debug("could not find any transition state, starting with a fresh state", "is verkle", db.triedb.IsVerkle())
-		// Start with a fresh state
-		ts = &TransitionState{ended: false}
+		if len(data) > 0 {
+			var newts TransitionState
+			// Decode transition state
+			err = rlp.DecodeBytes(data, &newts)
+			if err != nil {
+				log.Error("failed to decode transition state", "err", err)
+				return
+			}
+			ts = &newts
+		}
+
+		// Fallback
+		if ts == nil {
+			// Initialize the first transition state, with the "ended"
+			// field set to true if the database was created
+			// as a verkle database.
+			log.Debug("no transition state found, starting fresh", "is verkle", db.triedb.IsVerkle())
+			// Start with a fresh state
+			ts = &TransitionState{ended: db.triedb.IsVerkle()}
+		}
 	}
 
 	// Copy so that the CurrentAddress pointer in the map

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -113,13 +113,13 @@ type StateDB struct {
 	preimages map[common.Hash][]byte
 
 	// Per-transaction access list
-	accessList *accessList
+	accessList accessList
 
 	// Transient storage
 	transientStorage transientStorage
 
 	// Verkle witness
-	witness *AccessWitness
+	witness accessList
 
 	// Journal of state modifications. This is the backbone of
 	// Snapshot and RevertToSnapshot.
@@ -192,7 +192,7 @@ func (s *StateDB) NewAccessWitness() *AccessWitness {
 	return NewAccessWitness(s.db.(*cachingDB).addrToPoint)
 }
 
-func (s *StateDB) Witness() *AccessWitness {
+func (s *StateDB) Witness() accessList {
 	if s.witness == nil {
 		s.witness = s.NewAccessWitness()
 	}

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -823,7 +823,7 @@ func TestStateDBAccessList(t *testing.T) {
 			}
 		}
 		// Check that only the expected addresses are present in the access list
-		for address := range state.accessList.addresses {
+		for address := range state.accessList.(*accessList2929).addresses {
 			if _, exist := addressMap[address]; !exist {
 				t.Fatalf("extra address %x in access list", address)
 			}
@@ -849,9 +849,9 @@ func TestStateDBAccessList(t *testing.T) {
 			}
 		}
 		// Check that no extra elements are in the access list
-		index := state.accessList.addresses[address]
+		index := state.accessList.(*accessList2929).addresses[address]
 		if index >= 0 {
-			stateSlots := state.accessList.slots[index]
+			stateSlots := state.accessList.(*accessList2929).slots[index]
 			for s := range stateSlots {
 				if _, slotPresent := slotMap[s]; !slotPresent {
 					t.Fatalf("scope has extra slot %v (address %v)", s, addrString)
@@ -947,10 +947,10 @@ func TestStateDBAccessList(t *testing.T) {
 	if state.AddressInAccessList(addr("aa")) {
 		t.Fatalf("addr present, expected missing")
 	}
-	if got, exp := len(state.accessList.addresses), 0; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).addresses), 0; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
-	if got, exp := len(state.accessList.slots), 0; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).slots), 0; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
 	// Check the copy
@@ -958,10 +958,10 @@ func TestStateDBAccessList(t *testing.T) {
 	state = stateCopy1
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02")
-	if got, exp := len(state.accessList.addresses), 2; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).addresses), 2; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
-	if got, exp := len(state.accessList.slots), 1; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).slots), 1; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -61,7 +61,7 @@ func NewStateProcessor(config *params.ChainConfig, bc *BlockChain, engine consen
 // returns the amount of gas that was used in the process. If any of the
 // transactions failed to execute due to insufficient gas it will return an error.
 func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, error) {
-	fmt.Println("process block", statedb.Database().GetCurrentAccountAddress(), statedb.Database().GetCurrentAccountHash())
+	fmt.Println("process block", block.NumberU64())
 	var (
 		receipts    types.Receipts
 		usedGas     = new(uint64)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -194,6 +194,6 @@ func ProcessParentBlockHash(statedb *state.StateDB, prevNumber uint64, prevHash 
 	var key common.Hash
 	binary.BigEndian.PutUint64(key[24:], prevNumber)
 	statedb.SetState(params.HistoryStorageAddress, key, prevHash)
-	index, suffix := utils.GetTreeKeyStorageSlotTreeIndexes(key[:])
-	statedb.Witness().TouchAddressOnWriteAndComputeGas(params.HistoryStorageAddress[:], *index, suffix)
+	// index, suffix := utils.GetTreeKeyStorageSlotTreeIndexes(key[:])
+	statedb.Witness().TouchAddressOnWriteAndComputeGas(params.HistoryStorageAddress[:], key, key[31])
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -108,12 +108,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		return nil, nil, 0, errors.New("withdrawals before shanghai")
 	}
 
-	// Perform the overlay transition, if relevant
-	//parent := p.bc.GetHeaderByHash(header.ParentHash)
-	//if err := OverlayVerkleTransition(statedb, parent.Root); err != nil {
-	//	return nil, nil, 0, fmt.Errorf("error performing verkle overlay transition: %w", err)
-	//}
-
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.engine.Finalize(p.bc, header, statedb, block.Transactions(), block.Uncles(), withdrawals)
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -61,6 +61,7 @@ func NewStateProcessor(config *params.ChainConfig, bc *BlockChain, engine consen
 // returns the amount of gas that was used in the process. If any of the
 // transactions failed to execute due to insufficient gas it will return an error.
 func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, error) {
+	fmt.Println("process block", statedb.Database().GetCurrentAccountAddress(), statedb.Database().GetCurrentAccountHash())
 	var (
 		receipts    types.Receipts
 		usedGas     = new(uint64)

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	trieUtils "github.com/ethereum/go-ethereum/trie/utils"
-	"github.com/holiman/uint256"
 )
 
 // memoryGasCost calculates the quadratic gas for memory expansion. It does so
@@ -102,7 +101,7 @@ func gasExtCodeSize(evm *EVM, contract *Contract, stack *Stack, mem *Memory, mem
 	usedGas := uint64(0)
 	slot := stack.Back(0)
 	if evm.chainRules.IsPrague {
-		usedGas += evm.TxContext.Accesses.TouchAddressOnReadAndComputeGas(slot.Bytes(), uint256.Int{}, trieUtils.CodeSizeLeafKey)
+		usedGas += evm.TxContext.Accesses.TouchAddressOnReadAndComputeGas(slot.Bytes(), common.Hash{}, trieUtils.CodeSizeLeafKey)
 	}
 
 	return usedGas, nil
@@ -112,9 +111,9 @@ func gasSLoad(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySiz
 	usedGas := uint64(0)
 
 	if evm.chainRules.IsPrague {
-		where := stack.Back(0)
-		treeIndex, subIndex := trieUtils.GetTreeKeyStorageSlotTreeIndexes(where.Bytes())
-		usedGas += evm.Accesses.TouchAddressOnReadAndComputeGas(contract.Address().Bytes(), *treeIndex, subIndex)
+		where := stack.Back(0).Bytes()
+		// treeIndexx, subIndex := trieUtils.GetTreeKeyStorageSlotTreeIndexes(where.Bytes())
+		usedGas += evm.Accesses.TouchAddressOnReadAndComputeGas(contract.Address().Bytes(), common.BytesToHash(where), where[31])
 	}
 
 	return usedGas, nil

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -80,7 +80,7 @@ type StateDB interface {
 	AddLog(*types.Log)
 	AddPreimage(common.Hash, []byte)
 
-	Witness() *state.AccessWitness
+	Witness() accessList
 	SetWitness(*state.AccessWitness)
 }
 

--- a/light/trie.go
+++ b/light/trie.go
@@ -177,6 +177,13 @@ func (db *odrDatabase) LoadTransitionState(common.Hash) {
 	panic("not implemented") // TODO: Implement
 }
 
+func (db *odrDatabase) LockCurrentTransitionState() {
+	panic("not implemented") // TODO: Implement
+}
+func (db *odrDatabase) UnLockCurrentTransitionState() {
+	panic("not implemented") // TODO: Implement
+}
+
 type odrTrie struct {
 	db   *odrDatabase
 	id   *TrieID


### PR DESCRIPTION
This is step one: simply the union of both interfaces.

This isn't very interesting, since the access lists are created differently and have two different apis. The next step is to create a single instantiation scheme, before the apis are merged.