### PR TITLE
statedb: avoid getting code from cache

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -576,7 +576,7 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 	}
 	// Encode the account and update the account trie
 	addr := obj.Address()
-	if err := s.trie.UpdateAccount(addr, &obj.data, len(obj.code)); err != nil {
+	if err := s.trie.UpdateAccount(addr, &obj.data, len(s.GetCode(addr))); err != nil {
 		s.setError(fmt.Errorf("updateStateObject (%x) error: %v", addr[:], err))
 	}
 	if obj.dirtyCode {


### PR DESCRIPTION
This PR fixes a bug discovered while debugging a test fixture.