### PR TITLE
ci: update stable fixtures version

### DIFF
--- a/.github/workflows/stable-spec-tests.yml
+++ b/.github/workflows/stable-spec-tests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  FIXTURES_TAG: "verkle@v0.0.7-alpha-8"
+  FIXTURES_TAG: "verkle@v0.0.7"
 
 jobs:
   setup:


### PR DESCRIPTION
This PR updates the version of stable-fixtures to the latest (official) v0.0.7.