### PR TITLE
witness: fix code touching if size is zero

### DIFF
--- a/core/state/access_witness.go
+++ b/core/state/access_witness.go
@@ -237,7 +237,7 @@ func (aw *AccessWitness) TouchCodeChunksRangeAndChargeGas(contractAddr []byte, s
 	// reason that we do not need the last leaf is the account's code size
 	// is already in the AccessWitness so a stateless verifier can see that
 	// the code from the last leaf is not needed.
-	if size == 0 || startPC > codeLen {
+	if size == 0 || startPC >= codeLen {
 		return 0
 	}
 

--- a/core/state/access_witness.go
+++ b/core/state/access_witness.go
@@ -237,7 +237,7 @@ func (aw *AccessWitness) TouchCodeChunksRangeAndChargeGas(contractAddr []byte, s
 	// reason that we do not need the last leaf is the account's code size
 	// is already in the AccessWitness so a stateless verifier can see that
 	// the code from the last leaf is not needed.
-	if (codeLen == 0 && size == 0) || startPC > codeLen {
+	if size == 0 || startPC > codeLen {
 		return 0
 	}
 


### PR DESCRIPTION
If `size` is zero, we were touching at least one chunk which is incorrect.