### PR TITLE
add a helper command to compute the verkle address

### DIFF
--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/tests"
+	"github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/urfave/cli/v2"
 )
 
@@ -490,5 +491,31 @@ func dispatchOutput(ctx *cli.Context, baseDir string, result *ExecutionResult, a
 		os.Stderr.Write(b)
 		os.Stderr.WriteString("\n")
 	}
+	return nil
+}
+
+// VerkleKeys computes the tree key given an address and an optional
+// slot number.
+func VerkleKeys(ctx *cli.Context) error {
+	if ctx.Args().Len() == 0 || ctx.Args().Len() > 2 {
+		return errors.New("invalid number of arguments: expecting an address and an optional slot number")
+	}
+	addr, err := hexutil.Decode(ctx.Args().Get(0))
+	if err != nil {
+		return fmt.Errorf("error decoding address: %w", err)
+	}
+
+	if ctx.Args().Len() == 2 {
+		slot, err := hexutil.Decode(ctx.Args().Get(1))
+		if err != nil {
+			return fmt.Errorf("error decoding slot: %w", err)
+		}
+
+		ap := utils.EvaluateAddressPoint(addr)
+		fmt.Printf("%#x\n", utils.GetTreeKeyStorageSlotWithEvaluatedAddress(ap, slot))
+	} else {
+		fmt.Printf("%#x\n", utils.GetTreeKeyVersion(addr))
+	}
+
 	return nil
 }

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -153,6 +153,14 @@ var stateTransitionCommand = &cli.Command{
 		t8ntool.RewardFlag,
 		t8ntool.VerbosityFlag,
 	},
+	Subcommands: []*cli.Command{
+		&cli.Command{
+			Name:    "verkle",
+			Aliases: []string{"v"},
+			Action:  t8ntool.VerkleKeys,
+			Usage:   "compute the verkle tree key given an address and optional slot number",
+		},
+	},
 }
 
 var transactionCommand = &cli.Command{


### PR DESCRIPTION
Adds a helper command to compute a verkle tree key, given an account address and an optional slot number. Use as follows:

```
evm t8n verkle <address> [<slot>]
```

where `address` and `slot` are hexadecimal numbers prefixed by `0x`.

Note that this uncovered issue #394 