### PR TITLE
ci: stable fixtures target v0.0.5

### DIFF
--- a/.github/workflows/stable-spec-tests.yml
+++ b/.github/workflows/stable-spec-tests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  FIXTURES_TAG: "verkle@v0.0.4"
+  FIXTURES_TAG: "verkle@v0.0.5"
 
 jobs:
   setup:


### PR DESCRIPTION
This PR updates our stable-fixtures CI to now target v0.0.5 which now must pass.