### PR TITLE
merge redundant conversion base tree hash vars

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -299,7 +299,6 @@ type cachingDB struct {
 
 	// Transition-specific fields
 	// TODO ensure that this info is in the DB
-	LastMerkleRoot         common.Hash // root hash of the read-only base tree
 	CurrentTransitionState *TransitionState
 	TransitionStatePerRoot lru.BasicLRU[common.Hash, *TransitionState]
 	transitionStateLock    sync.Mutex
@@ -396,7 +395,7 @@ func (db *cachingDB) OpenStorageTrie(stateRoot common.Hash, address common.Addre
 	}
 	if db.InTransition() {
 		log.Info("OpenStorageTrie during transition", "state root", stateRoot, "root", root)
-		mpt, err := db.openStorageMPTrie(db.LastMerkleRoot, address, root, nil)
+		mpt, err := db.openStorageMPTrie(db.baseRoot, address, root, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -528,7 +527,7 @@ func (db *cachingDB) AddRootTranslation(originalRoot, translatedRoot common.Hash
 }
 
 func (db *cachingDB) SetLastMerkleRoot(merkleRoot common.Hash) {
-	db.LastMerkleRoot = merkleRoot
+	db.baseRoot = merkleRoot
 }
 
 func (db *cachingDB) SaveTransitionState(root common.Hash) {


### PR DESCRIPTION
Over the years, two variables with very similar roles have been created:

 * `LastMerkleRoot`, that comes from the time of the replay and is used to retain the base tree. It is set at the end of `IntermediateRoot`
 * `baseRoot` which is also the pointer to the root of the base tree, but is coming from the shadowfork codebase.

These two variables do the same thing, and if they are not in sync, weird bugs appear. Hence the need to remove one of them.

**TODO**

 - [x] make sure that it syncs kaustinen
 - [x] make sure that it still performs shadowforks
 - [ ] check that it also works with the replay