### PR TITLE
vm: charge code-chunk in JUMP and JUMPI if corresponds

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -585,6 +585,9 @@ func opJump(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	}
 	pos := scope.Stack.pop()
 	if !scope.Contract.validJumpdest(&pos) {
+		if !scope.Contract.UseGas(interpreter.evm.TxContext.Accesses.TouchCodeChunksRangeAndChargeGas(scope.Contract.CodeAddr[:], pos.Uint64(), 1, uint64(len(scope.Contract.Code)), false)) {
+			return nil, ErrOutOfGas
+		}
 		return nil, ErrInvalidJump
 	}
 	*pc = pos.Uint64() - 1 // pc will be increased by the interpreter loop
@@ -598,6 +601,9 @@ func opJumpi(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	pos, cond := scope.Stack.pop(), scope.Stack.pop()
 	if !cond.IsZero() {
 		if !scope.Contract.validJumpdest(&pos) {
+			if !scope.Contract.UseGas(interpreter.evm.TxContext.Accesses.TouchCodeChunksRangeAndChargeGas(scope.Contract.CodeAddr[:], pos.Uint64(), 1, uint64(len(scope.Contract.Code)), false)) {
+				return nil, ErrOutOfGas
+			}
 			return nil, ErrInvalidJump
 		}
 		*pc = pos.Uint64() - 1 // pc will be increased by the interpreter loop


### PR DESCRIPTION
This PR fixes a bug where in JUMP or positively evaluated JUMPI we weren't charging including the target code-chunk in an invalid jump. 

This is mandatory since it's the only way for a stateless client to know the jump was invalid.