### PR TITLE
*CALL: charge witness costs before 1/64th subtraction

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -404,6 +404,8 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 	}
 
 	if evm.chainRules.IsEIP4762 {
+		// If value is transferred, it is charged before 1/64th
+		// is subtracted from the available gas pool.
 		if transfersValue {
 			gas, overflow = math.SafeAdd(gas, evm.Accesses.TouchAndChargeValueTransfer(contract.Address().Bytes()[:], address.Bytes()[:]))
 			if overflow {

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -403,13 +403,6 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 		return 0, ErrGasUintOverflow
 	}
 
-	evm.callGasTemp, err = callGas(evm.chainRules.IsEIP150, contract.Gas, gas, stack.Back(0))
-	if err != nil {
-		return 0, err
-	}
-	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
-		return 0, ErrGasUintOverflow
-	}
 	if evm.chainRules.IsEIP4762 {
 		if transfersValue {
 			gas, overflow = math.SafeAdd(gas, evm.Accesses.TouchAndChargeValueTransfer(contract.Address().Bytes()[:], address.Bytes()[:]))
@@ -417,6 +410,14 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 				return 0, ErrGasUintOverflow
 			}
 		}
+	}
+
+	evm.callGasTemp, err = callGas(evm.chainRules.IsEIP150, contract.Gas, gas, stack.Back(0))
+	if err != nil {
+		return 0, err
+	}
+	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
+		return 0, ErrGasUintOverflow
 	}
 
 	return gas, nil
@@ -437,13 +438,6 @@ func gasCallCode(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
 	if gas, overflow = math.SafeAdd(gas, memoryGas); overflow {
 		return 0, ErrGasUintOverflow
 	}
-	evm.callGasTemp, err = callGas(evm.chainRules.IsEIP150, contract.Gas, gas, stack.Back(0))
-	if err != nil {
-		return 0, err
-	}
-	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
-		return 0, ErrGasUintOverflow
-	}
 	if evm.chainRules.IsEIP4762 {
 		address := common.Address(stack.Back(1).Bytes20())
 		transfersValue := !stack.Back(2).IsZero()
@@ -453,6 +447,13 @@ func gasCallCode(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
 				return 0, ErrGasUintOverflow
 			}
 		}
+	}
+	evm.callGasTemp, err = callGas(evm.chainRules.IsEIP150, contract.Gas, gas, stack.Back(0))
+	if err != nil {
+		return 0, err
+	}
+	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
+		return 0, ErrGasUintOverflow
 	}
 	return gas, nil
 }

--- a/core/vm/operations_verkle.go
+++ b/core/vm/operations_verkle.go
@@ -81,6 +81,10 @@ func makeCallVariantGasEIP4762(oldCalculator gasFunc) gasFunc {
 		if _, isPrecompile := evm.precompile(target); isPrecompile {
 			return gas, nil
 		}
+		// The charging for the value transfer is done BEFORE subtracting
+		// the 1/64th gas, as this is considered part of the CALL instruction.
+		// But the message call is part of the subcall, for which only 63/64th
+		// of the gas should be available.
 		wgas := evm.Accesses.TouchAndChargeMessageCall(target.Bytes())
 		if wgas == 0 {
 			wgas = params.WarmStorageReadCostEIP2929

--- a/core/vm/operations_verkle.go
+++ b/core/vm/operations_verkle.go
@@ -83,6 +83,7 @@ func makeCallVariantGasEIP4762(oldCalculator gasFunc) gasFunc {
 		}
 		// The charging for the value transfer is done BEFORE subtracting
 		// the 1/64th gas, as this is considered part of the CALL instruction.
+		// (so before we get to this point)
 		// But the message call is part of the subcall, for which only 63/64th
 		// of the gas should be available.
 		wgas := evm.Accesses.TouchAndChargeMessageCall(target.Bytes())


### PR DESCRIPTION
The spec has been updated to charge the witness costs before the 1/64th has been subtracted from the gas allocated to the subcall. This is already fixed on mainnet but it needs to be fixed in this branch for the testnet relaunch.

Fixes #430 