### PR TITLE
Fix precompile address checks & value bearing witness cost charging

### DIFF
--- a/core/vm/operations_verkle.go
+++ b/core/vm/operations_verkle.go
@@ -49,17 +49,22 @@ func gasBalance4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, mem
 
 func gasExtCodeSize4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	address := stack.peek().Bytes20()
+	if _, isPrecompile := evm.precompile(address); isPrecompile {
+		return 0, nil
+	}
 	wgas := evm.Accesses.TouchVersion(address[:], false)
 	wgas += evm.Accesses.TouchCodeSize(address[:], false)
 	if wgas == 0 {
 		wgas = params.WarmStorageReadCostEIP2929
 	}
-
 	return wgas, nil
 }
 
 func gasExtCodeHash4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	address := stack.peek().Bytes20()
+	if _, isPrecompile := evm.precompile(address); isPrecompile {
+		return 0, nil
+	}
 	codehashgas := evm.Accesses.TouchCodeHash(address[:], false)
 	if codehashgas == 0 {
 		codehashgas = params.WarmStorageReadCostEIP2929
@@ -73,8 +78,10 @@ func makeCallVariantGasEIP4762(oldCalculator gasFunc) gasFunc {
 		if err != nil {
 			return 0, err
 		}
-		wgas := evm.Accesses.TouchCodeSize(contract.Address().Bytes(), false)
-		wgas += evm.Accesses.TouchCodeHash(contract.Address().Bytes(), false)
+		if _, isPrecompile := evm.precompile(contract.Address()); isPrecompile {
+			return gas, nil
+		}
+		wgas := evm.Accesses.TouchAndChargeMessageCall(contract.Address().Bytes())
 		if wgas == 0 {
 			wgas = params.WarmStorageReadCostEIP2929
 		}
@@ -91,6 +98,10 @@ var (
 
 func gasSelfdestructEIP4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	beneficiaryAddr := common.Address(stack.peek().Bytes20())
+	if _, isPrecompile := evm.precompile(beneficiaryAddr); isPrecompile {
+		return 0, nil
+	}
+
 	contractAddr := contract.Address()
 	statelessGas := evm.Accesses.TouchVersion(contractAddr[:], false)
 	statelessGas += evm.Accesses.TouchCodeSize(contractAddr[:], false)
@@ -127,4 +138,3 @@ func gasExtCodeCopyEIP4762(evm *EVM, contract *Contract, stack *Stack, mem *Memo
 	}
 	return gas, nil
 }
-


### PR DESCRIPTION
This PR:
- Does some refactor to avoid duplicate work in CALL/CALLCODE/DELEGATECALL/STATICCALL witness events.
- Comply to the spec rule of only doing that if the target address isn't a precompile. Not only for the above instructions, but also for EXTCODEHASH, EXTCODESIZE and SELFDESTRUCT.
- Add a missing value-bearing charging for CALLCODE.