### PR TITLE
Fix TestProcessVerkle tests

### DIFF
--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -485,8 +485,8 @@ func TestProcessVerkle(t *testing.T) {
 
 	txCost1 := params.TxGas
 	txCost2 := params.TxGas
-	contractCreationCost := intrinsicContractCreationGas + uint64(7700 /* creation */ +2939 /* execution costs */)
-	codeWithExtCodeCopyGas := intrinsicCodeWithExtCodeCopyGas + uint64(7000 /* creation */ +299744 /* execution costs */)
+	contractCreationCost := intrinsicContractCreationGas + uint64(5600+700+700+700 /* creation with value */ +2739 /* execution costs */)
+	codeWithExtCodeCopyGas := intrinsicCodeWithExtCodeCopyGas + uint64(5600+700 /* creation */ +302044 /* execution costs */)
 	blockGasUsagesExpected := []uint64{
 		txCost1*2 + txCost2,
 		txCost1*2 + txCost2 + contractCreationCost + codeWithExtCodeCopyGas,

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -944,22 +944,6 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 		tracer.CaptureEnter(SELFDESTRUCT, scope.Contract.Address(), beneficiary.Bytes20(), []byte{}, 0, balance)
 		tracer.CaptureExit([]byte{}, 0, nil)
 	}
-	if interpreter.evm.chainRules.IsPrague {
-		contractAddr := scope.Contract.Address()
-		beneficiaryAddr := beneficiary.Bytes20()
-		// If the beneficiary isn't the contract, we need to touch the beneficiary's balance.
-		// If the beneficiary is the contract itself, there're two possibilities:
-		// 1. The contract was created in the same transaction: the balance is already touched (no need to touch again)
-		// 2. The contract wasn't created in the same transaction: there's no net change in balance,
-		//    and SELFDESTRUCT will perform no action on the account header. (we touch since we did SubBalance+AddBalance above)
-		if contractAddr != beneficiaryAddr || interpreter.evm.StateDB.WasCreatedInCurrentTx(contractAddr) {
-			statelessGas := interpreter.evm.Accesses.TouchAddressOnReadAndComputeGas(beneficiaryAddr[:], uint256.Int{}, utils.BalanceLeafKey)
-			if !scope.Contract.UseGas(statelessGas) {
-				scope.Contract.Gas = 0
-				return nil, ErrOutOfGas
-			}
-		}
-	}
 	return nil, errStopToken
 }
 
@@ -975,6 +959,22 @@ func opSelfdestruct6780(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCon
 	if tracer := interpreter.evm.Config.Tracer; tracer != nil {
 		tracer.CaptureEnter(SELFDESTRUCT, scope.Contract.Address(), beneficiary.Bytes20(), []byte{}, 0, balance)
 		tracer.CaptureExit([]byte{}, 0, nil)
+	}
+	if interpreter.evm.chainRules.IsPrague {
+		contractAddr := scope.Contract.Address()
+		beneficiaryAddr := beneficiary.Bytes20()
+		// If the beneficiary isn't the contract, we need to touch the beneficiary's balance.
+		// If the beneficiary is the contract itself, there're two possibilities:
+		// 1. The contract was created in the same transaction: the balance is already touched (no need to touch again)
+		// 2. The contract wasn't created in the same transaction: there's no net change in balance,
+		//    and SELFDESTRUCT will perform no action on the account header. (we touch since we did SubBalance+AddBalance above)
+		if contractAddr != beneficiaryAddr || interpreter.evm.StateDB.WasCreatedInCurrentTx(contractAddr) {
+			statelessGas := interpreter.evm.Accesses.TouchAddressOnReadAndComputeGas(beneficiaryAddr[:], uint256.Int{}, utils.BalanceLeafKey)
+			if !scope.Contract.UseGas(statelessGas) {
+				scope.Contract.Gas = 0
+				return nil, ErrOutOfGas
+			}
+		}
 	}
 	return nil, errStopToken
 }


### PR DESCRIPTION
This PR fixes our TestProcessVerkle* tests which had two problems:
- The SELFDESTRUCT witness logic got in the wrong method when #378 was merged (merging bug).
- Not touching the keccak on contract creation #393 surfaced a wrong existing calculation in the execution costs of the test setup. I'll try to explain more in comments.