### PR TITLE
[wip] consensus, core/{sate, vm}: Factor AccessWitness and accessList29292

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/ethereum/go-verkle"
-	"github.com/holiman/uint256"
 )
 
 // Proof-of-stake protocol constants.
@@ -346,9 +345,9 @@ func (beacon *Beacon) Prepare(chain consensus.ChainHeaderReader, header *types.H
 }
 
 // Finalize implements consensus.Engine and processes withdrawals on top.
-func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, withdrawals []*types.Withdrawal) {
+func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.Header, statedb *state.StateDB, txs []*types.Transaction, uncles []*types.Header, withdrawals []*types.Withdrawal) {
 	if !beacon.IsPoSHeader(header) {
-		beacon.ethone.Finalize(chain, header, state, txs, uncles, nil)
+		beacon.ethone.Finalize(chain, header, statedb, txs, uncles, nil)
 		return
 	}
 	// Withdrawals processing.
@@ -356,20 +355,16 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 		// Convert amount from gwei to wei.
 		amount := new(big.Int).SetUint64(w.Amount)
 		amount = amount.Mul(amount, big.NewInt(params.GWei))
-		state.AddBalance(w.Address, amount)
+		statedb.AddBalance(w.Address, amount)
 
 		// The returned gas is not charged
-		state.Witness().TouchAddressOnWriteAndComputeGas(w.Address[:], uint256.Int{}, utils.VersionLeafKey)
-		state.Witness().TouchAddressOnWriteAndComputeGas(w.Address[:], uint256.Int{}, utils.BalanceLeafKey)
-		state.Witness().TouchAddressOnWriteAndComputeGas(w.Address[:], uint256.Int{}, utils.NonceLeafKey)
-		state.Witness().TouchAddressOnWriteAndComputeGas(w.Address[:], uint256.Int{}, utils.CodeKeccakLeafKey)
-		state.Witness().TouchAddressOnWriteAndComputeGas(w.Address[:], uint256.Int{}, utils.CodeSizeLeafKey)
+		statedb.Witness().AddAddress(w.Address, state.AccessListWrite)
 	}
 
 	if chain.Config().IsPrague(header.Number, header.Time) {
-		fmt.Println("at block", header.Number, "performing transition?", state.Database().InTransition())
+		fmt.Println("at block", header.Number, "performing transition?", statedb.Database().InTransition())
 		parent := chain.GetHeaderByHash(header.ParentHash)
-		if err := overlay.OverlayVerkleTransition(state, parent.Root, chain.Config().OverlayStride); err != nil {
+		if err := overlay.OverlayVerkleTransition(statedb, parent.Root, chain.Config().OverlayStride); err != nil {
 			log.Error("error performing the transition", "err", err)
 		}
 	}

--- a/core/state/access_list.go
+++ b/core/state/access_list.go
@@ -18,22 +18,51 @@ package state
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
 )
 
