### PR TITLE
core/vm: fix wrong check

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -525,7 +525,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 				err = ErrCodeStoreOutOfGas
 			}
 
-			if err != nil && len(ret) > 0 && !contract.UseGas(evm.Accesses.TouchCodeChunksRangeAndChargeGas(address.Bytes(), 0, uint64(len(ret)), uint64(len(ret)), true)) {
+			if err == nil && len(ret) > 0 && !contract.UseGas(evm.Accesses.TouchCodeChunksRangeAndChargeGas(address.Bytes(), 0, uint64(len(ret)), uint64(len(ret)), true)) {
 				err = ErrCodeStoreOutOfGas
 			}
 		}


### PR DESCRIPTION
This PR fixes a bug that make `TestProcessVerkle*` test on the rebased branch.