### PR TITLE
add debug log to shadowfork, to validate a few hypotheses

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -467,7 +467,7 @@ func MakePreState(db ethdb.Database, chainConfig *params.ChainConfig, pre *Prest
 		if pre.Env.Started != nil {
 			log.Info("non-nil started", "started", *pre.Env.Started)
 		}
-		sdb.InitTransitionStatus(pre.Env.Started != nil && *pre.Env.Started, pre.Env.Ended != nil && *pre.Env.Ended, mptRoot)
+		sdb.InitTransitionStatus(pre.Env.Started != nil && *pre.Env.Started, pre.Env.Ended != nil && *pre.Env.Ended)
 		log.Info("loading current account address, if available", "available", pre.Env.CurrentAccountAddress != nil)
 		if pre.Env.CurrentAccountAddress != nil {
 			log.Info("loading current account address", "address", *pre.Env.CurrentAccountAddress)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -321,6 +321,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 
 	// Declare the end of the verkle transition if need be
 	if bc.chainConfig.IsPrague(head.Number, head.Time) {
+		log.Warn("Went through some reorg")
 		// TODO this only works when resuming a chain that has already gone
 		// through the conversion. All pointers should be saved to the DB
 		// for it to be able to recover if interrupted during the transition

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -327,7 +327,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		// for it to be able to recover if interrupted during the transition
 		// but that's left out to a later PR since there's not really a need
 		// right now.
-		bc.stateCache.InitTransitionStatus(true, true, common.Hash{})
+		bc.stateCache.InitTransitionStatus(true, true)
 		bc.stateCache.EndVerkleTransition()
 	}
 
@@ -1773,7 +1773,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			// If the verkle activation time hasn't started, declare it as "not started".
 			// This is so that if the miner activates the conversion, the insertion happens
 			// in the correct mode.
-			bc.stateCache.InitTransitionStatus(false, false, common.Hash{})
+			bc.stateCache.InitTransitionStatus(false, false)
 		}
 		if parent.Number.Uint64() == conversionBlock {
 			bc.StartVerkleTransition(parent.Root, emptyVerkleRoot, bc.Config(), &parent.Time, parent.Root)

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -78,7 +78,7 @@ type Database interface {
 
 	Transitioned() bool
 
-	InitTransitionStatus(bool, bool, common.Hash)
+	InitTransitionStatus(bool, bool)
 
 	SetCurrentSlotHash(common.Hash)
 
@@ -245,13 +245,12 @@ func (db *cachingDB) ReorgThroughVerkleTransition() {
 	log.Warn("trying to reorg through the transition, which makes no sense at this point")
 }
 
-func (db *cachingDB) InitTransitionStatus(started, ended bool, baseRoot common.Hash) {
+func (db *cachingDB) InitTransitionStatus(started, ended bool) {
 	db.CurrentTransitionState = &TransitionState{
 		Ended:   ended,
 		Started: started,
 		// TODO add other fields when we handle mid-transition interrupts
 	}
-	db.baseRoot = baseRoot
 }
 
 func (db *cachingDB) EndVerkleTransition() {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -79,7 +79,12 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		signer  = types.MakeSigner(p.config, header.Number, header.Time)
 	)
 	if p.config.IsPrague(block.Number(), block.Time()) {
-		ProcessParentBlockHash(statedb, block.NumberU64()-1, block.ParentHash())
+		parent := p.bc.GetBlockByHash(block.ParentHash())
+		if !p.config.IsPrague(parent.Number(), parent.Time()) {
+			InsertBlockHashHistoryAtEip2935Fork(statedb, block.NumberU64()-1, block.ParentHash(), p.bc)
+		} else {
+			ProcessParentBlockHash(statedb, block.NumberU64()-1, block.ParentHash())
+		}
 	}
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {

--- a/light/trie.go
+++ b/light/trie.go
@@ -121,7 +121,7 @@ func (db *odrDatabase) Transitioned() bool {
 	panic("not implemented") // TODO: Implement
 }
 
-func (db *odrDatabase) InitTransitionStatus(bool, bool, common.Hash) {
+func (db *odrDatabase) InitTransitionStatus(bool, bool) {
 	panic("not implemented") // TODO: Implement
 }
 


### PR DESCRIPTION
This PR tracks my attempts at understanding why the holesky shadowfork is broken.

- [ ] see if this is because of a `common.Hash` set to `baseRoot` after the reorg
  - [x] add a trace -> didn't show anything particular
  - [x] revert setting baseroot in `InitTransitionStatus` -> caused a merkle root error as well, but the blocks are empty :thinking: 
- [x] revert 2935 changes -> that is the issue