### PR TITLE
core/txpool/blobpool: fix metrics name for prometheus export (#27901)

### DIFF
--- a/core/txpool/blobpool/metrics.go
+++ b/core/txpool/blobpool/metrics.go
@@ -35,15 +35,15 @@ var (
 
 	// The below metrics track the per-shelf metrics for the primary blob store
 	// and the temporary limbo store.
-	shelfDatausedGaugeName = "blobpool/shelf-%d/dataused"
-	shelfDatagapsGaugeName = "blobpool/shelf-%d/datagaps"
-	shelfSlotusedGaugeName = "blobpool/shelf-%d/slotused"
-	shelfSlotgapsGaugeName = "blobpool/shelf-%d/slotgaps"
+	shelfDatausedGaugeName = "blobpool/shelf_%d/dataused"
+	shelfDatagapsGaugeName = "blobpool/shelf_%d/datagaps"
+	shelfSlotusedGaugeName = "blobpool/shelf_%d/slotused"
+	shelfSlotgapsGaugeName = "blobpool/shelf_%d/slotgaps"
 
-	limboShelfDatausedGaugeName = "blobpool/limbo/shelf-%d/dataused"
-	limboShelfDatagapsGaugeName = "blobpool/limbo/shelf-%d/datagaps"
-	limboShelfSlotusedGaugeName = "blobpool/limbo/shelf-%d/slotused"
-	limboShelfSlotgapsGaugeName = "blobpool/limbo/shelf-%d/slotgaps"
+	limboShelfDatausedGaugeName = "blobpool/limbo/shelf_%d/dataused"
+	limboShelfDatagapsGaugeName = "blobpool/limbo/shelf_%d/datagaps"
+	limboShelfSlotusedGaugeName = "blobpool/limbo/shelf_%d/slotused"
+	limboShelfSlotgapsGaugeName = "blobpool/limbo/shelf_%d/slotgaps"
 
 	// The oversized metrics aggregate the shelf stats above the max blob count
 	// limits to track transactions that are just huge, but don't contain blobs.


### PR DESCRIPTION
### Description
This PR imports a commit from upstream to fix Prometheus metrics due to incorrect naming standards.

### Rationale
If we try to scrape the Prometheus metrics, an error will occur. Here's an example output of `http://<prometheus-server-ip>:9090/targets`:

<img width="1910" alt="image" src="https://github.com/gballet/go-ethereum/assets/47109095/342edac4-e061-4df8-bf12-358c278ee601">

After applying the fix, the Prometheus metric is working as expected. An example below shows the Grafana dashboard:
<img width="934" alt="image" src="https://github.com/gballet/go-ethereum/assets/47109095/59e70610-009e-481a-98ab-9a30926cf3f6">

