### PR TITLE
Refactor access event object/use to only refer to gas accounting and not witness building

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -360,12 +360,6 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 		amount := new(uint256.Int).SetUint64(w.Amount)
 		amount = amount.Mul(amount, uint256.NewInt(params.GWei))
 		state.AddBalance(w.Address, amount, tracing.BalanceIncreaseWithdrawal)
-
-		// Add the balance of each withdrawal to the witness, no gas will
-		// be charged.
-		if chain.Config().IsEIP4762(header.Number, header.Time) {
-			state.AccessEvents().BalanceGas(w.Address[:], true)
-		}
 	}
 	// No block reward which is issued by consensus layer instead.
 }

--- a/core/state/access_events.go
+++ b/core/state/access_events.go
@@ -66,7 +66,7 @@ func (aw *AccessEvents) Merge(other *AccessEvents) {
 	}
 }
 
-// Key returns, predictably, the list of keys that were touched during the
+// Keys returns, predictably, the list of keys that were touched during the
 // buildup of the access witness.
 func (aw *AccessEvents) Keys() [][]byte {
 	// TODO: consider if parallelizing this is worth it, probably depending on len(aw.chunks).
@@ -173,7 +173,6 @@ func (aw *AccessEvents) touchAddressAndChargeGas(addr []byte, treeIndex uint256.
 	if selectorFill {
 		gas += params.WitnessChunkFillCost
 	}
-
 	return gas
 }
 
@@ -206,10 +205,8 @@ func (aw *AccessEvents) touchAddress(addr []byte, treeIndex uint256.Int, subInde
 			chunkWrite = true
 			aw.chunks[chunkKey] |= AccessWitnessWriteFlag
 		}
-
 		// TODO: charge chunk filling costs if the leaf was previously empty in the state
 	}
-
 	return branchRead, chunkRead, branchWrite, chunkWrite, chunkFill
 }
 
@@ -268,7 +265,6 @@ func (aw *AccessEvents) CodeChunksRangeGas(contractAddr []byte, startPC, size ui
 			panic("overflow when adding gas")
 		}
 	}
-
 	return statelessGasCharged
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -36,7 +36,6 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/trienode"
 	"github.com/ethereum/go-ethereum/trie/triestate"
-	"github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/holiman/uint256"
 )
 
