### PR TITLE
ci: consume stable fixtures

### DIFF
--- a/.github/workflows/spec-tests-branch.yml
+++ b/.github/workflows/spec-tests-branch.yml
@@ -1,4 +1,4 @@
-name: Execution Spec Tests Fill and Consume (Verkle genesis & conversion)
+name: Execution Spec Tests - Fill and Consume (branch)
 
 on:
   push:

--- a/.github/workflows/stable-spec-tests.yml
+++ b/.github/workflows/stable-spec-tests.yml
@@ -1,4 +1,4 @@
-name: Execution Spec Tests Fill and Consume (stable)
+name: Execution Spec Tests - Consume (stable)
 
 on:
   push:

--- a/.github/workflows/stable-spec-tests.yml
+++ b/.github/workflows/stable-spec-tests.yml
@@ -1,0 +1,82 @@
+name: Execution Spec Tests Fill and Consume (stable)
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master, kaustinen-with-shapella]
+  workflow_dispatch:
+
+env:
+  FIXTURES_TAG: "verkle@v0.0.3"
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout go-ethereum
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12.4"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.4
+
+      - name: Build geth evm
+        run: |
+          go build -v ./cmd/evm
+          mkdir -p ${{ github.workspace }}/bin
+          mv evm ${{ github.workspace }}/bin/evm
+          chmod +x ${{ github.workspace }}/bin/evm
+
+      - name: Archive built evm
+        uses: actions/upload-artifact@v4
+        with:
+          name: evm
+          path: ${{ github.workspace }}/bin/evm
+
+  consume:
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      matrix:
+        filename:
+          [
+            fixtures_verkle-conversion-stride-0.tar.gz,
+            fixtures_verkle-genesis.tar.gz,
+          ]
+    steps:
+      - name: Download geth evm
+        uses: actions/download-artifact@v4
+        with:
+          name: evm
+          path: ./bin
+
+      - name: Make evm binary executable and add to PATH
+        run: |
+          chmod +x ./bin/evm
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - name: Download fixtures
+        uses: robinraju/release-downloader@v1
+        with:
+          repository: "ethereum/execution-spec-tests"
+          tag: "${{ env.FIXTURES_TAG }}"
+          fileName: "${{ matrix.filename }}"
+          extract: true
+      - name: Clone execution-spec-tests and consume tests
+        run: |
+          git clone https://github.com/ethereum/execution-spec-tests -b ${{ env.FIXTURES_TAG }} --depth 1
+          cd execution-spec-tests
+          python3 -m venv venv
+          . venv/bin/activate
+          pip install --upgrade pip
+          pip install -e ".[docs,lint,test]"
+          solc-select use 0.8.24 --always-install
+          consume direct --input=../fixtures -n auto
+        shell: bash


### PR DESCRIPTION
This PR adds a separate workflow to consume stable fixtures pulled from a defined tag in `execution-spec-tests`.

Depending on the PR, we should make an "expert call" if the fix in the PR should pass or not those stable fixtures, for example:
- If the PR fixes a bug that affects filling, then it might make sense that the job shouldn't pass and that the PR should be merged anyway. This might be a signal to ask for a new `execution-spec-tests` release after the PR is merged.
- If the PR shouldn't affect filling, then this job failing means we might have a regression, and the PR should be further inspected.