### PR TITLE
add key comparison test

### DIFF
--- a/trie/utils/verkle_test.go
+++ b/trie/utils/verkle_test.go
@@ -17,10 +17,11 @@
 package utils
 
 import (
+	"bytes"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"math/big"
-	"math/rand"
 	"testing"
 
 	"github.com/ethereum/go-verkle"
@@ -91,5 +92,24 @@ func BenchmarkSha256Hash(b *testing.B) {
 		rand.Read(v[:])
 		rand.Read(addr[:])
 		sha256GetTreeKeyCodeSize(addr[:])
+	}
+}
+
+func TestCompareGetTreeKeyWithEvaluated(t *testing.T) {
+	var addr [32]byte
+	rand.Read(addr[:])
+	addrpoint := EvaluateAddressPoint(addr[:])
+	for i := 0; i < 100; i++ {
+		var val [32]byte
+		rand.Read(val[:])
+		n := uint256.NewInt(0).SetBytes(val[:])
+		n.Lsh(n, 8)
+		subindex := byte(val[0])
+		tk1 := GetTreeKey(addr[:], n, subindex)
+		tk2 := GetTreeKeyWithEvaluatedAddess(addrpoint, n, subindex)
+
+		if !bytes.Equal(tk1, tk2) {
+			t.Fatalf("error at iteration=%d, slot=%x, addr=%x", i, val, addr)
+		}
 	}
 }

--- a/trie/utils/verkle_test.go
+++ b/trie/utils/verkle_test.go
@@ -109,7 +109,7 @@ func TestCompareGetTreeKeyWithEvaluated(t *testing.T) {
 		tk2 := GetTreeKeyWithEvaluatedAddess(addrpoint, n, subindex)
 
 		if !bytes.Equal(tk1, tk2) {
-			t.Fatalf("error at iteration=%d, slot=%x, addr=%x", i, val, addr)
+			t.Fatalf("differing key: slot=%x, addr=%x", val, addr)
 		}
 	}
 }


### PR DESCRIPTION
I have seen instances of `GetTreeKey` and `EvaluateAddress` + `GetTreeKeyWithEvaluatedAddress` have given different results. I was not able to reproduce it in the lab, so I assume that came from a poor use of the API. Nonetheless, it makes sense to add a test to run each time, so that we have an example to reproduce the problem in case it breaks.