### PR TITLE
fix create init witness gas charge

### DIFF
--- a/core/state/access_witness.go
+++ b/core/state/access_witness.go
@@ -112,7 +112,7 @@ func (aw *AccessWitness) TouchAndChargeValueTransfer(callerAddr, targetAddr []by
 
 // TouchAndChargeContractCreateInit charges access costs to initiate
 // a contract creation
-func (aw *AccessWitness) TouchAndChargeContractCreateInit(addr []byte, createSendsValue bool) uint64 {
+func (aw *AccessWitness) TouchAndChargeContractCreateInit(addr []byte) uint64 {
 	var gas uint64
 	gas += aw.touchAddressAndChargeGas(addr, zeroTreeIndex, utils.BasicDataLeafKey, true)
 	return gas

--- a/core/state/access_witness.go
+++ b/core/state/access_witness.go
@@ -110,11 +110,23 @@ func (aw *AccessWitness) TouchAndChargeValueTransfer(callerAddr, targetAddr []by
 	return gas
 }
 
+// TouchAndChargeContractCreateCheck charges access costs before
+// a contract creation is initiated. It is just reads, because the
+// address collision is done before the transfer, and so no write
+// are guaranteed to happen at this point.
+func (aw *AccessWitness) TouchAndChargeContractCreateCheck(addr []byte) uint64 {
+	var gas uint64
+	gas += aw.touchAddressAndChargeGas(addr, zeroTreeIndex, utils.BasicDataLeafKey, false)
+	gas += aw.touchAddressAndChargeGas(addr, zeroTreeIndex, utils.CodeHashLeafKey, false)
+	return gas
+}
+
 // TouchAndChargeContractCreateInit charges access costs to initiate
-// a contract creation
+// a contract creation.
 func (aw *AccessWitness) TouchAndChargeContractCreateInit(addr []byte) uint64 {
 	var gas uint64
 	gas += aw.touchAddressAndChargeGas(addr, zeroTreeIndex, utils.BasicDataLeafKey, true)
+	gas += aw.touchAddressAndChargeGas(addr, zeroTreeIndex, utils.CodeHashLeafKey, true)
 	return gas
 }
 

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -732,7 +732,7 @@ func TestProcessVerkleInvalidContractCreation(t *testing.T) {
 			}
 		} else if bytes.Equal(stemStateDiff.Stem[:], common.Hex2Bytes("26f8a45c665b9ca0bf769b213ba9bb14e86d4028a41274ae2a509e71a89d86")) {
 			for _, suffixDiff := range stemStateDiff.SuffixDiffs {
-				if suffixDiff.Suffix != 105 && suffixDiff.Suffix != 0 && suffixDiff.Suffix != 2 && suffixDiff.Suffix != 3 {
+				if suffixDiff.Suffix != 105 && suffixDiff.Suffix != 0 && suffixDiff.Suffix != 1 {
 					t.Fatalf("invalid suffix diff found for %x in block #1: %d\n", stemStateDiff.Stem, suffixDiff.Suffix)
 				}
 			}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -494,9 +494,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		}
 	}
 
-	var ret []byte
-	var err error
-	ret, err = evm.interpreter.Run(contract, nil, false)
+	ret, err := evm.interpreter.Run(contract, nil, false)
 
 	// Check whether the max code size has been exceeded, assign err if the case.
 	if err == nil && evm.chainRules.IsEIP158 && len(ret) > params.MaxCodeSize {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -453,7 +453,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 	// Charge the contract creation init gas in verkle mode
 	if evm.chainRules.IsEIP4762 {
-		statelessGas := evm.Accesses.TouchAndChargeContractCreateInit(address.Bytes(), value.Sign() != 0)
+		statelessGas := evm.Accesses.TouchAndChargeContractCreateInit(address.Bytes())
 		if statelessGas > gas {
 			return nil, common.Address{}, gas, ErrOutOfGas
 		}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -455,7 +455,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	if evm.chainRules.IsEIP4762 {
 		statelessGas := evm.Accesses.TouchAndChargeContractCreateCheck(address.Bytes())
 		if statelessGas > gas {
-			return nil, common.Address{}, gas, ErrOutOfGas
+			return nil, common.Address{}, 0, ErrOutOfGas
 		}
 		gas = gas - statelessGas
 	}
@@ -480,7 +480,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	if evm.chainRules.IsEIP4762 {
 		statelessGas := evm.Accesses.TouchAndChargeContractCreateInit(address.Bytes())
 		if statelessGas > gas {
-			return nil, common.Address{}, gas, ErrOutOfGas
+			return nil, common.Address{}, 0, ErrOutOfGas
 		}
 		gas = gas - statelessGas
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -453,7 +453,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 	// Charge the contract creation init gas in verkle mode
 	if evm.chainRules.IsEIP4762 {
-		statelessGas := evm.Accesses.TouchAndChargeContractCreateInit(address.Bytes())
+		statelessGas := evm.Accesses.TouchAndChargeContractCreateCheck(address.Bytes())
 		if statelessGas > gas {
 			return nil, common.Address{}, gas, ErrOutOfGas
 		}
@@ -476,6 +476,14 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		evm.StateDB.SetNonce(address, 1)
 	}
 
+	// Charge the contract creation init gas in verkle mode
+	if evm.chainRules.IsEIP4762 {
+		statelessGas := evm.Accesses.TouchAndChargeContractCreateInit(address.Bytes())
+		if statelessGas > gas {
+			return nil, common.Address{}, gas, ErrOutOfGas
+		}
+		gas = gas - statelessGas
+	}
 	evm.Context.Transfer(evm.StateDB, caller.Address(), address, value)
 
 	// Initialise a new contract and set the code that is to be used by the EVM.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -525,11 +525,6 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 				err = ErrCodeStoreOutOfGas
 			}
 		} else {
-			// Contract creation completed, touch the missing fields in the contract
-			if !contract.UseGas(evm.Accesses.TouchFullAccount(address.Bytes()[:], true)) {
-				err = ErrCodeStoreOutOfGas
-			}
-
 			if err == nil && len(ret) > 0 && !contract.UseGas(evm.Accesses.TouchCodeChunksRangeAndChargeGas(address.Bytes(), 0, uint64(len(ret)), uint64(len(ret)), true)) {
 				err = ErrCodeStoreOutOfGas
 			}

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -630,13 +630,6 @@ func opCreate(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	}
 
 	value := scope.Stack.pop()
-	if interpreter.evm.chainRules.IsEIP4762 {
-		contractAddress := crypto.CreateAddress(scope.Contract.Address(), interpreter.evm.StateDB.GetNonce(scope.Contract.Address()))
-		statelessGas := interpreter.evm.Accesses.TouchAndChargeContractCreateInit(contractAddress.Bytes()[:], value.Sign() != 0)
-		if !scope.Contract.UseGas(statelessGas) {
-			return nil, ErrExecutionReverted
-		}
-	}
 
 	var (
 		offset, size = scope.Stack.pop(), scope.Stack.pop()
@@ -690,14 +683,6 @@ func opCreate2(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]
 		salt         = scope.Stack.pop()
 		input        = scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
 	)
-	if interpreter.evm.chainRules.IsEIP4762 {
-		codeAndHash := &codeAndHash{code: input}
-		contractAddress := crypto.CreateAddress2(scope.Contract.Address(), salt.Bytes32(), codeAndHash.Hash().Bytes())
-		statelessGas := interpreter.evm.Accesses.TouchAndChargeContractCreateInit(contractAddress.Bytes()[:], endowment.Sign() != 0)
-		if !scope.Contract.UseGas(statelessGas) {
-			return nil, ErrExecutionReverted
-		}
-	}
 
 	var gas = scope.Contract.Gas
 	// Apply EIP150


### PR DESCRIPTION
 - Remove additional TouchAndChargeContractCreateInit call before 1/64 gas is deducted
 - move the TouchAndChargeContractCreateInit call before the collison check and value transfer