### PR TITLE
blockhash: charge warm costs in witness

### DIFF
--- a/.github/workflows/stable-spec-tests.yml
+++ b/.github/workflows/stable-spec-tests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  FIXTURES_TAG: "verkle@v0.0.8"
+  FIXTURES_TAG: "verkle@v0.0.9-alpha-1"
 
 jobs:
   setup:

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -462,7 +462,7 @@ func getBlockHashFromContract(number uint64, statedb StateDB, witness *state.Acc
 	ringIndex := number % params.Eip2935BlockHashHistorySize
 	var pnum common.Hash
 	binary.BigEndian.PutUint64(pnum[24:], ringIndex)
-	statelessGas := witness.TouchSlotAndChargeGas(params.HistoryStorageAddress[:], pnum, false, availableGas, false)
+	statelessGas := witness.TouchSlotAndChargeGas(params.HistoryStorageAddress[:], pnum, false, availableGas, true)
 	return statedb.GetState(params.HistoryStorageAddress, pnum), statelessGas
 }
 


### PR DESCRIPTION
This PR fies a bug found by @lu-pinto while running the latest exec-spec-tests filled by geth.

Note: stabe-fixtures tests is expected to fail since this is a bug fix. "Fill" tests should not fail.