### PR TITLE
fix: remove ineffective witness assignment

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -443,7 +443,6 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 		if err != nil {
 			panic(fmt.Sprintf("could not find state for block %d: err=%v, parent root=%x", i, err, parent.Root()))
 		}
-		statedb.NewAccessWitness()
 		block, receipt := genblock(i, parent, statedb)
 		blocks[i] = block
 		receipts[i] = receipt

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -192,7 +192,7 @@ func (s *StateDB) NewAccessWitness() *AccessWitness {
 
 func (s *StateDB) Witness() *AccessWitness {
 	if s.witness == nil {
-		s.witness = s.NewAccessWitness()
+		panic("witness wasn't initialized")
 	}
 	return s.witness
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -137,9 +137,6 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 		chainConfig: chainConfig,
 		chainRules:  chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil, blockCtx.Time),
 	}
-	if txCtx.Accesses == nil && chainConfig.IsPrague(blockCtx.BlockNumber, blockCtx.Time) {
-		evm.Accesses = evm.StateDB.(*state.StateDB).NewAccessWitness()
-	}
 	evm.interpreter = NewEVMInterpreter(evm)
 	return evm
 }


### PR DESCRIPTION
I noticed that there was an ineffectual witness creation, as well as a misplaced check for the existence of the witness, I am removing them for cleanup - they clash with some changes introduced by FILL_COST