### PR TITLE
Truncate BALANCE opcode parameter for witness recording

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -265,7 +265,7 @@ func opBalance(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 	slot := scope.Stack.peek()
 	address := common.Address(slot.Bytes20())
 	if interpreter.evm.chainRules.IsPrague {
-		statelessGas := interpreter.evm.Accesses.TouchAddressOnReadAndComputeGas(slot.Bytes(), uint256.Int{}, utils.BalanceLeafKey)
+		statelessGas := interpreter.evm.Accesses.TouchAddressOnReadAndComputeGas(address[:], uint256.Int{}, utils.BalanceLeafKey)
 		if !scope.Contract.UseGas(statelessGas) {
 			scope.Contract.Gas = 0
 			return nil, ErrOutOfGas


### PR DESCRIPTION
This PR was found by running our replay code in the latest changes.

The run had a panic [at this line](https://github.com/gballet/go-ethereum/blob/kaustinen-with-shapella/core/state/access_witness.go#L246), since `20-len(addr)` was negative which is an illegal index access. For context, we changed this line some days ago in https://github.com/gballet/go-ethereum/pull/366. 

That PR fix was fine since it fixes cases where `addr` length is less than 20. If we don't do `20-len(addr)`, the alignment is wrong. But the situation here is the inverse, if `addr` is longer than 20 bytes then we have this panic. From where this came from, it was the `BALANCE` opcode. 

The value of `BALANCE` is a 32-byte value that must be truncated for a correct interpretation of the address (since no address can be 32 bytes anyway). This isn't always a problem since `.Bytes()` (old code line) truncates the value, removing the left-zeroes. But if the value is, for whatever reason, longer than 20 bytes, it can cause this panic. As in, most of the time the contract `BALANCE` parameter will be a 20-byte address (or smaller) since it's actually what it's expected semantically, but for weird cases where a potential arbitrary >20 byte value is provided is when this bug is triggered. (This is why this bug hasn't happened before)

