### PR TITLE
cmd/evm/t8n: Adds StorageProcessed flag

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -405,12 +405,14 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		ended := sdb.Transitioned()
 		if !ended {
 			var (
-				currentSlotHash = sdb.GetCurrentSlotHash()
-				started         = sdb.InTransition()
+				currentSlotHash  = sdb.GetCurrentSlotHash()
+				started          = sdb.InTransition()
+				storageProcessed = sdb.GetStorageProcessed()
 			)
 			execRs.CurrentAccountAddress = sdb.GetCurrentAccountAddress()
 			execRs.CurrentSlotHash = &currentSlotHash
 			execRs.Started = &started
+			execRs.StorageProcessed = &storageProcessed
 		}
 		execRs.Ended = &ended
 	}

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -68,7 +68,7 @@ type Database interface {
 	// TrieDB retrieves the low level trie database used for data storage.
 	TrieDB() *trie.Database
 
-	StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, cancunTime *uint64, root common.Hash)
+	StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, pragueTime *uint64, root common.Hash)
 
 	ReorgThroughVerkleTransition()
 


### PR DESCRIPTION
Adds the storage processed flag to t8n. This will be used when we need to set the stride > 0 (as far as my understanding goes).

Tested in execution-spec-tests: the field is now populated as an output from the t8n `result.json` and fed in as an input to next t8n `env.json` during a filling cycle.