### PR TITLE
fix(t8n/exec): Small change to fix t8n verkle filling post rebase.

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -186,8 +186,8 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		GetHash:     getHash,
 	}
 	// Save pre verkle tree to build the proof at the end
-	if len(pre.VKT) > 0 {
-		vtrpre = statedb.GetTrie().(*trie.VerkleTrie).Copy()
+	if pre.VKT != nil && len(pre.VKT) > 0 {
+		vtrpre = statedb.GetTrie().(*trie.TransitionTrie).Overlay().Copy()
 	}
 	// If currentBaseFee is defined, add it to the vmContext.
 	if pre.Env.BaseFee != nil {

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -142,6 +142,7 @@ var stateTransitionCommand = &cli.Command{
 		t8ntool.OutputBasedir,
 		t8ntool.OutputAllocFlag,
 		t8ntool.OutputVKTFlag,
+		t8ntool.OutputWitnessFlag,
 		t8ntool.OutputResultFlag,
 		t8ntool.OutputBodyFlag,
 		t8ntool.InputAllocFlag,


### PR DESCRIPTION
Fixes the t8n filling, and adds the witness output flag to t8n.