### PR TITLE
ci: temporarily switch to fixed consume direct

### DIFF
--- a/.github/workflows/stable-spec-tests.yml
+++ b/.github/workflows/stable-spec-tests.yml
@@ -71,8 +71,9 @@ jobs:
           extract: true
       - name: Clone execution-spec-tests and consume tests
         run: |
-          git clone https://github.com/ethereum/execution-spec-tests -b ${{ env.FIXTURES_TAG }} --depth 1
+          git clone https://github.com/ethereum/execution-spec-tests
           cd execution-spec-tests
+          git checkout 250a064ba38cd92cad02691f4f7c2ecbefedd954
           python3 -m venv venv
           . venv/bin/activate
           pip install --upgrade pip


### PR DESCRIPTION
This PR contains a temporary fix to solve the problem of the CI not failing when filling and/or consumption fails. This was due to a bug in `consume direct` in the testing library that just got fixed yesterday.

Look at the CI runs:
- The "Consume (stable)" jobs now are failing. This is the correct thing, since we already merged bugfixes for geth. And the current "stable-fixtures" are actually wrong, so the correct thing is that they should fail!
- The filling & consumption jobs don't fail. This is correct, since we're refilling and consuming with this branch itself (not stable one).