### PR TITLE
types: fix json field name for execution witness parent state root

### DIFF
--- a/.github/workflows/stable-spec-tests.yml
+++ b/.github/workflows/stable-spec-tests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  FIXTURES_TAG: "verkle@v0.0.7-alpha-4"
+  FIXTURES_TAG: "verkle@v0.0.7-alpha-5"
 
 jobs:
   setup:

--- a/.github/workflows/stable-spec-tests.yml
+++ b/.github/workflows/stable-spec-tests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  FIXTURES_TAG: "verkle@v0.0.7-alpha-5"
+  FIXTURES_TAG: "verkle@v0.0.7-alpha-8"
 
 jobs:
   setup:

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -69,7 +69,7 @@ type ExecutionResult struct {
 	// Verkle witness
 	VerkleProof *verkle.VerkleProof `json:"verkleProof,omitempty"`
 	StateDiff   verkle.StateDiff    `json:"stateDiff,omitempty"`
-	ParentRoot  common.Hash         `json:"parentRoot,omitempty"`
+	ParentRoot  common.Hash         `json:"parentStateRoot,omitempty"`
 
 	// Values to test the verkle conversion
 	CurrentAccountAddress *common.Address `json:"currentConversionAddress,omitempty" gencodec:"optional"`

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -133,18 +133,18 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 		return fmt.Errorf("invalid merkle root (remote: %x local: %x) dberr: %w", header.Root, root, statedb.Error())
 	}
 	if blockEw := block.ExecutionWitness(); blockEw != nil {
-		parent := v.bc.GetHeaderByNumber(header.Number.Uint64() - 1)
+		parent := v.bc.GetBlockByHash(header.ParentHash)
 		if parent == nil {
 			return fmt.Errorf("nil parent header for block %d", header.Number)
 		}
-		stateDiff, proof, err := beacon.BuildVerkleProof(header, statedb, parent.Root)
+		stateDiff, proof, err := beacon.BuildVerkleProof(header, statedb, parent.Root())
 		if err != nil {
 			return fmt.Errorf("error building verkle proof: %w", err)
 		}
 		ew := types.ExecutionWitness{
 			StateDiff:       stateDiff,
 			VerkleProof:     proof,
-			ParentStateRoot: parent.Root,
+			ParentStateRoot: parent.Root(),
 		}
 		if err := ew.Equal(blockEw); err != nil {
 			return fmt.Errorf("invalid execution witness: %v", err)

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -62,7 +62,7 @@ func (n *BlockNonce) UnmarshalText(input []byte) error {
 type ExecutionWitness struct {
 	StateDiff       verkle.StateDiff    `json:"stateDiff"`
 	VerkleProof     *verkle.VerkleProof `json:"verkleProof"`
-	ParentStateRoot common.Hash         `json:"parentRoot"`
+	ParentStateRoot common.Hash         `json:"parentStateRoot"`
 }
 
 func (ew *ExecutionWitness) Copy() *ExecutionWitness {


### PR DESCRIPTION
This PR fixes the new parent state root JSON field name in the witness to match what we get from CL. Additionally, we don't rely on canonical chain numbering to refer to the parent, which doesn't work in syncing mode.