### PR TITLE
core/vm: charge contract init before execution logic

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -689,7 +689,6 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 		offset, size = scope.Stack.pop(), scope.Stack.pop()
 		salt         = scope.Stack.pop()
 		input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
-		gas          = scope.Contract.Gas
 	)
 	if interpreter.evm.chainRules.IsEIP4762 {
 		codeAndHash := &codeAndHash{code: input}
@@ -700,6 +699,7 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 		}
 	}
 
+	var gas = scope.Contract.Gas
 	// Apply EIP150
 	gas -= gas / 64
 	scope.Contract.UseGas(gas)


### PR DESCRIPTION
This PR fixes a bug where the contract init witness logic is in the wrong place, making a `contract.UseGas(...)` quietly fail. 

The return value of `contract.UseGas(...)` isn't checked since it must never fail, but the witness cost addition in the wrong place makes this fail, so transactions can use more gas than they should.