### PR TITLE
Fix iterator from t8n

### DIFF
--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -231,11 +231,6 @@ func (trie *VerkleTrie) Hash() common.Hash {
 	return trie.root.Commit().Bytes()
 }
 
-func nodeToDBKey(n verkle.VerkleNode) []byte {
-	ret := n.Commitment().Bytes()
-	return ret[:]
-}
-
 // Commit writes all nodes to the trie's memory database, tracking the internal
 // and external (for account tries) references.
 func (trie *VerkleTrie) Commit(_ bool) (common.Hash, *trienode.NodeSet, error) {


### PR DESCRIPTION
While working on a verkle-enabled `evm t8n`, I found out that the iterator was broken. This PR merges the fixes back into `kaustinen-with-shapella` so that I can keep the t8n PR minimal.

