### PR TITLE
ci: update stable tests to v0.0.8

### DIFF
--- a/.github/workflows/stable-spec-tests.yml
+++ b/.github/workflows/stable-spec-tests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  FIXTURES_TAG: "verkle@v0.0.7"
+  FIXTURES_TAG: "verkle@v0.0.8"
 
 jobs:
   setup:


### PR DESCRIPTION
This PR updates the stable fixtures to the newest version v0.0.8 which contains new test cases reproducing found bugs in other EL clients in devnet7.