### PR TITLE
trie/verkle: fix identification of empty account

### DIFF
--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -115,6 +115,11 @@ func (t *VerkleTrie) GetAccount(addr common.Address) (*types.StateAccount, error
 		return nil, fmt.Errorf("GetAccount (%x) error: %v", addr, err)
 	}
 
+	// The following code is required for the MPT->VKT conversion.
+	// An account can be partially migrated, where storage slots were moved to the VKT
+	// but not yet the account. This means some account information as (header) storage slots
+	// are in the VKT but basic account information must be read in the base tree (MPT).
+	// TODO: we can simplify this logic depending if the conversion is in progress or finished.
 	emptyAccount := true
 	for i := 0; values != nil && i <= utils.CodeHashLeafKey && emptyAccount; i++ {
 		emptyAccount = emptyAccount && values[i] == nil

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -115,9 +115,14 @@ func (t *VerkleTrie) GetAccount(addr common.Address) (*types.StateAccount, error
 		return nil, fmt.Errorf("GetAccount (%x) error: %v", addr, err)
 	}
 
-	if values == nil {
+	emptyAccount := true
+	for i := 0; values != nil && i <= utils.CodeHashLeafKey && emptyAccount; i++ {
+		emptyAccount = emptyAccount && values[i] == nil
+	}
+	if emptyAccount {
 		return nil, nil
 	}
+
 	if len(values[utils.NonceLeafKey]) > 0 {
 		acc.Nonce = binary.LittleEndian.Uint64(values[utils.NonceLeafKey])
 	}


### PR DESCRIPTION
A bug was identified by replaying Byzantium data which worked correctly with `stride=10k` but failed with `stride=1k`.

After lots of debugging, the issue was related to a wrong identification of an empty account if that same account is in progress of being converted (i.e: storage slots being converted but not yet account basic data).

I've confirmed this fix solves the bad-block in the replay.