### PR TITLE
t8n: verkle genesis support

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -427,7 +427,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 
 func MakePreState(db ethdb.Database, chainConfig *params.ChainConfig, pre *Prestate, verkle bool) *state.StateDB {
 	// Start with generating the MPT DB, which should be empty if it's post-verkle transition
-	sdb := state.NewDatabaseWithConfig(db, &trie.Config{Preimages: true, Verkle: false})
+	sdb := state.NewDatabaseWithConfig(db, &trie.Config{Preimages: true, Verkle: verkle})
 
 	if verkle {
 		sdb.InitTransitionStatus(pre.Env.Started != nil && *pre.Env.Started, pre.Env.Ended != nil && *pre.Env.Ended, common.Hash{})
@@ -471,12 +471,11 @@ func MakePreState(db ethdb.Database, chainConfig *params.ChainConfig, pre *Prest
 		}
 		snaps.Cap(treeRoot, 0)
 
-		// t loggggLoad the conversion status
+		// Load the conversion status
 		log.Info("loading conversion status", "started", pre.Env.Started)
 		if pre.Env.Started != nil {
 			log.Info("non-nil started", "started", *pre.Env.Started)
 		}
-		sdb.InitTransitionStatus(pre.Env.Started != nil && *pre.Env.Started, pre.Env.Ended != nil && *pre.Env.Ended, treeRoot)
 		log.Info("loading current account address, if available", "available", pre.Env.CurrentAccountAddress != nil)
 		if pre.Env.CurrentAccountAddress != nil {
 			log.Info("loading current account address", "address", *pre.Env.CurrentAccountAddress)

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -471,9 +471,6 @@ func MakePreState(db ethdb.Database, chainConfig *params.ChainConfig, pre *Prest
 		}
 		snaps.Cap(treeRoot, 0)
 
-		// reuse the backend db so that the snapshot can be enumerated
-		sdb := sdb // := state.NewDatabaseWithConfig(db, &trie.Config{Verkle: true})
-
 		// Load the conversion status
 		log.Info("loading conversion status", "started", pre.Env.Started)
 		if pre.Env.Started != nil {

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -430,7 +430,7 @@ func MakePreState(db ethdb.Database, chainConfig *params.ChainConfig, pre *Prest
 	sdb := state.NewDatabaseWithConfig(db, &trie.Config{Preimages: true, Verkle: false})
 
 	if verkle {
-		sdb.InitTransitionStatus(pre.Env.Started != nil && *pre.Env.Started, pre.Env.Ended != nil && *pre.Env.Ended)
+		sdb.InitTransitionStatus(pre.Env.Started != nil && *pre.Env.Started, pre.Env.Ended != nil && *pre.Env.Ended, common.Hash{})
 	}
 
 	statedb, _ := state.New(types.EmptyRootHash, sdb, nil)
@@ -471,11 +471,12 @@ func MakePreState(db ethdb.Database, chainConfig *params.ChainConfig, pre *Prest
 		}
 		snaps.Cap(treeRoot, 0)
 
-		// Load the conversion status
+		// t loggggLoad the conversion status
 		log.Info("loading conversion status", "started", pre.Env.Started)
 		if pre.Env.Started != nil {
 			log.Info("non-nil started", "started", *pre.Env.Started)
 		}
+		sdb.InitTransitionStatus(pre.Env.Started != nil && *pre.Env.Started, pre.Env.Ended != nil && *pre.Env.Ended, treeRoot)
 		log.Info("loading current account address, if available", "available", pre.Env.CurrentAccountAddress != nil)
 		if pre.Env.CurrentAccountAddress != nil {
 			log.Info("loading current account address", "address", *pre.Env.CurrentAccountAddress)
@@ -489,7 +490,7 @@ func MakePreState(db ethdb.Database, chainConfig *params.ChainConfig, pre *Prest
 		}
 
 		// start the conversion on the first block
-		log.Info("starting verkle transition?", "in transition", sdb.InTransition(), "transitioned", sdb.Transitioned(), "mpt root", mptRoot)
+		log.Info("starting verkle transition?", "in transition", sdb.InTransition(), "transitioned", sdb.Transitioned(), "mpt root", treeRoot)
 		if !sdb.InTransition() && !sdb.Transitioned() {
 			sdb.StartVerkleTransition(treeRoot, treeRoot, chainConfig, chainConfig.PragueTime, treeRoot)
 		}


### PR DESCRIPTION
This PR has some changes to make `t8n` work in verkle genesis setups.

The way I used to fill:
```
$ fill --evm-dump-dir=evmdump --fork Prague -k "6800 and test_contract_creation" --output=fixtures-verkle-0
```
with the `evm` in PATH being this branch binary, and the `execution-spec-tests` branch [this branch](https://github.com/ethereum/execution-spec-tests/pull/659).