### PR TITLE
add back single key computation command

### DIFF
--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -499,6 +499,31 @@ func dispatchOutput(ctx *cli.Context, baseDir string, result *ExecutionResult, a
 
 // VerkleKeys computes the tree key given an address and an optional
 // slot number.
+func VerkleKey(ctx *cli.Context) error {
+	if ctx.Args().Len() == 0 || ctx.Args().Len() > 2 {
+		return errors.New("invalid number of arguments: expecting an address and an optional slot number")
+	}
+
+	addr, err := hexutil.Decode(ctx.Args().Get(0))
+	if err != nil {
+		return fmt.Errorf("error decoding address: %w", err)
+	}
+
+	ap := utils.EvaluateAddressPoint(addr)
+	if ctx.Args().Len() == 2 {
+		slot, err := hexutil.Decode(ctx.Args().Get(1))
+		if err != nil {
+			return fmt.Errorf("error decoding slot: %w", err)
+		}
+		fmt.Printf("%#x\n", utils.GetTreeKeyStorageSlotWithEvaluatedAddress(ap, slot))
+	} else {
+		fmt.Printf("%#x\n", utils.GetTreeKeyVersionWithEvaluatedAddress(ap))
+	}
+	return nil
+}
+
+// VerkleKeys computes a set of tree keys given a set of addresses
+// and their optional slot numbers.
 func VerkleKeys(ctx *cli.Context) error {
 	var allocStr = ctx.String(InputAllocFlag.Name)
 	var alloc core.GenesisAlloc

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -155,13 +155,19 @@ var stateTransitionCommand = &cli.Command{
 	},
 	Subcommands: []*cli.Command{
 		&cli.Command{
-			Name:    "verkle",
+			Name:    "verkle-keys",
 			Aliases: []string{"v"},
-			Usage:   "compute the verkle tree key given an address and optional slot number",
+			Usage:   "compute a set of verkle tree keys, given their source addresses and optional slot numbers",
 			Action:  t8ntool.VerkleKeys,
 			Flags: []cli.Flag{
 				t8ntool.InputAllocFlag,
 			},
+		},
+		&cli.Command{
+			Name:    "verkle-key",
+			Aliases: []string{"V"},
+			Usage:   "compute the verkle tree key given an address and optional slot number",
+			Action:  t8ntool.VerkleKey,
 		},
 	},
 }


### PR DESCRIPTION
Reintroduce the command to compute a single tree key. The single key command is called `verkle-key` and the one to compute an entire tree is called `verkle-keys`.