### PR TITLE
witness: don't touch transfer for value-bearing CALLCODE

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -440,16 +440,6 @@ func gasCallCode(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
 	if gas, overflow = math.SafeAdd(gas, memoryGas); overflow {
 		return 0, ErrGasUintOverflow
 	}
-	if evm.chainRules.IsEIP4762 {
-		address := common.Address(stack.Back(1).Bytes20())
-		transfersValue := !stack.Back(2).IsZero()
-		if transfersValue {
-			gas, overflow = math.SafeAdd(gas, evm.Accesses.TouchAndChargeValueTransfer(contract.Address().Bytes()[:], address.Bytes()[:]))
-			if overflow {
-				return 0, ErrGasUintOverflow
-			}
-		}
-	}
 	evm.callGasTemp, err = callGas(evm.chainRules.IsEIP150, contract.Gas, gas, stack.Back(0))
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
This PR makes a fix pointed out by @tanishqjasoria