### PR TITLE
merge redundant conversion base tree hash vars

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -363,14 +363,12 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 		// If the verkle conversion has ended, return a single
 		// verkle trie.
 		if db.CurrentTransitionState.Ended {
-			log.Info("transition ended, returning a simple verkle tree")
 			log.Debug("transition ended, returning a simple verkle tree")
 			return vkt, nil
 		}
 
 		// Otherwise, return a transition trie, with a base MPT
 		// trie and an overlay, verkle trie.
-		log.Info("opening base tree", "base root", db.baseRoot)
 		mpt, err := db.openMPTTrie(db.baseRoot)
 		if err != nil {
 			log.Error("failed to open the mpt", "err", err, "root", db.baseRoot)

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -369,7 +369,7 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 
 		// Otherwise, return a transition trie, with a base MPT
 		// trie and an overlay, verkle trie.
-		mpt, err := db.openMPTTrie(db.baseRoot)
+		mpt, err = db.openMPTTrie(db.baseRoot)
 		if err != nil {
 			log.Error("failed to open the mpt", "err", err, "root", db.baseRoot)
 			return nil, err


### PR DESCRIPTION
Over the years, two variables with very similar roles have been created:

 * `LastMerkleRoot`, that comes from the time of the replay and is used to retain the base tree. It is set at the end of `IntermediateRoot`
 * `baseRoot` which is also the pointer to the root of the base tree, but is coming from the shadowfork codebase.

These two variables do the same thing, and if they are not in sync, weird bugs appear. Hence the need to remove one of them.

This is a cherry-pick of #445 on top of `kaustinen-with-shapella` as something broke the shadowfork system in the t8n branch.

**TODO**

 - [x] make sure that it syncs kaustinen
 - [x] make sure that it still performs shadowforks
 - [x] check that it also works with the replay