### PR TITLE
ci: new workflows for testing

### DIFF
--- a/.github/workflows/spec-tests-branch.yml
+++ b/.github/workflows/spec-tests-branch.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master, kaustinen-with-shapella]
+    branches: [master, kaustinen-with-shapella, jsign-witness-fix]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/spec-tests-branch.yml
+++ b/.github/workflows/spec-tests-branch.yml
@@ -64,7 +64,6 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           git clone https://github.com/${{ env.EEST_USER }}/execution-spec-tests -b ${{ env.EEST_BRANCH }} --depth 1
           cd execution-spec-tests
-          uv sync
           if [ "${{ matrix.test-type }}" == "genesis" ]; then
             uv run fill --evm-bin="${{ github.workspace }}/bin/evm" --fork Verkle --output=../fixtures-${{ matrix.test-type }} -v -m blockchain_test -n auto
           else
@@ -107,6 +106,5 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           git clone https://github.com/${{ env.EEST_USER }}/execution-spec-tests -b ${{ env.EEST_BRANCH }}
           cd execution-spec-tests
-          uv sync
-          uv run consume direct --input=../fixtures-${{ matrix.test-type }} -n auto
+          uv run consume direct --evm-bin="${{ github.workspace }}/bin/evm" --input=../fixtures-${{ matrix.test-type }} -n auto
         shell: bash

--- a/.github/workflows/spec-tests-branch.yml
+++ b/.github/workflows/spec-tests-branch.yml
@@ -66,9 +66,9 @@ jobs:
           cd execution-spec-tests
           uv sync
           if [ "${{ matrix.test-type }}" == "genesis" ]; then
-            uv run fill --fork Verkle --output=../fixtures-${{ matrix.test-type }} -v -m blockchain_test -n auto
+            uv run fill --evm-bin="${{ github.workspace }}/bin/evm" --fork Verkle --output=../fixtures-${{ matrix.test-type }} -v -m blockchain_test -n auto
           else
-            uv run fill --from Shanghai --until EIP6800Transition --output=../fixtures-${{ matrix.test-type }} -v -m blockchain_test -n auto
+            uv run fill --evm-bin="${{ github.workspace }}/bin/evm" --from Shanghai --until EIP6800Transition --output=../fixtures-${{ matrix.test-type }} -v -m blockchain_test -n auto
           fi
         shell: bash
 

--- a/.github/workflows/spec-tests-branch.yml
+++ b/.github/workflows/spec-tests-branch.yml
@@ -61,17 +61,14 @@ jobs:
 
       - name: Clone execution-spec-tests and fill tests
         run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
           git clone https://github.com/${{ env.EEST_USER }}/execution-spec-tests -b ${{ env.EEST_BRANCH }}
           cd execution-spec-tests
-          python3 -m venv venv
-          . venv/bin/activate
-          pip install --upgrade pip
-          pip install -e ".[docs,lint,test]"
-          solc-select use 0.8.24 --always-install
+          uv sync
           if [ "${{ matrix.test-type }}" == "genesis" ]; then
-            fill --fork Verkle --output=../fixtures-${{ matrix.test-type }} -v -m blockchain_test -n auto
+            uv run fill --fork Verkle --output=../fixtures-${{ matrix.test-type }} -v -m blockchain_test -n auto
           else
-            fill --from Shanghai --until EIP6800Transition --output=../fixtures-${{ matrix.test-type }} -v -m blockchain_test -n auto
+            uv run fill --from Shanghai --until EIP6800Transition --output=../fixtures-${{ matrix.test-type }} -v -m blockchain_test -n auto
           fi
         shell: bash
 
@@ -107,12 +104,9 @@ jobs:
 
       - name: Clone execution-spec-tests and consume tests
         run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
           git clone https://github.com/${{ env.EEST_USER }}/execution-spec-tests -b ${{ env.EEST_BRANCH }}
           cd execution-spec-tests
-          python3 -m venv venv
-          . venv/bin/activate
-          pip install --upgrade pip
-          pip install -e ".[docs,lint,test]"
-          solc-select use 0.8.24 --always-install
-          consume direct --input=../fixtures-${{ matrix.test-type }} -n auto
+          uv sync
+          uv run consume direct --input=../fixtures-${{ matrix.test-type }} -n auto
         shell: bash

--- a/.github/workflows/spec-tests-branch.yml
+++ b/.github/workflows/spec-tests-branch.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Clone execution-spec-tests and fill tests
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          git clone https://github.com/${{ env.EEST_USER }}/execution-spec-tests -b ${{ env.EEST_BRANCH }}
+          git clone https://github.com/${{ env.EEST_USER }}/execution-spec-tests -b ${{ env.EEST_BRANCH }} --depth 1
           cd execution-spec-tests
           uv sync
           if [ "${{ matrix.test-type }}" == "genesis" ]; then

--- a/.github/workflows/stable-spec-tests.yml
+++ b/.github/workflows/stable-spec-tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master, kaustinen-with-shapella]
+    branches: [master, kaustinen-with-shapella, jsign-witness-fix]
   workflow_dispatch:
 
 env:
@@ -71,13 +71,9 @@ jobs:
           extract: true
       - name: Clone execution-spec-tests and consume tests
         run: |
-          git clone https://github.com/ethereum/execution-spec-tests
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          git clone https://github.com/ethereum/execution-spec-tests  -b ${{ env.FIXTURES_TAG }} --depth 1
           cd execution-spec-tests
-          git checkout 250a064ba38cd92cad02691f4f7c2ecbefedd954
-          python3 -m venv venv
-          . venv/bin/activate
-          pip install --upgrade pip
-          pip install -e ".[docs,lint,test]"
-          solc-select use 0.8.24 --always-install
-          consume direct --input=../fixtures -n auto
+          uv sync
+          uv run consume direct --input=../fixtures -n auto
         shell: bash

--- a/.github/workflows/stable-spec-tests.yml
+++ b/.github/workflows/stable-spec-tests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  FIXTURES_TAG: "verkle@v0.0.3"
+  FIXTURES_TAG: "verkle@v0.0.4"
 
 jobs:
   setup:

--- a/.github/workflows/stable-spec-tests.yml
+++ b/.github/workflows/stable-spec-tests.yml
@@ -75,5 +75,5 @@ jobs:
           git clone https://github.com/ethereum/execution-spec-tests  -b ${{ env.FIXTURES_TAG }} --depth 1
           cd execution-spec-tests
           uv sync
-          uv run consume direct --input=../fixtures -n auto
+          uv run consume direct --evm-bin="${{ github.workspace }}/bin/evm" --input=../fixtures -n auto
         shell: bash

--- a/.github/workflows/stable-spec-tests.yml
+++ b/.github/workflows/stable-spec-tests.yml
@@ -74,6 +74,5 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           git clone https://github.com/ethereum/execution-spec-tests  -b ${{ env.FIXTURES_TAG }} --depth 1
           cd execution-spec-tests
-          uv sync
           uv run consume direct --evm-bin="${{ github.workspace }}/bin/evm" --input=../fixtures -n auto
         shell: bash


### PR DESCRIPTION
Fix the CI to use `uv` and use `v0.0.4` tag for stable fixtures.