### PR TITLE
fix: force conversion of withdrawal code

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -344,6 +344,17 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		// Amount is in gwei, turn into wei
 		amount := new(big.Int).Mul(new(big.Int).SetUint64(w.Amount), big.NewInt(params.GWei))
 		statedb.AddBalance(w.Address, amount)
+
+		// fix: during the transition, if the withdrawals account
+		// hasn't been translated yet, then the code will not make
+		// it to the verkle tree when it's being written.
+		if state.Database().InTransition() {
+			codeHash := state.GetCodeHash(w.Address)
+			if codeHash != types.EmptyCodeHash {
+				code := state.GetCode(w.Address)
+				state.GetTrie().UpdateContractCode(w.Address, codeHash, code)
+			}
+		}
 	}
 	if chainConfig.IsPrague(big.NewInt(int64(pre.Env.Number)), pre.Env.Timestamp) {
 		if err := overlay.OverlayVerkleTransition(statedb, common.Hash{}, chainConfig.OverlayStride); err != nil {


### PR DESCRIPTION
This is a tentative fix that is probably unnecessary but that I am keeping around in case my analysis is wrong and the fix is indeed needed.

During the overlay transition, withdrawals to unconverted addresses will cause the account to be loaded, but not its code/data. if that is the case, then we have this strange situation where the code is not in the tree but a non-empty code hash refers to it.

this shouldn't be a problem since, as said, fullnodes store the code out of the tree, and so the code will be found as soon as the code  hash can be read. nonetheless, the account will be partially translated until the account is converted and so the node commitment will reflect that. this can be surprising to stateless clients, although they should not function during the conversion anyway.