### PR TITLE
fix: charge stateless gas on jump

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -584,12 +584,14 @@ func opJump(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 		return nil, errStopToken
 	}
 	pos := scope.Stack.pop()
-	if !scope.Contract.validJumpdest(&pos) {
+	if interpreter.evm.chainRules.IsEIP4762 {
 		statelessGas, wanted := interpreter.evm.TxContext.Accesses.TouchCodeChunksRangeAndChargeGas(scope.Contract.CodeAddr[:], pos.Uint64(), 1, uint64(len(scope.Contract.Code)), false, scope.Contract.Gas)
 		scope.Contract.UseGas(statelessGas)
 		if statelessGas < wanted {
 			return nil, ErrOutOfGas
 		}
+	}
+	if !scope.Contract.validJumpdest(&pos) {
 		return nil, ErrInvalidJump
 	}
 	*pc = pos.Uint64() - 1 // pc will be increased by the interpreter loop
@@ -602,12 +604,14 @@ func opJumpi(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	}
 	pos, cond := scope.Stack.pop(), scope.Stack.pop()
 	if !cond.IsZero() {
-		if !scope.Contract.validJumpdest(&pos) {
+		if interpreter.evm.chainRules.IsEIP4762 {
 			statelessGas, wanted := interpreter.evm.TxContext.Accesses.TouchCodeChunksRangeAndChargeGas(scope.Contract.CodeAddr[:], pos.Uint64(), 1, uint64(len(scope.Contract.Code)), false, scope.Contract.Gas)
 			scope.Contract.UseGas(statelessGas)
 			if statelessGas < wanted {
 				return nil, ErrOutOfGas
 			}
+		}
+		if !scope.Contract.validJumpdest(&pos) {
 			return nil, ErrInvalidJump
 		}
 		*pc = pos.Uint64() - 1 // pc will be increased by the interpreter loop

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -584,7 +584,7 @@ func opJump(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 		return nil, errStopToken
 	}
 	pos := scope.Stack.pop()
-	if interpreter.evm.chainRules.IsEIP4762 {
+	if interpreter.evm.chainRules.IsEIP4762 && !scope.Contract.IsDeployment {
 		statelessGas, wanted := interpreter.evm.TxContext.Accesses.TouchCodeChunksRangeAndChargeGas(scope.Contract.CodeAddr[:], pos.Uint64(), 1, uint64(len(scope.Contract.Code)), false, scope.Contract.Gas)
 		scope.Contract.UseGas(statelessGas)
 		if statelessGas < wanted {
@@ -604,7 +604,7 @@ func opJumpi(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	}
 	pos, cond := scope.Stack.pop(), scope.Stack.pop()
 	if !cond.IsZero() {
-		if interpreter.evm.chainRules.IsEIP4762 {
+		if interpreter.evm.chainRules.IsEIP4762 && !scope.Contract.IsDeployment {
 			statelessGas, wanted := interpreter.evm.TxContext.Accesses.TouchCodeChunksRangeAndChargeGas(scope.Contract.CodeAddr[:], pos.Uint64(), 1, uint64(len(scope.Contract.Code)), false, scope.Contract.Gas)
 			scope.Contract.UseGas(statelessGas)
 			if statelessGas < wanted {


### PR DESCRIPTION
No check was made to see if the access witness was allocated when charging for an invalid jump.

I have changed it to execute the charge regardless. This is redundant with the interpreter's execution loop, but I think it's easier to read.