### PR TITLE
ci: run fill and consume in main branch

### DIFF
--- a/.github/workflows/spec-tests-branch.yml
+++ b/.github/workflows/spec-tests-branch.yml
@@ -2,7 +2,7 @@ name: Execution Spec Tests - Fill and Consume (branch)
 
 on:
   push:
-    branches: [master]
+    branches: [master, kaustinen-with-shapella]
   pull_request:
     branches: [master, kaustinen-with-shapella]
   workflow_dispatch:


### PR DESCRIPTION
This PR enables to run the filling and consumption when merging in `kaustinen-with-shapella`.