### PR TITLE
t8n: add verkle-code-chunk-key and verkle-chunkify-code commands

### DIFF
--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -612,3 +612,20 @@ func VerkleCodeChunkKey(ctx *cli.Context) error {
 
 	return nil
 }
+
+// VerkleChunkifyCode returns the code chunkification for a given code.
+func VerkleChunkifyCode(ctx *cli.Context) error {
+	if ctx.Args().Len() == 0 || ctx.Args().Len() > 1 {
+		return errors.New("invalid number of arguments: expecting a bytecode")
+	}
+
+	bytecode, err := hexutil.Decode(ctx.Args().Get(0))
+	if err != nil {
+		return fmt.Errorf("error decoding address: %w", err)
+	}
+
+	chunkedCode := trie.ChunkifyCode(bytecode)
+	fmt.Printf("%#x\n", chunkedCode)
+
+	return nil
+}

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -43,6 +43,7 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/ethereum/go-verkle"
+	"github.com/holiman/uint256"
 	"github.com/urfave/cli/v2"
 )
 
@@ -505,7 +506,7 @@ func dispatchOutput(ctx *cli.Context, baseDir string, result *ExecutionResult, a
 	return nil
 }
 
-// VerkleKeys computes the tree key given an address and an optional
+// VerkleKey computes the tree key given an address and an optional
 // slot number.
 func VerkleKey(ctx *cli.Context) error {
 	if ctx.Args().Len() == 0 || ctx.Args().Len() > 2 {
@@ -530,8 +531,7 @@ func VerkleKey(ctx *cli.Context) error {
 	return nil
 }
 
-// VerkleKeys computes a set of tree keys given a set of addresses
-// and their optional slot numbers.
+// VerkleKeys computes a set of tree keys given a genesis alloc.
 func VerkleKeys(ctx *cli.Context) error {
 	var allocStr = ctx.String(InputAllocFlag.Name)
 	var alloc core.GenesisAlloc
@@ -587,6 +587,28 @@ func VerkleKeys(ctx *cli.Context) error {
 	}
 
 	fmt.Println(string(output))
+
+	return nil
+}
+
+// VerkleCodeChunkKey computes the tree key of a code-chunk for a given address.
+func VerkleCodeChunkKey(ctx *cli.Context) error {
+	if ctx.Args().Len() == 0 || ctx.Args().Len() > 2 {
+		return errors.New("invalid number of arguments: expecting an address and an code-chunk number")
+	}
+
+	addr, err := hexutil.Decode(ctx.Args().Get(0))
+	if err != nil {
+		return fmt.Errorf("error decoding address: %w", err)
+	}
+	chunkNumberBytes, err := hexutil.Decode(ctx.Args().Get(1))
+	if err != nil {
+		return fmt.Errorf("error decoding chunk number: %w", err)
+	}
+	var chunkNumber uint256.Int
+	chunkNumber.SetBytes(chunkNumberBytes)
+
+	fmt.Printf("%#x\n", utils.GetTreeKeyCodeChunk(addr, &chunkNumber))
 
 	return nil
 }

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -153,9 +153,15 @@ var stateTransitionCommand = &cli.Command{
 		t8ntool.RewardFlag,
 		t8ntool.VerbosityFlag,
 	},
+}
+
+var verkleCommand = &cli.Command{
+	Name:    "verkle",
+	Aliases: []string{"vkt"},
+	Usage:   "Verkle helpers",
 	Subcommands: []*cli.Command{
 		{
-			Name:    "verkle-keys",
+			Name:    "tree-keys",
 			Aliases: []string{"v"},
 			Usage:   "compute a set of verkle tree keys, given their source addresses and optional slot numbers",
 			Action:  t8ntool.VerkleKeys,
@@ -164,19 +170,19 @@ var stateTransitionCommand = &cli.Command{
 			},
 		},
 		{
-			Name:    "verkle-key",
+			Name:    "single-key",
 			Aliases: []string{"V"},
 			Usage:   "compute the verkle tree key given an address and optional slot number",
 			Action:  t8ntool.VerkleKey,
 		},
 		{
-			Name:    "verkle-code-chunk-key",
+			Name:    "code-chunk-key",
 			Aliases: []string{"VCK"},
 			Usage:   "compute the verkle tree key given an address and chunk number",
 			Action:  t8ntool.VerkleCodeChunkKey,
 		},
 		{
-			Name:    "verkle-chunkify-code",
+			Name:    "chunkify-code",
 			Aliases: []string{"VCC"},
 			Usage:   "chunkify a given bytecode",
 			Action:  t8ntool.VerkleChunkifyCode,
@@ -251,6 +257,7 @@ func init() {
 		stateTransitionCommand,
 		transactionCommand,
 		blockBuilderCommand,
+		verkleCommand,
 	}
 }
 

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -154,7 +154,7 @@ var stateTransitionCommand = &cli.Command{
 		t8ntool.VerbosityFlag,
 	},
 	Subcommands: []*cli.Command{
-		&cli.Command{
+		{
 			Name:    "verkle-keys",
 			Aliases: []string{"v"},
 			Usage:   "compute a set of verkle tree keys, given their source addresses and optional slot numbers",
@@ -163,11 +163,17 @@ var stateTransitionCommand = &cli.Command{
 				t8ntool.InputAllocFlag,
 			},
 		},
-		&cli.Command{
+		{
 			Name:    "verkle-key",
 			Aliases: []string{"V"},
 			Usage:   "compute the verkle tree key given an address and optional slot number",
 			Action:  t8ntool.VerkleKey,
+		},
+		{
+			Name:    "verkle-code-chunk-key",
+			Aliases: []string{"VC"},
+			Usage:   "compute the verkle tree key given an address and chunk number",
+			Action:  t8ntool.VerkleCodeChunkKey,
 		},
 	},
 }

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -171,9 +171,15 @@ var stateTransitionCommand = &cli.Command{
 		},
 		{
 			Name:    "verkle-code-chunk-key",
-			Aliases: []string{"VC"},
+			Aliases: []string{"VCK"},
 			Usage:   "compute the verkle tree key given an address and chunk number",
 			Action:  t8ntool.VerkleCodeChunkKey,
+		},
+		{
+			Name:    "verkle-chunkify-code",
+			Aliases: []string{"VCC"},
+			Usage:   "chunkify a given bytecode",
+			Action:  t8ntool.VerkleChunkifyCode,
 		},
 	},
 }


### PR DESCRIPTION
This PR groups all existing commands in a new `evm verkle` parent command which:
- Rename previous `evm transition tree-key` to `evm verkle single-key`.
- Rename previous `evm transition tree-keys` to `evm verkle tree-keys`
- Add a new `evm verkle chunk-code-key` which calculates the tree key for a given code chunk number for an address.
- Add a new `evm verkle chunkify-code` which chunkifies a given bytecode.

Examples of running the new commands:
```
$ go run ./cmd/evm verkle code-chunk-key 0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5 0x99
0x7a4c83df5aaf589b93bab2a650afad5fb4536fc45ae04543391595045035ae19
```
```
$ go run ./cmd/evm verkle chunkify-code 0x11111111111111111111111111111111111111111111111111111111111111111111111111
0x00111111111111111111111111111111111111111111111111111111111111110011111111111100000000000000000000000000000000000000000000000000
```