### PR TITLE
consensus, core/{sate, vm}: Factor AccessWitness and AccessList

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -384,12 +384,12 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 	header.Root = state.IntermediateRoot(true)
 
 	var (
-		p    *verkle.VerkleProof
-		k    verkle.StateDiff
-		keys = state.Witness().Keys()
+		p *verkle.VerkleProof
+		k verkle.StateDiff
 	)
 	if chain.Config().IsPrague(header.Number, header.Time) && chain.Config().ProofInBlocks {
 		// Open the pre-tree to prove the pre-state against
+		keys := state.Witness().Keys()
 		parent := chain.GetHeaderByNumber(header.Number.Uint64() - 1)
 		if parent == nil {
 			return nil, fmt.Errorf("nil parent header for block %d", header.Number)

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -33,8 +33,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
-	"github.com/ethereum/go-ethereum/trie/utils"
-	"github.com/holiman/uint256"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -567,20 +565,10 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		r.Mul(r, blockReward)
 		r.Div(r, big8)
 
-		// This should not happen, but it's useful for replay tests
-		if config.IsPrague(header.Number, header.Time) {
-			state.Witness().TouchAddressOnReadAndComputeGas(uncle.Coinbase.Bytes(), uint256.Int{}, utils.BalanceLeafKey)
-		}
 		state.AddBalance(uncle.Coinbase, r)
 
 		r.Div(blockReward, big32)
 		reward.Add(reward, r)
-	}
-	if config.IsPrague(header.Number, header.Time) {
-		state.Witness().TouchAddressOnReadAndComputeGas(header.Coinbase.Bytes(), uint256.Int{}, utils.BalanceLeafKey)
-		state.Witness().TouchAddressOnReadAndComputeGas(header.Coinbase.Bytes(), uint256.Int{}, utils.VersionLeafKey)
-		state.Witness().TouchAddressOnReadAndComputeGas(header.Coinbase.Bytes(), uint256.Int{}, utils.NonceLeafKey)
-		state.Witness().TouchAddressOnReadAndComputeGas(header.Coinbase.Bytes(), uint256.Int{}, utils.CodeKeccakLeafKey)
 	}
 	state.AddBalance(header.Coinbase, reward)
 }

--- a/core/state/access_list.go
+++ b/core/state/access_list.go
@@ -18,22 +18,62 @@ package state
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
 )
 
