### PR TITLE
[wip] replay at 17M but deleting storage slots + accounts

### DIFF
--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -193,10 +193,14 @@ func ImportChain(chain *core.BlockChain, fn string) error {
 		}
 		i := 0
 		for ; i < importBatchSize; i++ {
+			if i == 1907 {
+				break
+			}
 			var b types.Block
-			if err := stream.Decode(&b); err == io.EOF {
+			if err := stream.Decode(&b); errors.Is(err, io.EOF) {
 				break
 			} else if err != nil {
+				fmt.Println(batch, i)
 				return fmt.Errorf("at block %d: %v", n, err)
 			}
 			// don't import first block

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -289,7 +289,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	}
 	// Create a new context to be used in the EVM environment
 	blockContext := NewEVMBlockContext(header, bc, author)
-	istarget := blockContext.BlockNumber.Uint64() == 17366216
+	istarget := blockContext.BlockNumber.Uint64() == 17165311
 	if istarget {
 		tracer := logger.NewStructLogger(&logger.Config{
 			Debug:          istarget,

--- a/trie/transition.go
+++ b/trie/transition.go
@@ -123,12 +123,20 @@ func (t *TransitionTrie) UpdateAccount(addr common.Address, account *types.State
 // Delete removes any existing value for key from the trie. If a node was not
 // found in the database, a trie.MissingNodeError is returned.
 func (t *TransitionTrie) DeleteStorage(addr common.Address, key []byte) error {
-	return t.overlay.DeleteStorage(addr, key)
+	err := t.overlay.DeleteStorage(addr, key)
+	if err != nil {
+		return err
+	}
+	return t.base.DeleteStorage(addr, key)
 }
 
 // DeleteAccount abstracts an account deletion from the trie.
 func (t *TransitionTrie) DeleteAccount(key common.Address) error {
-	return t.overlay.DeleteAccount(key)
+	err := t.overlay.DeleteAccount(key)
+	if err != nil {
+		return err
+	}
+	return t.base.DeleteAccount(key)
 }
 
 // Hash returns the root hash of the trie. It does not write to the database and


### PR DESCRIPTION
note: This is mostly for me to remember the current state on monday since I have to move on to something else and want to jot down notes before I do.

This approach deletes values from the verkle tree, and also from the merkle tree. It's only intended to work with block replay. Most of the difficulty comes from being pre-cancun, as accounts have to be deleted also.