### PR TITLE
trie/utils: simplify GetTreeKeyWithEvaluatedAddress

### DIFF
--- a/trie/utils/verkle.go
+++ b/trie/utils/verkle.go
@@ -17,8 +17,6 @@
 package utils
 
 import (
-	"encoding/binary"
-
 	"github.com/crate-crypto/go-ipa/bandersnatch/fr"
 	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-verkle"
@@ -199,13 +197,9 @@ func GetTreeKeyWithEvaluatedAddess(evaluated *verkle.Point, treeIndex *uint256.I
 	poly[1].SetZero()
 	poly[2].SetZero()
 
-	// little-endian, 32-byte aligned treeIndex
-	var index [32]byte
-	for i := 0; i < len(treeIndex); i++ {
-		binary.LittleEndian.PutUint64(index[i*8:(i+1)*8], treeIndex[i])
-	}
-	verkle.FromLEBytes(&poly[3], index[:16])
-	verkle.FromLEBytes(&poly[4], index[16:])
+	trieIndexBytes := treeIndex.Bytes32()
+	verkle.FromBytes(&poly[3], trieIndexBytes[16:])
+	verkle.FromBytes(&poly[4], trieIndexBytes[:16])
 
 	cfg := verkle.GetConfig()
 	ret := cfg.CommitToPoly(poly[:], 0)

--- a/trie/utils/verkle_test.go
+++ b/trie/utils/verkle_test.go
@@ -113,3 +113,20 @@ func TestCompareGetTreeKeyWithEvaluated(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkGetTreeKeyWithEvaluatedAddress(b *testing.B) {
+	var buf [32]byte
+	rand.Read(buf[:])
+	addrpoint := EvaluateAddressPoint(buf[:])
+
+	rand.Read(buf[:])
+	n := uint256.NewInt(0).SetBytes32(buf[:])
+
+	_ = verkle.GetConfig()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = GetTreeKeyWithEvaluatedAddess(addrpoint, n, 0)
+	}
+}


### PR DESCRIPTION
This PR makes a slight change in `GetTreeKeyWithEvaluatedAddress` which allows to avoid copying the tree index to a separate array to accommodate for endianness. 

This is a trick I introduced a long ago in `GetTreeKey(...)` but was just missing in this other variant.