### PR TITLE
[wip] implement FILL_COST

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -402,6 +402,14 @@ func (s *StateDB) GetCommittedState(addr common.Address, hash common.Hash) commo
 	return common.Hash{}
 }
 
+func (s *StateDB) GetFillStatus(addr common.Address, hash common.Hash) bool {
+	stateObject := s.getStateObject(addr)
+	if stateObject != nil {
+		return stateObject.GetFillStatus(hash)
+	}
+	return false
+}
+
 // Database retrieves the low level database supporting the lower level trie ops.
 func (s *StateDB) Database() Database {
 	return s.db

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -196,5 +196,5 @@ func ProcessParentBlockHash(statedb *state.StateDB, prevNumber uint64, prevHash 
 	var key common.Hash
 	binary.BigEndian.PutUint64(key[24:], ringIndex)
 	statedb.SetState(params.HistoryStorageAddress, key, prevHash)
-	statedb.Witness().TouchSlotAndChargeGas(params.HistoryStorageAddress[:], key, true)
+	statedb.Witness().TouchSlotAndChargeGas(params.HistoryStorageAddress[:], key, true, false)
 }

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -462,7 +462,7 @@ func getBlockHashFromContract(number uint64, statedb StateDB, witness *state.Acc
 	ringIndex := number % params.Eip2935BlockHashHistorySize
 	var pnum common.Hash
 	binary.BigEndian.PutUint64(pnum[24:], ringIndex)
-	statelessGas := witness.TouchSlotAndChargeGas(params.HistoryStorageAddress[:], pnum, false)
+	statelessGas := witness.TouchSlotAndChargeGas(params.HistoryStorageAddress[:], pnum, false, false)
 	return statedb.GetState(params.HistoryStorageAddress, pnum), statelessGas
 }
 

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -48,6 +48,7 @@ type StateDB interface {
 	GetCommittedState(common.Address, common.Hash) common.Hash
 	GetState(common.Address, common.Hash) common.Hash
 	SetState(common.Address, common.Hash, common.Hash)
+	GetFillStatus(common.Address, common.Hash) bool
 
 	GetTransientState(addr common.Address, key common.Hash) common.Hash
 	SetTransientState(addr common.Address, key, value common.Hash)

--- a/core/vm/operations_verkle.go
+++ b/core/vm/operations_verkle.go
@@ -23,7 +23,8 @@ import (
 )
 
 func gasSStore4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	gas := evm.Accesses.TouchSlotAndChargeGas(contract.Address().Bytes(), common.Hash(stack.peek().Bytes32()), true)
+	isFill := evm.StateDB.GetFillStatus(contract.Address(), common.Hash(stack.peek().Bytes32()))
+	gas := evm.Accesses.TouchSlotAndChargeGas(contract.Address().Bytes(), common.Hash(stack.peek().Bytes32()), true, isFill)
 	if gas == 0 {
 		gas = params.WarmStorageReadCostEIP2929
 	}
@@ -31,7 +32,7 @@ func gasSStore4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memo
 }
 
 func gasSLoad4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	gas := evm.Accesses.TouchSlotAndChargeGas(contract.Address().Bytes(), common.Hash(stack.peek().Bytes32()), false)
+	gas := evm.Accesses.TouchSlotAndChargeGas(contract.Address().Bytes(), common.Hash(stack.peek().Bytes32()), false, false)
 	if gas == 0 {
 		gas = params.WarmStorageReadCostEIP2929
 	}


### PR DESCRIPTION
Extract the information of whether the value was present from `StateDB` and use it to let the access witness know if the fill costs are to be charged.