### PR TITLE
remove ineffectual check

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -499,12 +499,6 @@ func gasSelfdestruct(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 		}
 	}
 
-	if evm.chainRules.IsVerkle {
-		// TODO turn this into a panic (when we are sure this method
-		// will never execute when verkle is enabled)
-		log.Warn("verkle witness accumulation not supported for selfdestruct")
-	}
-
 	if !evm.StateDB.HasSelfDestructed(contract.Address()) {
 		evm.StateDB.AddRefund(params.SelfdestructRefundGas)
 	}


### PR DESCRIPTION
This is a leftover going back to 2021. master geth has greatly changed, and so has the verkle branch, this warning no longer makes sense.