### PR TITLE
charge for account creation if selfdestruct creates a new account

### DIFF
--- a/core/vm/operations_verkle.go
+++ b/core/vm/operations_verkle.go
@@ -115,6 +115,13 @@ func gasSelfdestructEIP4762(evm *EVM, contract *Contract, stack *Stack, mem *Mem
 		if contractAddr != beneficiaryAddr {
 			statelessGas += evm.Accesses.TouchBalance(beneficiaryAddr[:], true)
 		}
+
+		// Case when the beneficiary does not exist: touch the account
+		// but leave code hash and size alone.
+		if evm.StateDB.Empty(beneficiaryAddr) {
+			statelessGas += evm.Accesses.TouchVersion(beneficiaryAddr[:], true)
+			statelessGas += evm.Accesses.TouchNonce(beneficiaryAddr[:], true)
+		}
 	}
 	return statelessGas, nil
 }


### PR DESCRIPTION
This behavior is not explicitly specified in the spec. However, this change abides by the general design principle of EIP 4762, which is to make the gas changes behave like the pre-verkle ones, as much as possible.

#### EIP 2929 / EIP 3529

When a contract selfdestructs and sends value to its designated beneficiary:

 * the beneficiary is added to the access list
 * if the beneficiary address is cold, charge the cold address access cost: 2600 gas
 * otherwise, charge the warm address access cost: 100 gas
 * if the selfdestruction sends value AND the beneficiary does not exist, charge `CreateBySelfdestructGas`, i.e. 25000 gas
 
#### EIP 4762

In this case, it is quite difficult to charge the same gas, and the final charge will be slightly cheaper.

 * touch the version, code size and balance of the self-destructing contract in READ access mode
 * touch the balance of the beneficiary in READ access mode
 * if the selfdestruction sends value:
   * write-touch the balances of the self-destructing and beneficiary addresses
   * (**NEW USE CASE**)  if the beneficiary address does not exist, also charge write-access for its version and nonce

Thus, more gas gets charged in relation with the creation of the target account. This amount (23700) is a bit less than the 25000 charged in eip 2929. Charging the code-related fields would make this operation markedly more expensive (30600 if only the code hash is created).