### PR TITLE
core: change block hash history scope

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -371,14 +371,14 @@ func (kvm *keyValueMigrator) migrateCollectedKeyValues(tree *trie.VerkleTrie) er
 
 func InsertBlockHashHistoryAtEip2935Fork(statedb *state.StateDB, prevNumber uint64, prevHash common.Hash, chain consensus.ChainHeaderReader) {
 	ancestor := chain.GetHeader(prevHash, prevNumber)
-	for i := prevNumber; i > 0 && i >= prevNumber-256; i-- {
+	for i := prevNumber; i > 0 && i >= prevNumber-params.Eip2935BlockHashHistorySize; i-- {
 		ProcessParentBlockHash(statedb, i, ancestor.Hash())
 		ancestor = chain.GetHeader(ancestor.ParentHash, ancestor.Number.Uint64()-1)
 	}
 }
 
 func ProcessParentBlockHash(statedb *state.StateDB, prevNumber uint64, prevHash common.Hash) {
-	ringIndex := prevNumber % 256
+	ringIndex := prevNumber % params.Eip2935BlockHashHistorySize
 	var key common.Hash
 	binary.BigEndian.PutUint64(key[24:], ringIndex)
 	statedb.SetState(params.HistoryStorageAddress, key, prevHash)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -517,7 +517,7 @@ func opGasprice(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 }
 
 func getBlockHashFromContract(number uint64, statedb StateDB, witness *state.AccessWitness) common.Hash {
-	ringIndex := number % 256
+	ringIndex := number % params.Eip2935BlockHashHistorySize
 	var pnum common.Hash
 	binary.BigEndian.PutUint64(pnum[24:], ringIndex)
 	treeIndex, suffix := utils.GetTreeKeyStorageSlotTreeIndexes(pnum.Bytes())

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -173,6 +173,9 @@ const (
 	BlobTxMinBlobGasprice              = 1       // Minimum gas price for data blobs
 	BlobTxBlobGaspriceUpdateFraction   = 2225652 // Controls the maximum rate of change for blob gas price
 	BlobTxPointEvaluationPrecompileGas = 50000   // Gas price for the point evaluation precompile.
+
+	// Block hash history parameters
+	Eip2935BlockHashHistorySize = 8192
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations


### PR DESCRIPTION
This PR changes the block hash contract history to 8192 block hashes, but keeps the `BLOCKHASH` instruction have access to the last 256 ones. 