-type accessList struct {
+type ALAccessMode bool
+
+var (
+	AccessListRead  = ALAccessMode(false)
+	AccessListWrite = ALAccessMode(true)
+)
+
+type ALAccountItem uint64
+
+const (
+	ALVersion = ALAccountItem(1 << iota)
+	ALBalance
+	ALNonce
+	ALCodeHash
+	ALCodeSize
+	ALLastHeaderItem
+)
+
+const ALAllItems = ALVersion | ALBalance | ALNonce | ALCodeSize | ALCodeHash
+
+type AccessList interface {
+	ContainsAddress(address common.Address) bool
+	Contains(address common.Address, slot common.Hash) (addressPresent bool, slotPresent bool)
+	Copy() AccessList
+	AddAddress(address common.Address, items ALAccountItem, isWrite ALAccessMode) uint64
+	AddSlot(address common.Address, slot common.Hash, isWrite ALAccessMode) uint64
+	DeleteSlot(address common.Address, slot common.Hash)
+	DeleteAddress(address common.Address)
+
+	TouchAndChargeValueTransfer(callerAddr, targetAddr []byte) uint64
+	TouchAndChargeContractCreateInit(addr []byte, createSendsValue bool) uint64
+	TouchTxOriginAndComputeGas(originAddr []byte) uint64
+	TouchTxExistingAndComputeGas(targetAddr []byte, sendsValue bool) uint64
+	TouchAddressOnReadAndComputeGas(addr []byte, index uint256.Int, suffix byte) uint64
+	Merge(AccessList)
+	Keys() [][]byte
+}
+
+type accessList2929 struct {
 	addresses map[common.Address]int
 	slots     []map[common.Hash]struct{}
 }
 
 // ContainsAddress returns true if the address is in the access list.
-func (al *accessList) ContainsAddress(address common.Address) bool {
+func (al *accessList2929) ContainsAddress(address common.Address) bool {
 	_, ok := al.addresses[address]
 	return ok
 }
 
 // Contains checks if a slot within an account is present in the access list, returning
 // separate flags for the presence of the account and the slot respectively.
-func (al *accessList) Contains(address common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
+func (al *accessList2929) Contains(address common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
 	idx, ok := al.addresses[address]
 	if !ok {
 		// no such address (and hence zero slots)
@@ -48,15 +88,15 @@ func (al *accessList) Contains(address common.Address, slot common.Hash) (addres
 }
 
 // newAccessList creates a new accessList.
-func newAccessList() *accessList {
-	return &accessList{
+func newAccessList() AccessList {
+	return &accessList2929{
 		addresses: make(map[common.Address]int),
 	}
 }
 
 // Copy creates an independent copy of an accessList.
-func (a *accessList) Copy() *accessList {
-	cp := newAccessList()
+func (a *accessList2929) Copy() AccessList {
+	cp := newAccessList().(*accessList2929)
 	for k, v := range a.addresses {
 		cp.addresses[k] = v
 	}
@@ -73,44 +113,41 @@ func (a *accessList) Copy() *accessList {
 
 // AddAddress adds an address to the access list, and returns 'true' if the operation
 // caused a change (addr was not previously in the list).
-func (al *accessList) AddAddress(address common.Address) bool {
+func (al *accessList2929) AddAddress(address common.Address, _ ALAccountItem, _ ALAccessMode) uint64 {
 	if _, present := al.addresses[address]; present {
-		return false
+		return params.WarmStorageReadCostEIP2929
 	}
 	al.addresses[address] = -1
-	return true
+	return params.ColdAccountAccessCostEIP2929
 }
 
 // AddSlot adds the specified (addr, slot) combo to the access list.
-// Return values are:
-// - address added
-// - slot added
-// For any 'true' value returned, a corresponding journal entry must be made.
-func (al *accessList) AddSlot(address common.Address, slot common.Hash) (addrChange bool, slotChange bool) {
+// Returns the gas consumed.
+func (al *accessList2929) AddSlot(address common.Address, slot common.Hash, _ ALAccessMode) (gas uint64) {
 	idx, addrPresent := al.addresses[address]
 	if !addrPresent || idx == -1 {
 		// Address not present, or addr present but no slots there
 		al.addresses[address] = len(al.slots)
 		slotmap := map[common.Hash]struct{}{slot: {}}
 		al.slots = append(al.slots, slotmap)
-		return !addrPresent, true
+		return params.WarmStorageReadCostEIP2929
 	}
 	// There is already an (address,slot) mapping
 	slotmap := al.slots[idx]
 	if _, ok := slotmap[slot]; !ok {
 		slotmap[slot] = struct{}{}
 		// Journal add slot change
-		return false, true
+		return params.ColdAccountAccessCostEIP2929
 	}
 	// No changes required
-	return false, false
+	return params.WarmStorageReadCostEIP2929
 }
 
 // DeleteSlot removes an (address, slot)-tuple from the access list.
 // This operation needs to be performed in the same order as the addition happened.
 // This method is meant to be used  by the journal, which maintains ordering of
 // operations.
-func (al *accessList) DeleteSlot(address common.Address, slot common.Hash) {
+func (al *accessList2929) DeleteSlot(address common.Address, slot common.Hash) {
 	idx, addrOk := al.addresses[address]
 	// There are two ways this can fail
 	if !addrOk {
@@ -131,6 +168,29 @@ func (al *accessList) DeleteSlot(address common.Address, slot common.Hash) {
 // needs to be performed in the same order as the addition happened.
 // This method is meant to be used  by the journal, which maintains ordering of
 // operations.
-func (al *accessList) DeleteAddress(address common.Address) {
+func (al *accessList2929) DeleteAddress(address common.Address) {
 	delete(al.addresses, address)
 }
+
+func (al *accessList2929) TouchAndChargeValueTransfer(callerAddr []byte, targetAddr []byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchAndChargeContractCreateInit(addr []byte, createSendsValue bool) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchTxOriginAndComputeGas(originAddr []byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchTxExistingAndComputeGas(targetAddr []byte, sendsValue bool) uint64 {
+	return 0
+}
+
+func (al *accessList2929) TouchAddressOnReadAndComputeGas(addr []byte, index uint256.Int, subIndex byte) uint64 {
+	return 0
+}
+
+func (al *accessList2929) Merge(other AccessList) {}
+func (al *accessList2929) Keys() [][]byte         { return nil }

--- a/core/state/access_witness.go
+++ b/core/state/access_witness.go
@@ -56,7 +56,8 @@ func NewAccessWitness(pointCache *utils.PointCache) *AccessWitness {
 // Merge is used to merge the witness that got generated during the execution
 // of a tx, with the accumulation of witnesses that were generated during the
 // execution of all the txs preceding this one in a given block.
-func (aw *AccessWitness) Merge(other *AccessWitness) {
+func (aw *AccessWitness) Merge(o AccessList) {
+	other := o.(*AccessWitness)
 	for k := range other.branches {
 		aw.branches[k] |= other.branches[k]
 	}
@@ -78,7 +79,7 @@ func (aw *AccessWitness) Keys() [][]byte {
 	return keys
 }
 
-func (aw *AccessWitness) Copy() *AccessWitness {
+func (aw *AccessWitness) Copy() AccessList {
 	naw := &AccessWitness{
 		branches:   make(map[branchAccessKey]mode),
 		chunks:     make(map[chunkAccessKey]mode),
@@ -88,27 +89,10 @@ func (aw *AccessWitness) Copy() *AccessWitness {
 	return naw
 }
 
-func (aw *AccessWitness) TouchAndChargeProofOfAbsence(addr []byte) uint64 {
-	var gas uint64
-	gas += aw.TouchAddressOnReadAndComputeGas(addr, zeroTreeIndex, utils.VersionLeafKey)
-	gas += aw.TouchAddressOnReadAndComputeGas(addr, zeroTreeIndex, utils.BalanceLeafKey)
-	gas += aw.TouchAddressOnReadAndComputeGas(addr, zeroTreeIndex, utils.CodeSizeLeafKey)
-	gas += aw.TouchAddressOnReadAndComputeGas(addr, zeroTreeIndex, utils.CodeKeccakLeafKey)
-	gas += aw.TouchAddressOnReadAndComputeGas(addr, zeroTreeIndex, utils.NonceLeafKey)
-	return gas
-}
-
-func (aw *AccessWitness) TouchAndChargeMessageCall(addr []byte) uint64 {
-	var gas uint64
-	gas += aw.TouchAddressOnReadAndComputeGas(addr, zeroTreeIndex, utils.VersionLeafKey)
-	gas += aw.TouchAddressOnReadAndComputeGas(addr, zeroTreeIndex, utils.CodeSizeLeafKey)
-	return gas
-}
-
 func (aw *AccessWitness) TouchAndChargeValueTransfer(callerAddr, targetAddr []byte) uint64 {
 	var gas uint64
-	gas += aw.TouchAddressOnWriteAndComputeGas(callerAddr, zeroTreeIndex, utils.BalanceLeafKey)
-	gas += aw.TouchAddressOnWriteAndComputeGas(targetAddr, zeroTreeIndex, utils.BalanceLeafKey)
+	gas += aw.touchAddressAndChargeGas(callerAddr, zeroTreeIndex, utils.BalanceLeafKey, AccessListWrite)
+	gas += aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.BalanceLeafKey, AccessListWrite)
 	return gas
 }
 
@@ -116,33 +100,21 @@ func (aw *AccessWitness) TouchAndChargeValueTransfer(callerAddr, targetAddr []by
 // a contract creation
 func (aw *AccessWitness) TouchAndChargeContractCreateInit(addr []byte, createSendsValue bool) uint64 {
 	var gas uint64
-	gas += aw.TouchAddressOnWriteAndComputeGas(addr, zeroTreeIndex, utils.VersionLeafKey)
-	gas += aw.TouchAddressOnWriteAndComputeGas(addr, zeroTreeIndex, utils.NonceLeafKey)
+	gas += aw.touchAddressAndChargeGas(addr, zeroTreeIndex, utils.VersionLeafKey, AccessListWrite)
+	gas += aw.touchAddressAndChargeGas(addr, zeroTreeIndex, utils.NonceLeafKey, AccessListWrite)
+	// FIXME note that this is incompatible with the spec
 	if createSendsValue {
-		gas += aw.TouchAddressOnWriteAndComputeGas(addr, zeroTreeIndex, utils.BalanceLeafKey)
+		gas += aw.touchAddressAndChargeGas(addr, zeroTreeIndex, utils.BalanceLeafKey, AccessListWrite)
 	}
 	return gas
 }
 
-// TouchAndChargeContractCreateCompleted charges access access costs after
-// the completion of a contract creation to populate the created account in
-// the tree
-func (aw *AccessWitness) TouchAndChargeContractCreateCompleted(addr []byte) uint64 {
-	var gas uint64
-	gas += aw.TouchAddressOnWriteAndComputeGas(addr, zeroTreeIndex, utils.VersionLeafKey)
-	gas += aw.TouchAddressOnWriteAndComputeGas(addr, zeroTreeIndex, utils.BalanceLeafKey)
-	gas += aw.TouchAddressOnWriteAndComputeGas(addr, zeroTreeIndex, utils.CodeSizeLeafKey)
-	gas += aw.TouchAddressOnWriteAndComputeGas(addr, zeroTreeIndex, utils.CodeKeccakLeafKey)
-	gas += aw.TouchAddressOnWriteAndComputeGas(addr, zeroTreeIndex, utils.NonceLeafKey)
-	return gas
-}
-
 func (aw *AccessWitness) TouchTxOriginAndComputeGas(originAddr []byte) uint64 {
-	aw.TouchAddressOnReadAndComputeGas(originAddr, zeroTreeIndex, utils.VersionLeafKey)
-	aw.TouchAddressOnReadAndComputeGas(originAddr, zeroTreeIndex, utils.CodeSizeLeafKey)
-	aw.TouchAddressOnReadAndComputeGas(originAddr, zeroTreeIndex, utils.CodeKeccakLeafKey)
-	aw.TouchAddressOnWriteAndComputeGas(originAddr, zeroTreeIndex, utils.NonceLeafKey)
-	aw.TouchAddressOnWriteAndComputeGas(originAddr, zeroTreeIndex, utils.BalanceLeafKey)
+	aw.touchAddressAndChargeGas(originAddr, zeroTreeIndex, utils.VersionLeafKey, AccessListRead)
+	aw.touchAddressAndChargeGas(originAddr, zeroTreeIndex, utils.CodeSizeLeafKey, AccessListRead)
+	aw.touchAddressAndChargeGas(originAddr, zeroTreeIndex, utils.CodeKeccakLeafKey, AccessListRead)
+	aw.touchAddressAndChargeGas(originAddr, zeroTreeIndex, utils.NonceLeafKey, AccessListWrite)
+	aw.touchAddressAndChargeGas(originAddr, zeroTreeIndex, utils.BalanceLeafKey, AccessListWrite)
 
 	// Kaustinen note: we're currently experimenting with stop chargin gas for the origin address
 	// so simple transfer still take 21000 gas. This is to potentially avoid breaking existing tooling.
@@ -152,14 +124,14 @@ func (aw *AccessWitness) TouchTxOriginAndComputeGas(originAddr []byte) uint64 {
 }
 
 func (aw *AccessWitness) TouchTxExistingAndComputeGas(targetAddr []byte, sendsValue bool) uint64 {
-	aw.TouchAddressOnReadAndComputeGas(targetAddr, zeroTreeIndex, utils.VersionLeafKey)
-	aw.TouchAddressOnReadAndComputeGas(targetAddr, zeroTreeIndex, utils.CodeSizeLeafKey)
-	aw.TouchAddressOnReadAndComputeGas(targetAddr, zeroTreeIndex, utils.CodeKeccakLeafKey)
-	aw.TouchAddressOnReadAndComputeGas(targetAddr, zeroTreeIndex, utils.NonceLeafKey)
+	aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.VersionLeafKey, AccessListRead)
+	aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.CodeSizeLeafKey, AccessListRead)
+	aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.CodeKeccakLeafKey, AccessListRead)
+	aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.NonceLeafKey, AccessListRead)
 	if sendsValue {
-		aw.TouchAddressOnWriteAndComputeGas(targetAddr, zeroTreeIndex, utils.BalanceLeafKey)
+		aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.BalanceLeafKey, AccessListWrite)
 	} else {
-		aw.TouchAddressOnReadAndComputeGas(targetAddr, zeroTreeIndex, utils.BalanceLeafKey)
+		aw.touchAddressAndChargeGas(targetAddr, zeroTreeIndex, utils.BalanceLeafKey, AccessListRead)
 	}
 
 	// Kaustinen note: we're currently experimenting with stop chargin gas for the origin address
@@ -169,22 +141,18 @@ func (aw *AccessWitness) TouchTxExistingAndComputeGas(targetAddr []byte, sendsVa
 	return 0
 }
 
-func (aw *AccessWitness) TouchAddressOnWriteAndComputeGas(addr []byte, treeIndex uint256.Int, subIndex byte) uint64 {
-	return aw.touchAddressAndChargeGas(addr, treeIndex, subIndex, true)
-}
-
 func (aw *AccessWitness) TouchAddressOnReadAndComputeGas(addr []byte, treeIndex uint256.Int, subIndex byte) uint64 {
-	return aw.touchAddressAndChargeGas(addr, treeIndex, subIndex, false)
+	return aw.touchAddressAndChargeGas(addr, treeIndex, subIndex, AccessListRead)
 }
 
-func (aw *AccessWitness) touchAddressAndChargeGas(addr []byte, treeIndex uint256.Int, subIndex byte, isWrite bool) uint64 {
-	stemRead, selectorRead, stemWrite, selectorWrite, selectorFill := aw.touchAddress(addr, treeIndex, subIndex, isWrite)
+func (aw *AccessWitness) touchAddressAndChargeGas(addr []byte, treeIndex uint256.Int, subIndex byte, isWrite ALAccessMode) uint64 {
+	stemRead, suffixRead, stemWrite, selectorWrite, selectorFill := aw.touchAddress(addr, treeIndex, subIndex, isWrite)
 
 	var gas uint64
 	if stemRead {
 		gas += params.WitnessBranchReadCost
 	}
-	if selectorRead {
+	if suffixRead {
 		gas += params.WitnessChunkReadCost
 	}
 	if stemWrite {
@@ -201,7 +169,7 @@ func (aw *AccessWitness) touchAddressAndChargeGas(addr []byte, treeIndex uint256
 }
 
 // touchAddress adds any missing access event to the witness.
-func (aw *AccessWitness) touchAddress(addr []byte, treeIndex uint256.Int, subIndex byte, isWrite bool) (bool, bool, bool, bool, bool) {
+func (aw *AccessWitness) touchAddress(addr []byte, treeIndex uint256.Int, subIndex byte, isWrite ALAccessMode) (bool, bool, bool, bool, bool) {
 	branchKey := newBranchAccessKey(addr, treeIndex)
 	chunkKey := newChunkAccessKey(branchKey, subIndex)
 
@@ -258,4 +226,35 @@ func newChunkAccessKey(branchKey branchAccessKey, leafKey byte) chunkAccessKey {
 	lk.branchAccessKey = branchKey
 	lk.leafKey = leafKey
 	return lk
+}
+
+func (aw *AccessWitness) AddAddress(addr common.Address, items ALAccountItem, isWrite ALAccessMode) uint64 {
+	var gas uint64
+	for index := utils.VersionLeafKey; index <= utils.CodeSizeLeafKey; index++ {
+		if (1<<index)&items != 0 {
+			gas += aw.touchAddressAndChargeGas(addr[:], zeroTreeIndex, index, isWrite)
+		}
+	}
+	return gas
+}
+
+func (aw *AccessWitness) AddSlot(address common.Address, slot common.Hash, isWrite ALAccessMode) uint64 {
+	treeIndex, suffix := utils.GetTreeKeyStorageSlotTreeIndexes(slot.Bytes())
+	return aw.touchAddressAndChargeGas(address[:], *treeIndex, suffix, isWrite)
+}
+
+func (aw *AccessWitness) DeleteSlot(address common.Address, slot common.Hash) {
+	// Should remain in the witness
+}
+
+func (aw *AccessWitness) DeleteAddress(address common.Address) {
+	// Should remain in the witness
+}
+
+func (aw *AccessWitness) ContainsAddress(address common.Address) bool {
+	panic("not implemented") // TODO: Implement
+}
+
+func (aw *AccessWitness) Contains(address common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
+	panic("not implemented") // TODO: Implement
 }

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -335,14 +335,14 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 		{
 			name: "AddAddressToAccessList",
 			fn: func(a testAction, s *StateDB) {
-				s.AddAddressToAccessList(addr)
+				s.AddAddressToAccessList(addr, 0, AccessListRead)
 			},
 		},
 		{
 			name: "AddSlotToAccessList",
 			fn: func(a testAction, s *StateDB) {
 				s.AddSlotToAccessList(addr,
-					common.Hash{byte(a.args[0])})
+					common.Hash{byte(a.args[0])}, AccessListRead)
 			},
 			args: make([]int64, 1),
 		},
@@ -818,19 +818,19 @@ func TestStateDBAccessList(t *testing.T) {
 		}
 		// Check that the given addresses are in the access list
 		for _, address := range addresses {
-			if !state.AddressInAccessList(address) {
+			if !state.addressInAccessList(address) {
 				t.Fatalf("expected %x to be in access list", address)
 			}
 		}
 		// Check that only the expected addresses are present in the access list
-		for address := range state.accessList.addresses {
+		for address := range state.accessList.(*accessList2929).addresses {
 			if _, exist := addressMap[address]; !exist {
 				t.Fatalf("extra address %x in access list", address)
 			}
 		}
 	}
 	verifySlots := func(addrString string, slotStrings ...string) {
-		if !state.AddressInAccessList(addr(addrString)) {
+		if !state.addressInAccessList(addr(addrString)) {
 			t.Fatalf("scope missing address/slots %v", addrString)
 		}
 		var address = addr(addrString)
@@ -844,14 +844,14 @@ func TestStateDBAccessList(t *testing.T) {
 		}
 		// Check that the expected items are in the access list
 		for i, s := range slots {
-			if _, slotPresent := state.SlotInAccessList(address, s); !slotPresent {
+			if _, slotPresent := state.slotInAccessList(address, s); !slotPresent {
 				t.Fatalf("input %d: scope missing slot %v (address %v)", i, s, addrString)
 			}
 		}
 		// Check that no extra elements are in the access list
-		index := state.accessList.addresses[address]
+		index := state.accessList.(*accessList2929).addresses[address]
 		if index >= 0 {
-			stateSlots := state.accessList.slots[index]
+			stateSlots := state.accessList.(*accessList2929).slots[index]
 			for s := range stateSlots {
 				if _, slotPresent := slotMap[s]; !slotPresent {
 					t.Fatalf("scope has extra slot %v (address %v)", s, addrString)
@@ -860,9 +860,9 @@ func TestStateDBAccessList(t *testing.T) {
 		}
 	}
 
-	state.AddAddressToAccessList(addr("aa"))          // 1
-	state.AddSlotToAccessList(addr("bb"), slot("01")) // 2,3
-	state.AddSlotToAccessList(addr("bb"), slot("02")) // 4
+	state.AddAddressToAccessList(addr("aa"), 0, AccessListRead)       // 1
+	state.AddSlotToAccessList(addr("bb"), slot("01"), AccessListRead) // 2,3
+	state.AddSlotToAccessList(addr("bb"), slot("02"), AccessListRead) // 4
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02")
 
@@ -873,17 +873,17 @@ func TestStateDBAccessList(t *testing.T) {
 	}
 
 	// same again, should cause no journal entries
-	state.AddSlotToAccessList(addr("bb"), slot("01"))
-	state.AddSlotToAccessList(addr("bb"), slot("02"))
-	state.AddAddressToAccessList(addr("aa"))
+	state.AddSlotToAccessList(addr("bb"), slot("01"), AccessListRead)
+	state.AddSlotToAccessList(addr("bb"), slot("02"), AccessListRead)
+	state.AddAddressToAccessList(addr("aa"), 0, AccessListRead)
 	if exp, got := 4, state.journal.length(); exp != got {
 		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
 	}
 	// some new ones
-	state.AddSlotToAccessList(addr("bb"), slot("03")) // 5
-	state.AddSlotToAccessList(addr("aa"), slot("01")) // 6
-	state.AddSlotToAccessList(addr("cc"), slot("01")) // 7,8
-	state.AddAddressToAccessList(addr("cc"))
+	state.AddSlotToAccessList(addr("bb"), slot("03"), AccessListRead) // 5
+	state.AddSlotToAccessList(addr("aa"), slot("01"), AccessListRead) // 6
+	state.AddSlotToAccessList(addr("cc"), slot("01"), AccessListRead) // 7,8
+	state.AddAddressToAccessList(addr("cc"), 0, AccessListRead)
 	if exp, got := 8, state.journal.length(); exp != got {
 		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
 	}
@@ -895,7 +895,7 @@ func TestStateDBAccessList(t *testing.T) {
 
 	// now start rolling back changes
 	state.journal.revert(state, 7)
-	if _, ok := state.SlotInAccessList(addr("cc"), slot("01")); ok {
+	if _, ok := state.slotInAccessList(addr("cc"), slot("01")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb", "cc")
@@ -903,7 +903,7 @@ func TestStateDBAccessList(t *testing.T) {
 	verifySlots("bb", "01", "02", "03")
 
 	state.journal.revert(state, 6)
-	if state.AddressInAccessList(addr("cc")) {
+	if state.addressInAccessList(addr("cc")) {
 		t.Fatalf("addr present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
@@ -911,46 +911,46 @@ func TestStateDBAccessList(t *testing.T) {
 	verifySlots("bb", "01", "02", "03")
 
 	state.journal.revert(state, 5)
-	if _, ok := state.SlotInAccessList(addr("aa"), slot("01")); ok {
+	if _, ok := state.slotInAccessList(addr("aa"), slot("01")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02", "03")
 
 	state.journal.revert(state, 4)
-	if _, ok := state.SlotInAccessList(addr("bb"), slot("03")); ok {
+	if _, ok := state.slotInAccessList(addr("bb"), slot("03")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02")
 
 	state.journal.revert(state, 3)
-	if _, ok := state.SlotInAccessList(addr("bb"), slot("02")); ok {
+	if _, ok := state.slotInAccessList(addr("bb"), slot("02")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01")
 
 	state.journal.revert(state, 2)
-	if _, ok := state.SlotInAccessList(addr("bb"), slot("01")); ok {
+	if _, ok := state.slotInAccessList(addr("bb"), slot("01")); ok {
 		t.Fatalf("slot present, expected missing")
 	}
 	verifyAddrs("aa", "bb")
 
 	state.journal.revert(state, 1)
-	if state.AddressInAccessList(addr("bb")) {
+	if state.addressInAccessList(addr("bb")) {
 		t.Fatalf("addr present, expected missing")
 	}
 	verifyAddrs("aa")
 
 	state.journal.revert(state, 0)
-	if state.AddressInAccessList(addr("aa")) {
+	if state.addressInAccessList(addr("aa")) {
 		t.Fatalf("addr present, expected missing")
 	}
-	if got, exp := len(state.accessList.addresses), 0; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).addresses), 0; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
-	if got, exp := len(state.accessList.slots), 0; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).slots), 0; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
 	// Check the copy
@@ -958,10 +958,10 @@ func TestStateDBAccessList(t *testing.T) {
 	state = stateCopy1
 	verifyAddrs("aa", "bb")
 	verifySlots("bb", "01", "02")
-	if got, exp := len(state.accessList.addresses), 2; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).addresses), 2; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
-	if got, exp := len(state.accessList.slots), 1; got != exp {
+	if got, exp := len(state.accessList.(*accessList2929).slots), 1; got != exp {
 		t.Fatalf("expected empty, got %d", got)
 	}
 }

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -488,7 +488,7 @@ func TestProcessVerkle(t *testing.T) {
 	txCost1 := params.TxGas
 	txCost2 := params.TxGas
 	contractCreationCost := intrinsicContractCreationGas + uint64(5600+700+700+700 /* creation with value */ +2739 /* execution costs */)
-	codeWithExtCodeCopyGas := intrinsicCodeWithExtCodeCopyGas + uint64(5600+700 /* creation */ +235644 /* execution costs */)
+	codeWithExtCodeCopyGas := intrinsicCodeWithExtCodeCopyGas + uint64(5600+700 /* creation */ +235544 /* execution costs */)
 	blockGasUsagesExpected := []uint64{
 		txCost1*2 + txCost2,
 		txCost1*2 + txCost2 + contractCreationCost + codeWithExtCodeCopyGas,

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -488,7 +488,7 @@ func TestProcessVerkle(t *testing.T) {
 	txCost1 := params.TxGas
 	txCost2 := params.TxGas
 	contractCreationCost := intrinsicContractCreationGas + uint64(5600+700+700+700 /* creation with value */ +2739 /* execution costs */)
-	codeWithExtCodeCopyGas := intrinsicCodeWithExtCodeCopyGas + uint64(5600+700 /* creation */ +302044 /* execution costs */)
+	codeWithExtCodeCopyGas := intrinsicCodeWithExtCodeCopyGas + uint64(5600+700 /* creation */ +235644 /* execution costs */)
 	blockGasUsagesExpected := []uint64{
 		txCost1*2 + txCost2,
 		txCost1*2 + txCost2 + contractCreationCost + codeWithExtCodeCopyGas,

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -312,4 +312,7 @@ func enable2935(jt *JumpTable) {
 
 func enable4762(jt *JumpTable) {
 	jt[SSTORE].dynamicGas = gasSStore4762
+	jt[BALANCE].dynamicGas = gasBalance4762
+	jt[EXTCODESIZE].dynamicGas = gasExtCodeSize4762
+	jt[EXTCODEHASH].dynamicGas = gasExtCodeHash4762
 }

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -38,6 +38,7 @@ var activators = map[int]func(*JumpTable){
 	1344: enable1344,
 	1153: enable1153,
 	2935: enable2935,
+	4762: enable4762,
 }
 
 // EnableEIP enables the given EIP on the config.
@@ -307,4 +308,8 @@ func enable6780(jt *JumpTable) {
 
 func enable2935(jt *JumpTable) {
 	jt[BLOCKHASH].dynamicGas = gasBlockHashEip2935
+}
+
+func enable4762(jt *JumpTable) {
+	jt[SSTORE].dynamicGas = gasSStore4762
 }

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -37,6 +37,7 @@ var activators = map[int]func(*JumpTable){
 	1884: enable1884,
 	1344: enable1344,
 	1153: enable1153,
+	2935: enable2935,
 }
 
 // EnableEIP enables the given EIP on the config.
@@ -123,28 +124,28 @@ func enable2929(jt *JumpTable) {
 	jt[SLOAD].constantGas = 0
 	jt[SLOAD].dynamicGas = gasSLoadEIP2929
 
-	jt[EXTCODECOPY].constantGas = params.WarmStorageReadCostEIP2929
+	jt[EXTCODECOPY].constantGas = 0
 	jt[EXTCODECOPY].dynamicGas = gasExtCodeCopyEIP2929
 
-	jt[EXTCODESIZE].constantGas = params.WarmStorageReadCostEIP2929
+	jt[EXTCODESIZE].constantGas = 0
 	jt[EXTCODESIZE].dynamicGas = gasEip2929AccountCheck
 
-	jt[EXTCODEHASH].constantGas = params.WarmStorageReadCostEIP2929
+	jt[EXTCODEHASH].constantGas = 0
 	jt[EXTCODEHASH].dynamicGas = gasEip2929AccountCheck
 
-	jt[BALANCE].constantGas = params.WarmStorageReadCostEIP2929
+	jt[BALANCE].constantGas = 0
 	jt[BALANCE].dynamicGas = gasEip2929AccountCheck
 
-	jt[CALL].constantGas = params.WarmStorageReadCostEIP2929
+	jt[CALL].constantGas = 0
 	jt[CALL].dynamicGas = gasCallEIP2929
 
-	jt[CALLCODE].constantGas = params.WarmStorageReadCostEIP2929
+	jt[CALLCODE].constantGas = 0
 	jt[CALLCODE].dynamicGas = gasCallCodeEIP2929
 
-	jt[STATICCALL].constantGas = params.WarmStorageReadCostEIP2929
+	jt[STATICCALL].constantGas = 0
 	jt[STATICCALL].dynamicGas = gasStaticCallEIP2929
 
-	jt[DELEGATECALL].constantGas = params.WarmStorageReadCostEIP2929
+	jt[DELEGATECALL].constantGas = 0
 	jt[DELEGATECALL].dynamicGas = gasDelegateCallEIP2929
 
 	// This was previously part of the dynamic cost, but we're using it as a constantGas
@@ -302,4 +303,8 @@ func enable6780(jt *JumpTable) {
 		minStack:    minStack(1, 0),
 		maxStack:    maxStack(1, 0),
 	}
+}
+
+func enable2935(jt *JumpTable) {
+	jt[BLOCKHASH].dynamicGas = gasBlockHashEip2935
 }

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -35,6 +35,7 @@ var (
 	ErrWriteProtection          = errors.New("write protection")
 	ErrReturnDataOutOfBounds    = errors.New("return data out of bounds")
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
+	ErrBlockNumberUintOverflow  = errors.New("block number uint64 overflow")
 	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
 	ErrNonceUintOverflow        = errors.New("nonce uint64 overflow")
 

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -103,7 +103,7 @@ func gasExtCodeSize(evm *EVM, contract *Contract, stack *Stack, mem *Memory, mem
 	slot := stack.Back(0)
 	address := common.Address(slot.Bytes20())
 	if evm.chainRules.IsPrague {
-		usedGas += evm.StateDB.AddAddressToAccessList(address, state.ALCodeSize, state.AccessListRead)
+		usedGas += evm.StateDB.AddAddressToAccessList(address, state.ALVersion|state.ALCodeSize, state.AccessListRead)
 	}
 
 	return usedGas, nil

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -17,14 +17,14 @@
 package vm
 
 import (
+	"encoding/binary"
 	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	trieUtils "github.com/ethereum/go-ethereum/trie/utils"
-	"github.com/holiman/uint256"
 )
 
 // memoryGasCost calculates the quadratic gas for memory expansion. It does so
@@ -101,29 +101,15 @@ var (
 func gasExtCodeSize(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	usedGas := uint64(0)
 	slot := stack.Back(0)
-	address := slot.Bytes20()
+	address := common.Address(slot.Bytes20())
 	if evm.chainRules.IsPrague {
-		usedGas += evm.TxContext.Accesses.TouchAddressOnReadAndComputeGas(address[:], uint256.Int{}, trieUtils.CodeSizeLeafKey)
-	}
-
-	return usedGas, nil
-}
-
-func gasSLoad(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	usedGas := uint64(0)
-
-	if evm.chainRules.IsPrague {
-		where := stack.Back(0)
-		treeIndex, subIndex := trieUtils.GetTreeKeyStorageSlotTreeIndexes(where.Bytes())
-		usedGas += evm.Accesses.TouchAddressOnReadAndComputeGas(contract.Address().Bytes(), *treeIndex, subIndex)
+		usedGas += evm.StateDB.AddAddressToAccessList(address, state.ALCodeSize, state.AccessListRead)
 	}
 
 	return usedGas, nil
 }
 
 func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	// Apply the witness access costs, err is nil
-	accessGas, _ := gasSLoad(evm, contract, stack, mem, memorySize)
 	var (
 		y, x    = stack.Back(1), stack.Back(0)
 		current = evm.StateDB.GetState(contract.Address(), x.Bytes32())
@@ -139,12 +125,12 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 		// 3. From a non-zero to a non-zero                         (CHANGE)
 		switch {
 		case current == (common.Hash{}) && y.Sign() != 0: // 0 => non 0
-			return params.SstoreSetGas + accessGas, nil
+			return params.SstoreSetGas, nil
 		case current != (common.Hash{}) && y.Sign() == 0: // non 0 => 0
 			evm.StateDB.AddRefund(params.SstoreRefundGas)
-			return params.SstoreClearGas + accessGas, nil
+			return params.SstoreClearGas, nil
 		default: // non 0 => non 0 (or 0 => 0)
-			return params.SstoreResetGas + accessGas, nil
+			return params.SstoreResetGas, nil
 		}
 	}
 
@@ -426,13 +412,13 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 	}
 	if evm.chainRules.IsPrague {
 		if _, isPrecompile := evm.precompile(address); !isPrecompile {
-			gas, overflow = math.SafeAdd(gas, evm.Accesses.TouchAndChargeMessageCall(address.Bytes()[:]))
+			gas, overflow = math.SafeAdd(gas, evm.StateDB.AddAddressToAccessList(address, state.ALVersion|state.ALCodeSize, state.AccessListRead))
 			if overflow {
 				return 0, ErrGasUintOverflow
 			}
 		}
 		if transfersValue {
-			gas, overflow = math.SafeAdd(gas, evm.Accesses.TouchAndChargeValueTransfer(contract.Address().Bytes()[:], address.Bytes()[:]))
+			gas, overflow = math.SafeAdd(gas, evm.StateDB.TouchAndChargeValueTransfer(contract.Address(), address))
 			if overflow {
 				return 0, ErrGasUintOverflow
 			}
@@ -467,7 +453,7 @@ func gasCallCode(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
 	if evm.chainRules.IsPrague {
 		address := common.Address(stack.Back(1).Bytes20())
 		if _, isPrecompile := evm.precompile(address); !isPrecompile {
-			gas, overflow = math.SafeAdd(gas, evm.Accesses.TouchAndChargeMessageCall(address.Bytes()))
+			gas, overflow = math.SafeAdd(gas, evm.StateDB.AddAddressToAccessList(address, state.ALVersion|state.ALCodeSize, state.AccessListRead))
 			if overflow {
 				return 0, ErrGasUintOverflow
 			}
@@ -492,7 +478,7 @@ func gasDelegateCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 	if evm.chainRules.IsPrague {
 		address := common.Address(stack.Back(1).Bytes20())
 		if _, isPrecompile := evm.precompile(address); !isPrecompile {
-			gas, overflow = math.SafeAdd(gas, evm.Accesses.TouchAndChargeMessageCall(address.Bytes()))
+			gas, overflow = math.SafeAdd(gas, evm.StateDB.AddAddressToAccessList(address, state.ALVersion|state.ALCodeSize, state.AccessListRead))
 			if overflow {
 				return 0, ErrGasUintOverflow
 			}
@@ -517,7 +503,7 @@ func gasStaticCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memo
 	if evm.chainRules.IsPrague {
 		address := common.Address(stack.Back(1).Bytes20())
 		if _, isPrecompile := evm.precompile(address); !isPrecompile {
-			gas, overflow = math.SafeAdd(gas, evm.Accesses.TouchAndChargeMessageCall(address.Bytes()))
+			gas, overflow = math.SafeAdd(gas, evm.StateDB.AddAddressToAccessList(address, state.ALVersion|state.ALCodeSize, state.AccessListRead))
 			if overflow {
 				return 0, ErrGasUintOverflow
 			}
@@ -553,4 +539,17 @@ func gasSelfdestruct(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 		evm.StateDB.AddRefund(params.SelfdestructRefundGas)
 	}
 	return gas, nil
+}
+
+func gasBlockHashEip2935(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	num := stack.peek()
+	num64, overflow := num.Uint64WithOverflow()
+	if overflow {
+		num.Clear()
+		return 0, ErrBlockNumberUintOverflow
+	}
+
+	var pnum common.Hash
+	binary.BigEndian.PutUint64(pnum[24:], num64)
+	return evm.StateDB.AddSlotToAccessList(params.HistoryStorageAddress, pnum, state.AccessListRead), nil
 }

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -534,7 +534,7 @@ func opBlockhash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 	if num64 >= lower && num64 < upper {
 		// if Prague is active, read it from the history contract (EIP 2935).
 		if evm.chainRules.IsPrague {
-			num.SetBytes(getBlockHashFromContract(num64, evm.StateDB, evm.Accesses).Bytes())
+			num.SetBytes(getBlockHashFromContract(num64, evm.StateDB).Bytes())
 		} else {
 			num.SetBytes(interpreter.evm.Context.GetHash(num64).Bytes())
 		}

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -66,14 +66,18 @@ type StateDB interface {
 	// is defined according to EIP161 (balance = nonce = code = 0).
 	Empty(common.Address) bool
 
-	AddressInAccessList(addr common.Address) bool
-	SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool)
 	// AddAddressToAccessList adds the given address to the access list. This operation is safe to perform
 	// even if the feature/fork is not active yet
-	AddAddressToAccessList(addr common.Address)
+	AddAddressToAccessList(addr common.Address, item state.ALAccountItem, isWrite state.ALAccessMode) uint64
 	// AddSlotToAccessList adds the given (address,slot) to the access list. This operation is safe to perform
 	// even if the feature/fork is not active yet
-	AddSlotToAccessList(addr common.Address, slot common.Hash)
+	AddSlotToAccessList(addr common.Address, slot common.Hash, write state.ALAccessMode) uint64
+	TouchTxOriginAndComputeGas(addr common.Address) uint64
+	TouchTxExistingAndComputeGas(addr common.Address, sendsValue bool) uint64
+	TouchAndChargeContractCreateInit(addr common.Address, sendsValue bool) uint64
+	TouchAndChargeValueTransfer(from, to common.Address) uint64
+	TouchAddressOnReadAndComputeGas(from common.Address, chunk uint64) uint64
+
 	Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
 
 	RevertToSnapshot(int)
@@ -82,8 +86,7 @@ type StateDB interface {
 	AddLog(*types.Log)
 	AddPreimage(common.Hash, []byte)
 
-	Witness() *state.AccessWitness
-	SetWitness(*state.AccessWitness)
+	Witness() state.AccessList
 }
 
 // CallContext provides a basic interface for the EVM calling conventions. The EVM

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -59,6 +59,9 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	case evm.chainRules.IsPrague:
 		// TODO replace with prooper instruction set when fork is specified
 		table = &pragueInstructionSet
+		if err := EnableEIP(2935, table); err != nil {
+			log.Error("EIP 2935 activation failed", "error", err)
+		}
 	case evm.chainRules.IsCancun:
 		table = &cancunInstructionSet
 	case evm.chainRules.IsShanghai:
@@ -183,7 +186,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			// if the PC ends up in a new "chunk" of verkleized code, charge the
 			// associated costs.
 			contractAddr := contract.Address()
-			contract.Gas -= touchCodeChunksRangeOnReadAndChargeGas(contractAddr[:], pc, 1, uint64(len(contract.Code)), in.evm.TxContext.Accesses)
+			contract.Gas -= touchCodeChunksRangeOnReadAndChargeGas(contractAddr, pc, 1, uint64(len(contract.Code)), in.evm.StateDB)
 		}
 
 		// Get the operation from the jump table and validate the stack to ensure there are

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -61,6 +61,7 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 		table = &pragueInstructionSet
 		if err := EnableEIP(2935, table); err != nil {
 			log.Error("EIP 2935 activation failed", "error", err)
+			panic(err)
 		}
 	case evm.chainRules.IsCancun:
 		table = &cancunInstructionSet

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -558,7 +558,6 @@ func newFrontierInstructionSet() JumpTable {
 		SLOAD: {
 			execute:     opSload,
 			constantGas: params.SloadGasFrontier,
-			dynamicGas:  gasSLoad,
 			minStack:    minStack(1, 1),
 			maxStack:    maxStack(1, 1),
 		},

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -84,6 +84,7 @@ func validate(jt JumpTable) JumpTable {
 func newPragueInstructionSet() JumpTable {
 	instructionSet := newShanghaiInstructionSet()
 	enable6780(&instructionSet)
+	enable4762(&instructionSet)
 	return validate(instructionSet)
 }
 

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -93,6 +93,11 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 	}
 }
 
+func gasSStore4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	gas := evm.StateDB.AddSlotToAccessList(contract.Address(), common.Hash(stack.peek().Bytes32()), state.AccessListWrite)
+	return gas, nil
+}
+
 // gasSLoadEIP2929 calculates dynamic gas for SLOAD according to EIP-2929
 // For SLOAD, if the (address, storage_key) pair (where address is the address of the contract
 // whose storage is being read) is not yet in accessed_storage_keys,
@@ -101,12 +106,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 func gasSLoadEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	loc := stack.peek()
 	slot := common.Hash(loc.Bytes32())
-	verkleGas := evm.StateDB.AddSlotToAccessList(contract.Address(), slot, false)
-	// XXX this is for compat with the current testnet but it should be removed.
-	if verkleGas > 0 {
-		return params.ColdSloadCostEIP2929 + verkleGas, nil
-	}
-	return params.WarmStorageReadCostEIP2929, nil
+	return evm.StateDB.AddSlotToAccessList(contract.Address(), slot, false), nil
 }
 
 // gasExtCodeCopyEIP2929 implements extcodecopy according to EIP-2929

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -111,7 +111,7 @@ func gasExtCodeHash4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory,
 func gasSLoadEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	loc := stack.peek()
 	slot := common.Hash(loc.Bytes32())
-	return evm.StateDB.AddSlotToAccessList(contract.Address(), slot, false), nil
+	return evm.StateDB.AddSlotToAccessList(contract.Address(), slot, state.AccessModeRead), nil
 }
 
 // gasExtCodeCopyEIP2929 implements extcodecopy according to EIP-2929
@@ -126,7 +126,7 @@ func gasExtCodeCopyEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memo
 		return 0, err
 	}
 	addr := common.Address(stack.peek().Bytes20())
-	algas := evm.StateDB.AddAddressToAccessList(addr, state.ALCodeSize, state.AccessListRead)
+	algas := evm.StateDB.AddAddressToAccessList(addr, state.ALVersion|state.ALCodeSize, state.AccessListRead)
 	var overflow bool
 	// We charge (cold-warm), since 'warm' is already charged as constantGas
 	if gas, overflow = math.SafeAdd(gas, algas); overflow {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1051,11 +1051,6 @@ func doCall(ctx context.Context, b Backend, args TransactionArgs, state *state.S
 	}
 	evm, vmError := b.GetEVM(ctx, msg, state, header, &vm.Config{NoBaseFee: true}, &blockCtx)
 
-	// Set witness if trie is verkle
-	if state.Database().TrieDB().IsVerkle() {
-		state.SetWitness(state.NewAccessWitness())
-	}
-
 	// Wait for the context to be done and cancel the evm. Even if the
 	// EVM has finished, cancelling may be done (repeatedly)
 	go func() {

--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -26,11 +26,11 @@ import (
 )
 
 const (
-	VersionLeafKey    = 0
-	BalanceLeafKey    = 1
-	NonceLeafKey      = 2
-	CodeKeccakLeafKey = 3
-	CodeSizeLeafKey   = 4
+	VersionLeafKey = byte(iota)
+	BalanceLeafKey
+	NonceLeafKey
+	CodeKeccakLeafKey
+	CodeSizeLeafKey
 
 	maxPointCacheByteSize = 100 << 20
 )

--- a/trie/utils/verkle_test.go
+++ b/trie/utils/verkle_test.go
@@ -17,10 +17,10 @@
 package utils
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"math/big"
-	"math/rand"
 	"testing"
 
 	"github.com/ethereum/go-verkle"
@@ -63,6 +63,7 @@ func BenchmarkPedersenHash(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
+		//lint:ignore SA1019 crypto.Read not needed in tests
 		rand.Read(v[:])
 		rand.Read(addr[:])
 		GetTreeKeyCodeSize(addr[:])


### PR DESCRIPTION
This is a rewrite of `AccessWitness` that merges with `accessList` into a single `AccessList` interface, so that it can be merged into go-ethereum more quickly and thus reduce the pain of rebasing.

Notes:

 * ~~This PR hacks in bits of the old behavior in which both the 2929 and verkle gas costs are charged together. This should not be the case, but it's good enough that it's charged for syncing the current testnet~~

TODO:

 * [x] write specific functions for eip 4762 so that it doesn't clash with the eip 2929 functions
 * [ ] ~~try syncing the testnet~~ -> build some test blocks to be executed by clients statelessly instead
 * [x] remove the hacks
 * [x] Update gas consumption in the tests
 * [x] Fix comment
 * [ ] figure out why `CreateInit` is still needed in spite of the proper touching being done in `create`