### PR TITLE
fix: in CALL, touch callee instead of caller

### DIFF
--- a/core/vm/operations_verkle.go
+++ b/core/vm/operations_verkle.go
@@ -61,7 +61,7 @@ func gasExtCodeSize4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory,
 }
 
 func gasExtCodeHash4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	address := stack.Back(1).Bytes20()
+	address := stack.peek().Bytes20()
 	if _, isPrecompile := evm.precompile(address); isPrecompile {
 		return 0, nil
 	}
@@ -74,7 +74,7 @@ func gasExtCodeHash4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory,
 
 func makeCallVariantGasEIP4762(oldCalculator gasFunc) gasFunc {
 	return func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-		address := stack.peek().Bytes20()
+		address := stack.Back(1).Bytes20()
 		gas, err := oldCalculator(evm, contract, stack, mem, memorySize)
 		if err != nil {
 			return 0, err

--- a/core/vm/operations_verkle.go
+++ b/core/vm/operations_verkle.go
@@ -61,7 +61,7 @@ func gasExtCodeSize4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory,
 }
 
 func gasExtCodeHash4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	address := stack.peek().Bytes20()
+	address := stack.Back(1).Bytes20()
 	if _, isPrecompile := evm.precompile(address); isPrecompile {
 		return 0, nil
 	}
@@ -74,14 +74,15 @@ func gasExtCodeHash4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory,
 
 func makeCallVariantGasEIP4762(oldCalculator gasFunc) gasFunc {
 	return func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+		address := stack.peek().Bytes20()
 		gas, err := oldCalculator(evm, contract, stack, mem, memorySize)
 		if err != nil {
 			return 0, err
 		}
-		if _, isPrecompile := evm.precompile(contract.Address()); isPrecompile {
+		if _, isPrecompile := evm.precompile(address); isPrecompile {
 			return gas, nil
 		}
-		wgas := evm.Accesses.TouchAndChargeMessageCall(contract.Address().Bytes())
+		wgas := evm.Accesses.TouchAndChargeMessageCall(address[:])
 		if wgas == 0 {
 			wgas = params.WarmStorageReadCostEIP2929
 		}


### PR DESCRIPTION
At block 123836 (AAVE deploy) we have some contract calling another with `CALL`. There is an error in the gas charging function, in that it tries to touch the caller and not the callee.