### PR TITLE
ci: target test main branch

### DIFF
--- a/.github/workflows/spec-tests.yml
+++ b/.github/workflows/spec-tests.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  EEST_USER: "jsign"
-  EEST_BRANCH: "jsign/fix-test"
+  EEST_USER: "ethereum"
+  EEST_BRANCH: "verkle/main"
 
 jobs:
   setup:


### PR DESCRIPTION
Now that https://github.com/ethereum/execution-spec-tests/pull/761 is merged, we can target `verkle/main` again.