### PR TITLE
truncate large balances

### DIFF
--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -164,8 +164,8 @@ func (t *VerkleTrie) UpdateAccount(addr common.Address, acc *types.StateAccount,
 	// the extra values. This happens in devmode, where
 	// 0xff**32 is allocated to the developer account.
 	balanceBytes := acc.Balance.Bytes()
-        // TODO: reduce the size of the allocation in devmode, then panic instead
-        // of truncating.
+	// TODO: reduce the size of the allocation in devmode, then panic instead
+	// of truncating.
 	if len(balanceBytes) > 16 {
 		balanceBytes = balanceBytes[16:]
 	}

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -164,6 +164,8 @@ func (t *VerkleTrie) UpdateAccount(addr common.Address, acc *types.StateAccount,
 	// the extra values. This happens in devmode, where
 	// 0xff**32 is allocated to the developer account.
 	balanceBytes := acc.Balance.Bytes()
+        // TODO: reduce the size of the allocation in devmode, then panic instead
+        // of truncating.
 	if len(balanceBytes) > 16 {
 		balanceBytes = balanceBytes[16:]
 	}

--- a/trie/verkle.go
+++ b/trie/verkle.go
@@ -160,7 +160,13 @@ func (t *VerkleTrie) UpdateAccount(addr common.Address, acc *types.StateAccount,
 
 	binary.BigEndian.PutUint32(basicData[utils.BasicDataCodeSizeOffset-1:], uint32(codeLen))
 	binary.BigEndian.PutUint64(basicData[utils.BasicDataNonceOffset:], acc.Nonce)
+	// Because the balance is a max of 16 bytes, truncate
+	// the extra values. This happens in devmode, where
+	// 0xff**32 is allocated to the developer account.
 	balanceBytes := acc.Balance.Bytes()
+	if len(balanceBytes) > 16 {
+		balanceBytes = balanceBytes[16:]
+	}
 	copy(basicData[32-len(balanceBytes):], balanceBytes[:])
 	values[utils.BasicDataLeafKey] = basicData[:]
 	values[utils.CodeHashLeafKey] = acc.CodeHash[:]


### PR DESCRIPTION
Large balances (>16 bytes) will overwrite the nonce in the basic data leaf. While this can not happen on mainnet, owing to the amount issued, it happens in devmode. This means the nonce will be overwritten with the balance, which is incorrect.

This PR truncates the balance if it's above that threshold.