### PR TITLE
Add EXTCODEHASH witness information to resolve Empty()

### DIFF
--- a/core/vm/operations_verkle.go
+++ b/core/vm/operations_verkle.go
@@ -65,7 +65,10 @@ func gasExtCodeHash4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory,
 	if _, isPrecompile := evm.precompile(address); isPrecompile {
 		return 0, nil
 	}
-	codehashgas := evm.Accesses.TouchCodeHash(address[:], false)
+	codehashgas := evm.Accesses.TouchVersion(address[:], false)
+	codehashgas += evm.Accesses.TouchBalance(address[:], false)
+	codehashgas += evm.Accesses.TouchNonce(address[:], false)
+	codehashgas += evm.Accesses.TouchCodeHash(address[:], false)
 	if codehashgas == 0 {
 		codehashgas = params.WarmStorageReadCostEIP2929
 	}


### PR DESCRIPTION
`EXTCODEHASH` instruction execution does an `.Empty(address)` check to early return a zero. This `Empty(...)` implies adding to the witness the nonce and balance.

Note: I added the version too to be coherent with the current status quo