-type accessList struct {
+type AccessListAccessMode bool
+
+var (
+	AccessListRead  = AccessListAccessMode(false)
+	AccessListWrite = AccessListAccessMode(true)
+)
+
+type AccessList interface {
+	ContainsAddress(address common.Address) bool
+	Contains(address common.Address, slot common.Hash) (addressPresent bool, slotPresent bool)
+	Copy() AccessList
+	AddAddress(address common.Address, isWrite AccessListAccessMode) uint64
+	AddSlot(address common.Address, slot common.Hash, isWrite AccessListAccessMode) uint64
+	DeleteSlot(address common.Address, slot common.Hash)
+	DeleteAddress(address common.Address)
+
+	TouchAndChargeMessageCall(addr []byte) uint64
+	TouchAndChargeValueTransfer(callerAddr, targetAddr []byte) uint64
+	TouchAndChargeContractCreateInit(addr []byte, createSendsValue bool) uint64
+	TouchAndChargeContractCreateCompleted(addr []byte) uint64
+	TouchTxOriginAndComputeGas(originAddr []byte) uint64
+	TouchTxExistingAndComputeGas(targetAddr []byte, sendsValue bool) uint64
+	TouchAddressOnReadAndComputeGas(addr []byte, index uint256.Int, suffix byte) uint64
+	Merge(AccessList)
+	Keys() [][]byte
+}
+
+type accessList2929 struct {
 	addresses map[common.Address]int
 	slots     []map[common.Hash]struct{}
 }
 
 // ContainsAddress returns true if the address is in the access list.
-func (al *accessList) ContainsAddress(address common.Address) bool {
+func (al *accessList2929) ContainsAddress(address common.Address) bool {
 	_, ok := al.addresses[address]
 	return ok
 }
 
 // Contains checks if a slot within an account is present in the access list, returning
 // separate flags for the presence of the account and the slot respectively.
-func (al *accessList) Contains(address common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
+func (al *accessList2929) Contains(address common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
 	idx, ok := al.addresses[address]
 	if !ok {
 		// no such address (and hence zero slots)
@@ -48,14 +77,14 @@ func (al *accessList) Contains(address common.Address, slot common.Hash) (addres
 }
 
 // newAccessList creates a new accessList.
-func newAccessList() *accessList {
-	return &accessList{
+func newAccessList() *accessList2929 {
+	return &accessList2929{
 		addresses: make(map[common.Address]int),
 	}
 }
 
 // Copy creates an independent copy of an accessList.
-func (a *accessList) Copy() *accessList {
+func (a *accessList2929) Copy() AccessList {
 	cp := newAccessList()
 	for k, v := range a.addresses {
 		cp.addresses[k] = v
@@ -73,44 +102,42 @@ func (a *accessList) Copy() *accessList {
 
 // AddAddress adds an address to the access list, and returns 'true' if the operation
 // caused a change (addr was not previously in the list).
-func (al *accessList) AddAddress(address common.Address) bool {
+func (al *accessList2929) AddAddress(address common.Address, _ AccessListAccessMode) uint64 {
 	if _, present := al.addresses[address]; present {
-		return false
+		return 0
 	}
 	al.addresses[address] = -1
-	return true
+	return params.ColdAccountAccessCostEIP2929
 }
 
 // AddSlot adds the specified (addr, slot) combo to the access list.
-// Return values are:
-// - address added
-// - slot added
-// For any 'true' value returned, a corresponding journal entry must be made.
-func (al *accessList) AddSlot(address common.Address, slot common.Hash) (addrChange bool, slotChange bool) {
+// Returns the gas consumed.
+// For any non-zero gas value returned, a corresponding journal entry must be made.
+func (al *accessList2929) AddSlot(address common.Address, slot common.Hash, isWrite AccessListAccessMode) (gas uint64) {
 	idx, addrPresent := al.addresses[address]
 	if !addrPresent || idx == -1 {
 		// Address not present, or addr present but no slots there
 		al.addresses[address] = len(al.slots)
 		slotmap := map[common.Hash]struct{}{slot: {}}
 		al.slots = append(al.slots, slotmap)
-		return !addrPresent, true
+		return params.ColdSloadCostEIP2929
 	}
 	// There is already an (address,slot) mapping
 	slotmap := al.slots[idx]
 	if _, ok := slotmap[slot]; !ok {
 		slotmap[slot] = struct{}{}
 		// Journal add slot change
-		return false, true
+		return params.ColdSloadCostEIP2929
 	}
 	// No changes required
-	return false, false
+	return params.WarmStorageReadCostEIP2929
 }
 
 // DeleteSlot removes an (address, slot)-tuple from the access list.
 // This operation needs to be performed in the same order as the addition happened.
 // This method is meant to be used  by the journal, which maintains ordering of
 // operations.
-func (al *accessList) DeleteSlot(address common.Address, slot common.Hash) {
+func (al *accessList2929) DeleteSlot(address common.Address, slot common.Hash) {
 	idx, addrOk := al.addresses[address]
 	// There are two ways this can fail
 	if !addrOk {
@@ -131,6 +158,41 @@ func (al *accessList) DeleteSlot(address common.Address, slot common.Hash) {
 // needs to be performed in the same order as the addition happened.
 // This method is meant to be used  by the journal, which maintains ordering of
 // operations.
-func (al *accessList) DeleteAddress(address common.Address) {
+func (al *accessList2929) DeleteAddress(address common.Address) {
 	delete(al.addresses, address)
 }
+
+func (al *accessList2929) TouchAndChargeProofOfAbsence(addr []byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchAndChargeMessageCall(addr []byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchAndChargeValueTransfer(callerAddr []byte, targetAddr []byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchAndChargeContractCreateInit(addr []byte, createSendsValue bool) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchAndChargeContractCreateCompleted(addr []byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchTxOriginAndComputeGas(originAddr []byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchTxExistingAndComputeGas(targetAddr []byte, sendsValue bool) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchAddressOnReadAndComputeGas(addr []byte, index uint256.Int, subIndex byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) Merge(other AccessList) {}
+func (al *accessList2929) Keys() [][]byte         { return nil }

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -335,14 +335,14 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 		{
 			name: "AddAddressToAccessList",
 			fn: func(a testAction, s *StateDB) {
-				s.AddAddressToAccessList(addr)
+				s.AddAddressToAccessList(addr, AccessListRead)
 			},
 		},
 		{
 			name: "AddSlotToAccessList",
 			fn: func(a testAction, s *StateDB) {
 				s.AddSlotToAccessList(addr,
-					common.Hash{byte(a.args[0])})
+					common.Hash{byte(a.args[0])}, AccessListRead)
 			},
 			args: make([]int64, 1),
 		},
@@ -818,19 +818,19 @@ func TestStateDBAccessList(t *testing.T) {
 		}
 		// Check that the given addresses are in the access list
 		for _, address := range addresses {
-			if !state.AddressInAccessList(address) {
+			if !state.addressInAccessList(address) {
 				t.Fatalf("expected %x to be in access list", address)
 			}
 		}
 		// Check that only the expected addresses are present in the access list
-		for address := range state.accessList.addresses {
+		for address := range state.accessList.(*accessList2929).addresses {
 			if _, exist := addressMap[address]; !exist {
 				t.Fatalf("extra address %x in access list", address)
 			}
 		}
 	}
 	verifySlots := func(addrString string, slotStrings ...string) {
-		if !state.AddressInAccessList(addr(addrString)) {
+		if !state.addressInAccessList(addr(addrString)) {
 			t.Fatalf("scope missing address/slots %v", addrString)
 		}
 		var address = addr(addrString)
@@ -844,14 +844,14 @@ func TestStateDBAccessList(t *testing.T) {
 		}
 		// Check that the expected items are in the access list
 		for i, s := range slots {
-			if _, slotPresent := state.SlotInAccessList(address, s); !slotPresent {
+			if _, slotPresent := state.slotInAccessList(address, s); !slotPresent {
 				t.Fatalf("input %d: scope missing slot %v (address %v)", i, s, addrString)
 			}
 		}
 		// Check that no extra elements are in the access list
-		index := state.accessList.addresses[address]
+		index := state.accessList.(*accessList2929).addresses[address]
 		if index >= 0 {
-			stateSlots := state.accessList.slots[index]
+			stateSlots := state.accessList.(*accessList2929).slots[index]
 			for s := range stateSlots {
 				if _, slotPresent := slotMap[s]; !slotPresent {
 					t.Fatalf("scope has extra slot %v (address %v)", s, addrString)
@@ -860,9 +860,9 @@ func TestStateDBAccessList(t *testing.T) {
 		}
 	}
 
-	state.AddAddressToAccessList(addr("aa"))          // 1
-	state.AddSlotToAccessList(addr("bb"), slot("01")) // 2,3
-	state.AddSlotToAccessList(addr("bb"), slot("02")) // 4
+	state.AddAddressToAccessList(addr("aa"), AccessListRead)          // 1
+	state.AddSlotToAccessList(addr("bb"), slot("01"), AccessListRead) // 2
+	state.AddSlotToAccessList(addr("bb"), slot("02"), AccessListRead) // 3
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02")
 
@@ -873,17 +873,17 @@ func TestStateDBAccessList(t *testing.T) {
 	}
 
 	// same again, should cause no journal entries
-	state.AddSlotToAccessList(addr("bb"), slot("01"))
-	state.AddSlotToAccessList(addr("bb"), slot("02"))
-	state.AddAddressToAccessList(addr("aa"))
+	state.AddSlotToAccessList(addr("bb"), slot("01"), AccessListRead)
+	state.AddSlotToAccessList(addr("bb"), slot("02"), AccessListRead)
+	state.AddAddressToAccessList(addr("aa"), AccessListRead)
 	if exp, got := 4, state.journal.length(); exp != got {
 		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
 	}
 	// some new ones
-	state.AddSlotToAccessList(addr("bb"), slot("03")) // 5
-	state.AddSlotToAccessList(addr("aa"), slot("01")) // 6
-	state.AddSlotToAccessList(addr("cc"), slot("01")) // 7,8
-	state.AddAddressToAccessList(addr("cc"))
+	state.AddSlotToAccessList(addr("bb"), slot("03"), AccessListRead) // 4
+	state.AddSlotToAccessList(addr("aa"), slot("01"), AccessListRead) // 5
+	state.AddSlotToAccessList(addr("cc"), slot("01"), AccessListRead) // 6
+	state.AddAddressToAccessList(addr("cc"), AccessListRead)
 	if exp, got := 8, state.journal.length(); exp != got {
 		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
 	}
@@ -895,7 +895,7 @@ func TestStateDBAccessList(t *testing.T) {
 
 	// now start rolling back changes
 	state.journal.revert(state, 7)
-	if _, ok := state.SlotInAccessList(addr("cc"), slot("01")); ok {
+	if _, ok := state.slotInAccessList(addr("cc"), slot("01")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb", "cc")
@@ -903,7 +903,7 @@ func TestStateDBAccessList(t *testing.T) {
 	verifySlots("bb", "01", "02", "03")
 
 	state.journal.revert(state, 6)
-	if state.AddressInAccessList(addr("cc")) {
+	if state.addressInAccessList(addr("cc")) {
 		t.Fatalf("addr present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
@@ -911,46 +911,46 @@ func TestStateDBAccessList(t *testing.T) {
 	verifySlots("bb", "01", "02", "03")
 
 	state.journal.revert(state, 5)
-	if _, ok := state.SlotInAccessList(addr("aa"), slot("01")); ok {
+	if _, ok := state.slotInAccessList(addr("aa"), slot("01")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02", "03")
 
 	state.journal.revert(state, 4)
-	if _, ok := state.SlotInAccessList(addr("bb"), slot("03")); ok {
+	if _, ok := state.slotInAccessList(addr("bb"), slot("03")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02")
 
 	state.journal.revert(state, 3)
-	if _, ok := state.SlotInAccessList(addr("bb"), slot("02")); ok {
+	if _, ok := state.slotInAccessList(addr("bb"), slot("02")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01")
 
 	state.journal.revert(state, 2)
-	if _, ok := state.SlotInAccessList(addr("bb"), slot("01")); ok {
+	if _, ok := state.slotInAccessList(addr("bb"), slot("01")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 
 	state.journal.revert(state, 1)
-	if state.AddressInAccessList(addr("bb")) {
+	if state.addressInAccessList(addr("bb")) {
 		t.Fatalf("addr present, expected missing")
 	}
 	verifyAddrs("aa")
 
 	state.journal.revert(state, 0)
-	if state.AddressInAccessList(addr("aa")) {
+	if state.addressInAccessList(addr("aa")) {
 		t.Fatalf("addr present, expected missing")
 	}
-	if got, exp := len(state.accessList.addresses), 0; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).addresses), 0; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
-	if got, exp := len(state.accessList.slots), 0; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).slots), 0; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
 	// Check the copy
@@ -958,10 +958,10 @@ func TestStateDBAccessList(t *testing.T) {
 	state = stateCopy1
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02")
-	if got, exp := len(state.accessList.addresses), 2; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).addresses), 2; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
-	if got, exp := len(state.accessList.slots), 1; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).slots), 1; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/trie/utils"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -193,6 +192,5 @@ func ProcessParentBlockHash(statedb *state.StateDB, prevNumber uint64, prevHash 
 	var key common.Hash
 	binary.BigEndian.PutUint64(key[24:], prevNumber)
 	statedb.SetState(params.HistoryStorageAddress, key, prevHash)
-	index, suffix := utils.GetTreeKeyStorageSlotTreeIndexes(key[:])
-	statedb.Witness().TouchAddressOnWriteAndComputeGas(params.HistoryStorageAddress[:], *index, suffix)
+	statedb.Witness().AddSlot(params.HistoryStorageAddress, key, state.AccessListWrite)
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -25,12 +25,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	cmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/trie/utils"
-	"github.com/holiman/uint256"
 )
 
 // ExecutionResult includes all output after executing given evm
@@ -481,11 +480,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 		// add the coinbase to the witness iff the fee is greater than 0
 		if rules.IsPrague && fee.Sign() != 0 {
-			st.evm.Accesses.TouchAddressOnWriteAndComputeGas(st.evm.Context.Coinbase[:], uint256.Int{}, utils.VersionLeafKey)
-			st.evm.Accesses.TouchAddressOnWriteAndComputeGas(st.evm.Context.Coinbase[:], uint256.Int{}, utils.BalanceLeafKey)
-			st.evm.Accesses.TouchAddressOnWriteAndComputeGas(st.evm.Context.Coinbase[:], uint256.Int{}, utils.NonceLeafKey)
-			st.evm.Accesses.TouchAddressOnWriteAndComputeGas(st.evm.Context.Coinbase[:], uint256.Int{}, utils.CodeKeccakLeafKey)
-			st.evm.Accesses.TouchAddressOnWriteAndComputeGas(st.evm.Context.Coinbase[:], uint256.Int{}, utils.CodeSizeLeafKey)
+			st.evm.Accesses.AddAddress(st.evm.Context.Coinbase, state.AccessListWrite)
 		}
 	}
 

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -37,6 +37,7 @@ var activators = map[int]func(*JumpTable){
 	1884: enable1884,
 	1344: enable1344,
 	1153: enable1153,
+	2935: enable2935,
 }
 
 // EnableEIP enables the given EIP on the config.
@@ -126,13 +127,13 @@ func enable2929(jt *JumpTable) {
 	jt[EXTCODECOPY].constantGas = params.WarmStorageReadCostEIP2929
 	jt[EXTCODECOPY].dynamicGas = gasExtCodeCopyEIP2929
 
-	jt[EXTCODESIZE].constantGas = params.WarmStorageReadCostEIP2929
+	jt[EXTCODESIZE].constantGas = 0
 	jt[EXTCODESIZE].dynamicGas = gasEip2929AccountCheck
 
-	jt[EXTCODEHASH].constantGas = params.WarmStorageReadCostEIP2929
+	jt[EXTCODEHASH].constantGas = 0
 	jt[EXTCODEHASH].dynamicGas = gasEip2929AccountCheck
 
-	jt[BALANCE].constantGas = params.WarmStorageReadCostEIP2929
+	jt[BALANCE].constantGas = 0
 	jt[BALANCE].dynamicGas = gasEip2929AccountCheck
 
 	jt[CALL].constantGas = params.WarmStorageReadCostEIP2929
@@ -302,4 +303,9 @@ func enable6780(jt *JumpTable) {
 		minStack:    minStack(1, 0),
 		maxStack:    maxStack(1, 0),
 	}
+}
+
+// enable4762 applies EIP-2935 (save historical block hash)
+func enable2935(jt *JumpTable) {
+	jt[BLOCKHASH].dynamicGas = gasBlockHashEip2935
 }

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -35,6 +35,7 @@ var (
 	ErrWriteProtection          = errors.New("write protection")
 	ErrReturnDataOutOfBounds    = errors.New("return data out of bounds")
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
+	ErrBlockNumberUintOverflow  = errors.New("block number uint64 overflow")
 	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
 	ErrNonceUintOverflow        = errors.New("nonce uint64 overflow")
 

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -66,14 +66,13 @@ type StateDB interface {
 	// is defined according to EIP161 (balance = nonce = code = 0).
 	Empty(common.Address) bool
 
-	AddressInAccessList(addr common.Address) bool
-	SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool)
-	// AddAddressToAccessList adds the given address to the access list. This operation is safe to perform
-	// even if the feature/fork is not active yet
-	AddAddressToAccessList(addr common.Address)
+	// AddAddressToAccessList adds the given address to the access list if it's not already
+	// present. It will return the amount of gas that should be charged . This operation is
+	// safe to perform even if the feature/fork is not active yet
+	AddAddressToAccessList(addr common.Address, write state.AccessListAccessMode) uint64
 	// AddSlotToAccessList adds the given (address,slot) to the access list. This operation is safe to perform
 	// even if the feature/fork is not active yet
-	AddSlotToAccessList(addr common.Address, slot common.Hash)
+	AddSlotToAccessList(addr common.Address, slot common.Hash, write state.AccessListAccessMode) uint64
 	Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
 
 	RevertToSnapshot(int)
@@ -82,8 +81,8 @@ type StateDB interface {
 	AddLog(*types.Log)
 	AddPreimage(common.Hash, []byte)
 
-	Witness() *state.AccessWitness
-	SetWitness(*state.AccessWitness)
+	Witness() state.AccessList
+	SetWitness(state.AccessList)
 }
 
 // CallContext provides a basic interface for the EVM calling conventions. The EVM

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -59,6 +59,9 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	case evm.chainRules.IsPrague:
 		// TODO replace with prooper instruction set when fork is specified
 		table = &pragueInstructionSet
+		if err := EnableEIP(2935, table); err != nil {
+			log.Error("EIP 2935 activation failed", "error", err)
+		}
 	case evm.chainRules.IsCancun:
 		table = &cancunInstructionSet
 	case evm.chainRules.IsShanghai:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -558,7 +558,6 @@ func newFrontierInstructionSet() JumpTable {
 		SLOAD: {
 			execute:     opSload,
 			constantGas: params.SloadGasFrontier,
-			dynamicGas:  gasSLoad,
 			minStack:    minStack(1, 1),
 			maxStack:    maxStack(1, 1),
 		},


### PR DESCRIPTION
This is intended as a rework to merge the `accessList` and `AccessWitness` so that it can be merged into geth as a way to simplify a potential rebase.

The interfaces are merged and factored into a simpler interface.

**Note that this might break replay at a block height < eip2929** since `gasSLoad` is removed. In theory, this should not make any difference because during replay, witness gas costs aren't charged. But if it is, for whatever reason, it will break.