### PR TITLE
remove unused deployment detection code

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -195,7 +195,6 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	p, isPrecompile := evm.precompile(addr)
 	debug := evm.Config.Tracer != nil
 
-	var creation bool
 	if !evm.StateDB.Exist(addr) {
 		if !isPrecompile && evm.chainRules.IsEIP4762 {
 			// add proof of absence to witness
@@ -221,7 +220,6 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 			return nil, gas, nil
 		}
 		evm.StateDB.CreateAccount(addr)
-		creation = true
 	}
 	evm.Context.Transfer(evm.StateDB, caller.Address(), addr, value)
 
@@ -256,7 +254,6 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 			// The depth-check is already done, and precompiles handled above
 			contract := NewContract(caller, AccountRef(addrCopy), value, gas)
 			contract.SetCallCode(&addrCopy, evm.StateDB.GetCodeHash(addrCopy), code)
-			contract.IsDeployment = creation
 			ret, err = evm.interpreter.Run(contract, input, false)
 			gas = contract.Gas
 		}


### PR DESCRIPTION
During the geth review of the eip 4762 PR, we identified that `IsDeployment` was set at a location that was not necessary. This PR cleans it up in `kaustinen-with-shapella` as well, ahead of a rebase.