### PR TITLE
fix post-verge sync

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1770,7 +1770,8 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			}
 		} else {
 			// If the verkle activation time hasn't started, declare it as "not started".
-			// This is so that
+			// This is so that if the miner activates the conversion, the insertion happens
+			// in the correct mode.
 			bc.stateCache.InitTransitionStatus(false, false)
 		}
 		if parent.Number.Uint64() == conversionBlock {


### PR DESCRIPTION
Sync was broken after the network had passed the verkle fork. This was because the EL will try to produce its own block when starting up, before the CL has had a chance to start inserting blocks.

The problem was that the timestamp being past the fork, verkle mode would activate for this side block. And then, when the first sync block was inserted (having been created before the fork), the `started` variable would not be reinitialized. This would cause an invalid merkle root.

The fix ensures that `started` is reinitialized to `false` when inserting a pre-verge block.