@@ -141,8 +140,7 @@ type StateDB struct {
 	transientStorage transientStorage
 
 	// State access events, used for EIP4762
-	pointCache   *utils.PointCache // shared in different transaction frame
-	accessEvents *AccessEvents     // reset for each transaction
+	accessEvents *AccessEvents // reset for each transaction
 
 	// Journal of state modifications. This is the backbone of
 	// Snapshot and RevertToSnapshot.
@@ -196,7 +194,6 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 		journal:              newJournal(),
 		accessList:           newAccessList(),
 		transientStorage:     newTransientStorage(),
-		pointCache:           utils.NewPointCache(1024),
 		hasher:               crypto.NewKeccakState(),
 	}
 	if sdb.snaps != nil {
@@ -715,7 +712,6 @@ func (s *StateDB) Copy() *StateDB {
 		journal:              s.journal.copy(),
 		validRevisions:       slices.Clone(s.validRevisions),
 		nextRevisionId:       s.nextRevisionId,
-		pointCache:           utils.NewPointCache(1024),
 
 		// In order for the block producer to be able to use and make additions
 		// to the snapshot tree, we need to copy that as well. Otherwise, any
@@ -1316,7 +1312,7 @@ func (s *StateDB) Prepare(rules params.Rules, sender, coinbase common.Address, d
 		}
 	}
 	if rules.IsEIP4762 {
-		s.accessEvents = NewAccessEvents(s.pointCache)
+		s.accessEvents = NewAccessEvents(s.db.PointCache())
 	}
 	// Reset transient storage at the beginning of transaction execution
 	s.transientStorage = newTransientStorage()

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -140,8 +140,9 @@ type StateDB struct {
 	// Transient storage
 	transientStorage transientStorage
 
-	// State access events, used for Verkle tries/EIP4762
-	accessEvents *AccessEvents
+	// State access events, used for EIP4762
+	pointCache   *utils.PointCache // shared in different transaction frame
+	accessEvents *AccessEvents     // reset for each transaction
 
 	// Journal of state modifications. This is the backbone of
 	// Snapshot and RevertToSnapshot.
@@ -195,10 +196,8 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 		journal:              newJournal(),
 		accessList:           newAccessList(),
 		transientStorage:     newTransientStorage(),
+		pointCache:           utils.NewPointCache(1024),
 		hasher:               crypto.NewKeccakState(),
-	}
-	if tr.IsVerkle() {
-		sdb.accessEvents = sdb.NewAccessEvents()
 	}
 	if sdb.snaps != nil {
 		sdb.snap = sdb.snaps.Snapshot(root)
@@ -206,19 +205,8 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 	return sdb, nil
 }
 
-func (s *StateDB) NewAccessEvents() *AccessEvents {
-	return NewAccessEvents(utils.NewPointCache(100))
-}
-
 func (s *StateDB) AccessEvents() *AccessEvents {
-	if s.accessEvents == nil {
-		s.accessEvents = s.NewAccessEvents()
-	}
 	return s.accessEvents
-}
-
-func (s *StateDB) SetAccessEvents(ae *AccessEvents) {
-	s.accessEvents = ae
 }
 
 // SetLogger sets the logger for account update hooks.
@@ -727,6 +715,7 @@ func (s *StateDB) Copy() *StateDB {
 		journal:              s.journal.copy(),
 		validRevisions:       slices.Clone(s.validRevisions),
 		nextRevisionId:       s.nextRevisionId,
+		pointCache:           utils.NewPointCache(1024),
 
 		// In order for the block producer to be able to use and make additions
 		// to the snapshot tree, we need to copy that as well. Otherwise, any
@@ -766,6 +755,9 @@ func (s *StateDB) Copy() *StateDB {
 	// know that they need to explicitly terminate an active copy).
 	if s.prefetcher != nil {
 		state.prefetcher = s.prefetcher.copy()
+	}
+	if s.accessEvents != nil {
+		state.accessEvents = s.accessEvents.Copy()
 	}
 	return state
 }
@@ -1297,6 +1289,9 @@ func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, er
 // - Add coinbase to access list (EIP-3651)
 // - Reset transient storage (EIP-1153)
 func (s *StateDB) Prepare(rules params.Rules, sender, coinbase common.Address, dst *common.Address, precompiles []common.Address, list types.AccessList) {
+	if rules.IsEIP2929 && rules.IsEIP4762 {
+		panic("eip2929 and eip4762 are both activated")
+	}
 	if rules.IsEIP2929 {
 		// Clear out any leftover from previous executions
 		al := newAccessList()
@@ -1319,6 +1314,9 @@ func (s *StateDB) Prepare(rules params.Rules, sender, coinbase common.Address, d
 		if rules.IsShanghai { // EIP-3651: warm coinbase
 			al.AddAddress(coinbase)
 		}
+	}
+	if rules.IsEIP4762 {
+		s.accessEvents = NewAccessEvents(s.pointCache)
 	}
 	// Reset transient storage at the beginning of transaction execution
 	s.transientStorage = newTransientStorage()

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -406,10 +406,10 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	st.gasRemaining -= gas
 
 	if rules.IsEIP4762 {
-		st.evm.AccessEvents.AddTxOrigin(msg.From.Bytes())
+		st.evm.StateDB.AccessEvents().AddTxOrigin(msg.From.Bytes())
 
 		if targetAddr := msg.To; targetAddr != nil {
-			st.evm.AccessEvents.AddTxDestination(targetAddr.Bytes(), msg.Value.Sign() != 0)
+			st.evm.StateDB.AccessEvents().AddTxDestination(targetAddr.Bytes(), msg.Value.Sign() != 0)
 
 			// ensure the code size ends up in the access witness
 			st.evm.StateDB.GetCodeSize(*targetAddr)
@@ -472,7 +472,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 		// add the coinbase to the witness iff the fee is greater than 0
 		if rules.IsEIP4762 && fee.Sign() != 0 {
-			st.evm.AccessEvents.BalanceGas(st.evm.Context.Coinbase[:], true)
+			st.evm.StateDB.AccessEvents().BalanceGas(st.evm.Context.Coinbase[:], true)
 		}
 	}
 

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -331,7 +331,7 @@ func opCreateEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContex
 	var endowment = scope.Stack.peek()
 
 	contractAddress := crypto.CreateAddress(scope.Contract.Address(), interpreter.evm.StateDB.GetNonce(scope.Contract.Address()))
-	statelessGas := interpreter.evm.AccessEvents.ContractCreateInitGas(contractAddress.Bytes()[:], endowment.Sign() != 0)
+	statelessGas := interpreter.evm.StateDB.AccessEvents().ContractCreateInitGas(contractAddress.Bytes()[:], endowment.Sign() != 0)
 	if !scope.Contract.UseGas(statelessGas, interpreter.evm.Config.Tracer, tracing.GasChangeUnspecified) {
 		return nil, ErrExecutionReverted
 	}
@@ -352,7 +352,7 @@ func opCreate2EIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 
 	codeAndHash := &codeAndHash{code: input}
 	contractAddress := crypto.CreateAddress2(scope.Contract.Address(), salt.Bytes32(), codeAndHash.Hash().Bytes())
-	statelessGas := interpreter.evm.AccessEvents.ContractCreateInitGas(contractAddress.Bytes()[:], endowment.Sign() != 0)
+	statelessGas := interpreter.evm.StateDB.AccessEvents().ContractCreateInitGas(contractAddress.Bytes()[:], endowment.Sign() != 0)
 	if !scope.Contract.UseGas(statelessGas, interpreter.evm.Config.Tracer, tracing.GasChangeUnspecified) {
 		return nil, ErrExecutionReverted
 	}
@@ -379,7 +379,7 @@ func opExtCodeCopyEIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeC
 		self: AccountRef(addr),
 	}
 	paddedCodeCopy, copyOffset, nonPaddedCopyLength := getDataAndAdjustedBounds(code, uint64CodeOffset, length.Uint64())
-	statelessGas := interpreter.evm.AccessEvents.CodeChunksRangeGas(addr[:], copyOffset, nonPaddedCopyLength, uint64(len(contract.Code)), false)
+	statelessGas := interpreter.evm.StateDB.AccessEvents().CodeChunksRangeGas(addr[:], copyOffset, nonPaddedCopyLength, uint64(len(contract.Code)), false)
 	if !scope.Contract.UseGas(statelessGas, interpreter.evm.Config.Tracer, tracing.GasChangeUnspecified) {
 		scope.Contract.Gas = 0
 		return nil, ErrOutOfGas
@@ -405,7 +405,7 @@ func opPush1EIP4762(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 			// touch next chunk if PUSH1 is at the boundary. if so, *pc has
 			// advanced past this boundary.
 			contractAddr := scope.Contract.Address()
-			statelessGas := interpreter.evm.AccessEvents.CodeChunksRangeGas(contractAddr[:], *pc+1, uint64(1), uint64(len(scope.Contract.Code)), false)
+			statelessGas := interpreter.evm.StateDB.AccessEvents().CodeChunksRangeGas(contractAddr[:], *pc+1, uint64(1), uint64(len(scope.Contract.Code)), false)
 			if !scope.Contract.UseGas(statelessGas, interpreter.evm.Config.Tracer, tracing.GasChangeUnspecified) {
 				scope.Contract.Gas = 0
 				return nil, ErrOutOfGas
@@ -433,7 +433,7 @@ func makePushEIP4762(size uint64, pushByteSize int) executionFunc {
 
 		if !scope.Contract.IsDeployment {
 			contractAddr := scope.Contract.Address()
-			statelessGas := interpreter.evm.AccessEvents.CodeChunksRangeGas(contractAddr[:], uint64(start), uint64(pushByteSize), uint64(len(scope.Contract.Code)), false)
+			statelessGas := interpreter.evm.StateDB.AccessEvents().CodeChunksRangeGas(contractAddr[:], uint64(start), uint64(pushByteSize), uint64(len(scope.Contract.Code)), false)
 			if !scope.Contract.UseGas(statelessGas, interpreter.evm.Config.Tracer, tracing.GasChangeUnspecified) {
 				scope.Contract.Gas = 0
 				return nil, ErrOutOfGas

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -404,7 +404,7 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 	}
 	if evm.chainRules.IsEIP4762 {
 		if transfersValue {
-			gas, overflow = math.SafeAdd(gas, evm.AccessEvents.ValueTransferGas(contract.Address().Bytes()[:], address.Bytes()[:]))
+			gas, overflow = math.SafeAdd(gas, evm.StateDB.AccessEvents().ValueTransferGas(contract.Address().Bytes()[:], address.Bytes()[:]))
 			if overflow {
 				return 0, ErrGasUintOverflow
 			}
@@ -440,7 +440,7 @@ func gasCallCode(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
 		address := common.Address(stack.Back(1).Bytes20())
 		transfersValue := !stack.Back(2).IsZero()
 		if transfersValue {
-			gas, overflow = math.SafeAdd(gas, evm.AccessEvents.ValueTransferGas(contract.Address().Bytes()[:], address.Bytes()[:]))
+			gas, overflow = math.SafeAdd(gas, evm.StateDB.AccessEvents().ValueTransferGas(contract.Address().Bytes()[:], address.Bytes()[:]))
 			if overflow {
 				return 0, ErrGasUintOverflow
 			}

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -75,6 +76,9 @@ type StateDB interface {
 	// AddSlotToAccessList adds the given (address,slot) to the access list. This operation is safe to perform
 	// even if the feature/fork is not active yet
 	AddSlotToAccessList(addr common.Address, slot common.Hash)
+
+	AccessEvents() *state.AccessEvents
+
 	Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
 
 	RevertToSnapshot(int)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -227,7 +227,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 			// if the PC ends up in a new "chunk" of verkleized code, charge the
 			// associated costs.
 			contractAddr := contract.Address()
-			contract.Gas -= in.evm.TxContext.AccessEvents.CodeChunksRangeGas(contractAddr[:], pc, 1, uint64(len(contract.Code)), false)
+			contract.Gas -= in.evm.StateDB.AccessEvents().CodeChunksRangeGas(contractAddr[:], pc, 1, uint64(len(contract.Code)), false)
 		}
 
 		// Get the operation from the jump table and validate the stack to ensure there are

--- a/params/config.go
+++ b/params/config.go
@@ -921,6 +921,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 	}
 	// disallow setting Merge out of order
 	isMerge = isMerge && c.IsLondon(num)
+	isVerkle := isMerge && c.IsVerkle(num, timestamp)
 	return Rules{
 		ChainID:          new(big.Int).Set(chainID),
 		IsHomestead:      c.IsHomestead(num),
@@ -932,13 +933,13 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsPetersburg:     c.IsPetersburg(num),
 		IsIstanbul:       c.IsIstanbul(num),
 		IsBerlin:         c.IsBerlin(num),
-		IsEIP2929:        c.IsBerlin(num) && !c.IsVerkle(num, timestamp),
-		IsEIP4762:        c.IsVerkle(num, timestamp),
+		IsEIP2929:        c.IsBerlin(num) && !isVerkle,
 		IsLondon:         c.IsLondon(num),
 		IsMerge:          isMerge,
 		IsShanghai:       isMerge && c.IsShanghai(num, timestamp),
 		IsCancun:         isMerge && c.IsCancun(num, timestamp),
 		IsPrague:         isMerge && c.IsPrague(num, timestamp),
-		IsVerkle:         isMerge && c.IsVerkle(num, timestamp),
+		IsVerkle:         isVerkle,
+		IsEIP4762:        isVerkle,
 	}
 }


### PR DESCRIPTION
I had to revert #425 because it broke the tests, I have reverted it and I'm reopening this PR to check for the offending issue.