### PR TITLE
core/rawdb, core/state: polish the transition state implementation

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
-	"github.com/ethereum/go-ethereum/core/overlay"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -382,8 +381,6 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 	// Create the block witness and attach to block.
 	// This step needs to happen as late as possible to catch all access events.
 	if chain.Config().IsVerkle(header.Number, header.Time) {
-		// TODO(gballet) move this to the end of the overlay conversion function in a subsequent PR
-		statedb.Database().(*state.CachingDB).SaveTransitionState(header.Root, &overlay.TransitionState{Ended: true})
 		keys := statedb.AccessEvents().Keys()
 
 		// Open the pre-tree to prove the pre-state against

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -577,7 +577,6 @@ func GenerateVerkleChain(config *params.ChainConfig, parent *types.Block, engine
 
 func GenerateVerkleChainWithGenesis(genesis *Genesis, engine consensus.Engine, n int, gen func(int, *BlockGen)) (common.Hash, ethdb.Database, []*types.Block, []types.Receipts, []*verkle.VerkleProof, []verkle.StateDiff) {
 	db := rawdb.NewMemoryDatabase()
-	saveVerkleTransitionStatusAtVerlkeGenesis(db)
 	cacheConfig := DefaultCacheConfigWithScheme(rawdb.PathScheme)
 	cacheConfig.SnapshotLimit = 0
 	triedb := triedb.NewDatabase(db, cacheConfig.triedbConfig(true))

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -146,9 +146,6 @@ func hashAlloc(ga *types.GenesisAlloc, isVerkle bool) (common.Hash, error) {
 		emptyRoot = types.EmptyVerkleHash
 	}
 	db := rawdb.NewMemoryDatabase()
-	if isVerkle {
-		saveVerkleTransitionStatusAtVerlkeGenesis(db)
-	}
 	statedb, err := state.New(emptyRoot, state.NewDatabase(triedb.NewDatabase(db, config), nil))
 	if err != nil {
 		return common.Hash{}, err
@@ -280,22 +277,6 @@ func (o *ChainOverrides) apply(cfg *params.ChainConfig) error {
 	return cfg.CheckConfigForkOrder()
 }
 
-// saveVerkleTransitionStatusAtVerlkeGenesis saves a conversion marker
-// representing a converted state, which is used in devnets that activate
-// verkle at genesis.
-func saveVerkleTransitionStatusAtVerlkeGenesis(db ethdb.Database) {
-	saveVerkleTransitionStatus(db, common.Hash{}, &overlay.TransitionState{Ended: true})
-}
-
-func saveVerkleTransitionStatus(db ethdb.Database, root common.Hash, ts *overlay.TransitionState) {
-	enc, err := rlp.EncodeToBytes(ts)
-	if err != nil {
-		log.Error("failed to encode transition state", "err", err)
-		return
-	}
-	rawdb.WriteVerkleTransitionState(db, root, enc)
-}
-
 // SetupGenesisBlock writes or updates the genesis block in db.
 // The block that will be used is:
 //
@@ -318,11 +299,6 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	// config attached.
 	if genesis != nil && genesis.Config == nil {
 		return nil, common.Hash{}, nil, errGenesisNoConfig
-	}
-	// In case of verkle-at-genesis, we need to ensure that the conversion
-	// markers are indicating that the conversion has completed.
-	if genesis != nil && genesis.Config.VerkleTime != nil && *genesis.Config.VerkleTime == genesis.Timestamp {
-		saveVerkleTransitionStatusAtVerlkeGenesis(db)
 	}
 	// Commit the genesis if the database is empty
 	ghash := rawdb.ReadCanonicalHash(db, 0)
@@ -572,9 +548,6 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 	if err != nil {
 		return nil, err
 	}
-	if g.IsVerkle() {
-		saveVerkleTransitionStatus(db, block.Root(), &overlay.TransitionState{Ended: true})
-	}
 	batch := db.NewBatch()
 	rawdb.WriteGenesisStateSpec(batch, block.Hash(), blob)
 	rawdb.WriteBlock(batch, block)
@@ -584,6 +557,12 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 	rawdb.WriteHeadFastBlockHash(batch, block.Hash())
 	rawdb.WriteHeadHeaderHash(batch, block.Hash())
 	rawdb.WriteChainConfig(batch, block.Hash(), config)
+
+	// In case of verkle-at-genesis, we need to ensure that the conversion
+	// markers are indicating that the conversion has completed.
+	if g.IsVerkle() {
+		overlay.StoreTransitionState(batch, block.Root(), &overlay.TransitionState{Ended: true})
+	}
 	return block, batch.Write()
 }
 

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -313,7 +313,6 @@ func TestVerkleGenesisCommit(t *testing.T) {
 	}
 
 	db := rawdb.NewMemoryDatabase()
-	saveVerkleTransitionStatusAtVerlkeGenesis(db)
 	triedb := triedb.NewDatabase(db, triedb.VerkleDefaults)
 	block := genesis.MustCommit(db, triedb)
 	if !bytes.Equal(block.Root().Bytes(), expected) {

--- a/core/overlay/state_transition.go
+++ b/core/overlay/state_transition.go
@@ -16,22 +16,51 @@
 
 package overlay
 
-import "github.com/ethereum/go-ethereum/common"
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/rlp"
+)
 
-// TransitionState is a structure that holds the progress markers of the
-// translation process.
+// TransitionState represents the progress of the Verkle transition process,
+// tracking which parts of the legacy MPT-based state have already been
+// migrated to the Verkle-based state.
 type TransitionState struct {
-	CurrentAccountAddress *common.Address `rlp:"nil"` // addresss of the last translated account
-	CurrentSlotHash       common.Hash     // hash of the last translated storage slot
-	CurrentPreimageOffset uint64          // next byte to read from the preimage file
-	Started, Ended        bool
+	// CurrentAccountHash is the hash of the next account to be migrated
+	// from the MPT state to the Verkle state.
+	CurrentAccountHash common.Hash
 
-	// Mark whether the storage for an account has been processed. This is useful if the
-	// maximum number of leaves of the conversion is reached before the whole storage is
-	// processed.
+	// CurrentSlotHash is the hash of the next storage slot (within the
+	// current account) to be migrated from the MPT state to the Verkle state.
+	// This field is irrelevant if StorageProcessed is true, indicating that
+	// all storage slots for the current account have already been migrated.
+	CurrentSlotHash common.Hash
+
+	// StorageProcessed indicates whether all storage slots for the current
+	// account have been fully migrated. This is useful in cases where the
+	// transition was interrupted before all state entries were processed
+	// (e.g., due to a configured migration step limit).
 	StorageProcessed bool
 
-	BaseRoot common.Hash // hash of the last read-only MPT base tree
+	// CurrentPreimageOffset is the byte offset in the preimage file from
+	// which the migration should resume.
+	CurrentPreimageOffset uint64
+
+	// Started is true if the transition process has begun. Note that the
+	// transition is considered started only after the MPT state referenced
+	// by BaseRoot has been finalized.
+	Started bool
+
+	// Ended is true if the transition process has completed, meaning the entire
+	// MPT-based state has been fully migrated. When true, the complete Ethereum
+	// state is available in the Verkle state, and constructing a mixed state
+	// view is no longer necessary.
+	Ended bool
+
+	// BaseRoot is the MPT root hash of the read-only base state, the original
+	// state prior to Verkle activation.
+	BaseRoot common.Hash
 }
 
 // InTransition returns true if the translation process is in progress.
@@ -44,20 +73,51 @@ func (ts *TransitionState) Transitioned() bool {
 	return ts != nil && ts.Ended
 }
 
-// Copy returns a deep copy of the TransitionState object.
-func (ts *TransitionState) Copy() *TransitionState {
-	ret := &TransitionState{
-		Started:               ts.Started,
-		Ended:                 ts.Ended,
-		CurrentSlotHash:       ts.CurrentSlotHash,
-		CurrentPreimageOffset: ts.CurrentPreimageOffset,
-		StorageProcessed:      ts.StorageProcessed,
+// LogAttrs returns a list of attributes for logging purpose.
+func (ts *TransitionState) LogAttrs(root common.Hash) []any {
+	var attrs []any
+	if !ts.Started {
+		attrs = append(attrs, "started", false)
+		return attrs
 	}
-
-	if ts.CurrentAccountAddress != nil {
-		ret.CurrentAccountAddress = &common.Address{}
-		copy(ret.CurrentAccountAddress[:], ts.CurrentAccountAddress[:])
+	if ts.Ended {
+		attrs = append(attrs, "ended", true)
+		return attrs
 	}
+	attrs = append(attrs, []interface{}{"root", root, "base", ts.BaseRoot}...)
 
-	return ret
+	if ts.StorageProcessed {
+		attrs = append(attrs, []interface{}{"at", ts.CurrentAccountHash}...)
+	} else {
+		attrs = append(attrs, []interface{}{
+			"in", ts.CurrentAccountHash,
+			"at", ts.CurrentSlotHash,
+		}...)
+	}
+	return attrs
+}
+
+// LoadTransitionState retrieves the Verkle transition state associated with
+// the given state root hash from the database.
+func LoadTransitionState(db ethdb.KeyValueReader, root common.Hash) (*TransitionState, error) {
+	data := rawdb.ReadVerkleTransitionState(db, root)
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var ts TransitionState
+	if err := rlp.DecodeBytes(data, &ts); err != nil {
+		return nil, err
+	}
+	return &ts, nil
+}
+
+// StoreTransitionState serializes and writes the provided Verkle transition state
+// to the database with the given state root hash.
+func StoreTransitionState(db ethdb.KeyValueWriter, root common.Hash, ts *TransitionState) error {
+	data, err := rlp.EncodeToBytes(ts)
+	if err != nil {
+		return err
+	}
+	rawdb.WriteVerkleTransitionState(db, root, data)
+	return nil
 }

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -174,16 +174,3 @@ func UpdateUncleanShutdownMarker(db ethdb.KeyValueStore) {
 		log.Warn("Failed to write unclean-shutdown marker", "err", err)
 	}
 }
-
-// ReadTransitionStatus retrieves the eth2 transition status from the database
-func ReadTransitionStatus(db ethdb.KeyValueReader) []byte {
-	data, _ := db.Get(transitionStatusKey)
-	return data
-}
-
-// WriteTransitionStatus stores the eth2 transition status to the database
-func WriteTransitionStatus(db ethdb.KeyValueWriter, data []byte) {
-	if err := db.Put(transitionStatusKey, data); err != nil {
-		log.Crit("Failed to store the eth2 transition status", "err", err)
-	}
-}

--- a/core/rawdb/accessors_overlay.go
+++ b/core/rawdb/accessors_overlay.go
@@ -19,12 +19,18 @@ package rawdb
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
 )
 
-func ReadVerkleTransitionState(db ethdb.KeyValueReader, hash common.Hash) ([]byte, error) {
-	return db.Get(transitionStateKey(hash))
+// ReadVerkleTransitionState reads the verkle transition data from the database.
+func ReadVerkleTransitionState(db ethdb.KeyValueReader, hash common.Hash) []byte {
+	data, _ := db.Get(transitionStateKey(hash))
+	return data
 }
 
-func WriteVerkleTransitionState(db ethdb.KeyValueWriter, hash common.Hash, state []byte) error {
-	return db.Put(transitionStateKey(hash), state)
+// WriteVerkleTransitionState writes the verkle transition data into the database.
+func WriteVerkleTransitionState(db ethdb.KeyValueWriter, hash common.Hash, state []byte) {
+	if err := db.Put(transitionStateKey(hash), state); err != nil {
+		log.Crit("Failed to write the verkle transition state", "hash", hash, "err", err)
+	}
 }

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -566,7 +566,7 @@ var knownMetadataKeys = [][]byte{
 	snapshotGeneratorKey, snapshotRecoveryKey, txIndexTailKey, fastTxLookupLimitKey,
 	uncleanShutdownKey, badBlockKey, transitionStatusKey, skeletonSyncStatusKey,
 	persistentStateIDKey, trieJournalKey, snapshotSyncStatusKey, snapSyncStatusFlagKey,
-	filterMapsRangeKey,
+	filterMapsRangeKey, verkleTransitionStatePrefix,
 }
 
 // printChainMetadata prints out chain metadata to stderr.

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -91,7 +91,7 @@ var (
 	uncleanShutdownKey = []byte("unclean-shutdown") // config prefix for the db
 
 	// transitionStatusKey tracks the eth2 transition status.
-	transitionStatusKey = []byte("eth2-transition")
+	transitionStatusKey = []byte("eth2-transition") // deprecated!
 
 	// snapSyncStatusFlagKey flags that status of snap sync.
 	snapSyncStatusFlagKey = []byte("SnapSyncStatus")
@@ -149,7 +149,7 @@ var (
 	preimageMissCounter = metrics.NewRegisteredCounter("db/preimage/miss", nil)
 
 	// Verkle transition information
-	VerkleTransitionStatePrefix = []byte("verkle-transition-state-")
+	verkleTransitionStatePrefix = []byte("verkle-transition-state-")
 )
 
 // LegacyTxLookupEntry is the legacy TxLookupEntry definition with some unnecessary
@@ -366,7 +366,7 @@ func filterMapBlockLVKey(number uint64) []byte {
 	return key
 }
 
-// transitionStateKey = transitionStatusKey + hash
+// transitionStateKey = verkleTransitionStatePrefix + hash
 func transitionStateKey(hash common.Hash) []byte {
-	return append(VerkleTransitionStatePrefix, hash.Bytes()...)
+	return append(verkleTransitionStatePrefix, hash.Bytes()...)
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -18,7 +18,6 @@ package state
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
@@ -29,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/trie/trienode"
 	"github.com/ethereum/go-ethereum/trie/utils"
@@ -157,19 +155,19 @@ type CachingDB struct {
 	pointCache    *utils.PointCache
 
 	// Transition-specific fields
-	TransitionStatePerRoot lru.BasicLRU[common.Hash, *overlay.TransitionState]
+	transitions *lru.Cache[common.Hash, *overlay.TransitionState]
 }
 
 // NewDatabase creates a state database with the provided data sources.
 func NewDatabase(triedb *triedb.Database, snap *snapshot.Tree) *CachingDB {
 	return &CachingDB{
-		disk:                   triedb.Disk(),
-		triedb:                 triedb,
-		snap:                   snap,
-		codeCache:              lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
-		codeSizeCache:          lru.NewCache[common.Hash, int](codeSizeCacheSize),
-		pointCache:             utils.NewPointCache(pointCacheSize),
-		TransitionStatePerRoot: lru.NewBasicLRU[common.Hash, *overlay.TransitionState](1000),
+		disk:          triedb.Disk(),
+		triedb:        triedb,
+		snap:          snap,
+		codeCache:     lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
+		codeSizeCache: lru.NewCache[common.Hash, int](codeSizeCacheSize),
+		pointCache:    utils.NewPointCache(pointCacheSize),
+		transitions:   lru.NewCache[common.Hash, *overlay.TransitionState](1000),
 	}
 }
 
@@ -201,10 +199,9 @@ func (db *CachingDB) Reader(stateRoot common.Hash) (Reader, error) {
 			readers = append(readers, newFlatReader(reader)) // state reader is optional
 		}
 	}
-	ts := db.LoadTransitionState(stateRoot)
 	// Set up the trie reader, which is expected to always be available
 	// as the gatekeeper unless the state is corrupted.
-	tr, err := newTrieReader(stateRoot, db.triedb, db.pointCache, ts)
+	tr, err := newTrieReader(stateRoot, db.triedb, db.pointCache)
 	if err != nil {
 		return nil, err
 	}
@@ -219,11 +216,7 @@ func (db *CachingDB) Reader(stateRoot common.Hash) (Reader, error) {
 
 // OpenTrie opens the main account trie at a specific root hash.
 func (db *CachingDB) OpenTrie(root common.Hash) (Trie, error) {
-	ts := db.LoadTransitionState(root)
-	if ts.InTransition() {
-		panic("transition isn't supported yet")
-	}
-	if ts.Transitioned() {
+	if db.triedb.IsVerkle() {
 		return trie.NewVerkleTrie(root, db.triedb, db.pointCache)
 	}
 	tr, err := trie.NewStateTrie(trie.StateTrieID(root), db.triedb)
@@ -235,11 +228,10 @@ func (db *CachingDB) OpenTrie(root common.Hash) (Trie, error) {
 
 // OpenStorageTrie opens the storage trie of an account.
 func (db *CachingDB) OpenStorageTrie(stateRoot common.Hash, address common.Address, root common.Hash, self Trie) (Trie, error) {
-	ts := db.LoadTransitionState(stateRoot)
 	// In the verkle case, there is only one tree. But the two-tree structure
 	// is hardcoded in the codebase. So we need to return the same trie in this
 	// case.
-	if ts.InTransition() || ts.Transitioned() {
+	if db.triedb.IsVerkle() {
 		return self, nil
 	}
 	tr, err := trie.NewStateTrie(trie.StorageTrieID(stateRoot, crypto.Keccak256Hash(address.Bytes()), root), db.triedb)
@@ -292,76 +284,37 @@ func mustCopyTrie(t Trie) Trie {
 	}
 }
 
-// SaveTransitionState saves the transition state to the cache and commits
-// it to the database if it's not already in the cache.
-func (db *CachingDB) SaveTransitionState(root common.Hash, ts *overlay.TransitionState) {
-	if ts == nil {
-		panic("nil transition state")
+// SaveTransitionState stores the given transition state associated with the
+// specified root. It writes the state to persistent storage and also updates
+// the in-memory cache.
+func (db *CachingDB) SaveTransitionState(root common.Hash, ts *overlay.TransitionState) error {
+	if err := overlay.StoreTransitionState(db.disk, root, ts); err != nil {
+		return err
 	}
-
-	enc, err := rlp.EncodeToBytes(ts)
-	if err != nil {
-		log.Error("failed to encode transition state", "err", err)
-		return
-	}
-
-	if !db.TransitionStatePerRoot.Contains(root) {
-		// Copy so that the address pointer isn't updated after
-		// it has been saved.
-		db.TransitionStatePerRoot.Add(root, ts.Copy())
-		rawdb.WriteVerkleTransitionState(db.TrieDB().Disk(), root, enc)
-	} else {
-		// Check that the state is consistent with what is in the cache,
-		// which is not strictly necessary but a good sanity check. Can
-		// be removed when the transition is stable.
-		cachedState, _ := db.TransitionStatePerRoot.Get(root)
-		if !reflect.DeepEqual(cachedState, ts) {
-			fmt.Println("transition state mismatch", "cached state", cachedState, "new state", ts)
-			panic("transition state mismatch")
-		}
-	}
-
-	log.Debug("saving transition state", "storage processed", ts.StorageProcessed, "addr", ts.CurrentAccountAddress, "slot hash", ts.CurrentSlotHash, "root", root, "ended", ts.Ended, "started", ts.Started)
+	db.transitions.Add(root, ts)
+	log.Debug("Saved transition state", ts.LogAttrs(root)...)
+	return nil
 }
 
-func (db *CachingDB) LoadTransitionState(root common.Hash) *overlay.TransitionState {
-	// Try to get the transition state from the cache and
-	// the DB if it's not there.
-	ts, ok := db.TransitionStatePerRoot.Get(root)
-	if !ok {
-		// Not in the cache, try getting it from the DB
-		data, _ := rawdb.ReadVerkleTransitionState(db.TrieDB().Disk(), root)
-
-		// if a state could be read from the db, attempt to decode it
-		if len(data) > 0 {
-			var newts overlay.TransitionState
-
-			// Decode transition state
-			err := rlp.DecodeBytes(data, &newts)
-			if err != nil {
-				log.Error("failed to decode transition state", "err", err)
-				return nil
-			}
-			ts = &newts
-		}
-
-		// Fallback that should only happen before the transition
-		if ts == nil {
-			// Initialize the first transition state, with the "ended"
-			// field set to true if the database was created
-			// as a verkle database.
-			log.Debug("no transition state found, starting fresh", "is verkle", db.triedb.IsVerkle())
-			// Start with a fresh state
-			ts = &overlay.TransitionState{Ended: db.triedb.IsVerkle()}
-		}
-
-		db.TransitionStatePerRoot.Add(root, ts)
+// LoadTransitionState loads the transition state associated with the specified
+// root. The transition state may be unavailable in the following cases:
+//
+// - Verkle has not been activated yet (the legacy MPT state should be used)
+// - The first block immediately since Verkle activation
+// - The block after the Verkle transition has completed
+func (db *CachingDB) LoadTransitionState(root common.Hash) (*overlay.TransitionState, error) {
+	ts, ok := db.transitions.Get(root)
+	if ok {
+		return ts, nil
 	}
-
-	// Copy so that the CurrentAddress pointer in the map
-	// doesn't get overwritten.
-	// db.CurrentTransitionState = ts.Copy()
-
-	log.Debug("loaded transition state", "storage processed", ts.StorageProcessed, "addr", ts.CurrentAccountAddress, "slot hash", ts.CurrentSlotHash, "root", root, "ended", ts.Ended, "started", ts.Started)
-	return ts
+	ts, err := overlay.LoadTransitionState(db.disk, root)
+	if err != nil {
+		return nil, err
+	}
+	if ts == nil {
+		log.Debug("Transition state is not found", "root", root)
+		return nil, nil
+	}
+	log.Debug("Loaded transition state", ts.LogAttrs(root)...)
+	return ts, nil
 }

--- a/core/state/reader.go
+++ b/core/state/reader.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
-	"github.com/ethereum/go-ethereum/core/overlay"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -208,12 +207,12 @@ type trieReader struct {
 
 // trieReader constructs a trie reader of the specific state. An error will be
 // returned if the associated trie specified by root is not existent.
-func newTrieReader(root common.Hash, db *triedb.Database, cache *utils.PointCache, ts *overlay.TransitionState) (*trieReader, error) {
+func newTrieReader(root common.Hash, db *triedb.Database, cache *utils.PointCache) (*trieReader, error) {
 	var (
 		tr  Trie
 		err error
 	)
-	if !ts.Transitioned() && !ts.InTransition() {
+	if !db.IsVerkle() {
 		tr, err = trie.NewStateTrie(trie.StateTrieID(root), db)
 	} else {
 		tr, err = trie.NewVerkleTrie(root, db, cache)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -181,7 +181,7 @@ func New(root common.Hash, db Database) (*StateDB, error) {
 		accessList:           newAccessList(),
 		transientStorage:     newTransientStorage(),
 	}
-	if tr.IsVerkle() {
+	if db.TrieDB().IsVerkle() {
 		sdb.accessEvents = NewAccessEvents(db.PointCache())
 	}
 	return sdb, nil


### PR DESCRIPTION
In this pull request, several changes have been made:

(a) Replaced `CurrentAccountAddress *common.Address` with `CurrentAccountHash common.Hash`

Managing a nullable pointer adds unnecessary complexity. This change simplifies the 
logic by replacing the pointer with a value based flag:
- Previously: `CurrentAccountAddress == nil` indicated that no account had been migrated yet.
- Now: `CurrentAccountHash == common.Hash{}` serves the same purpose.

This approach is already used in `CurrentSlotHash`, so this change aligns the handling of both fields.

(b) Removed `LoadTransitionState` call sites from the trie reader

The current usage of `LoadTransitionState` in the trie reader is not correct. We should consider 
five different scenarios:

```
(a) TransitionState(root) is not found:
Verkle is not activated yet => use merkle tree

(b) TransitionState(root) is not found and ChainConfig.IsVerkle(blockNumber, blockTime) is true:
The first Verkle block at the boundary => use overlay tree

(c) ChainConfig.IsVerkle(blockNumber, blockTime) is true and TransitionState(root).Started is false:
The verkle block before the  migration => use overlay tree

(d) ChainConfig.IsVerkle(blockNumber, blockTime) is true and TransitionState(root).Started is true:
The verkle block during the migration => use overlay tree

(e)  ChainConfig.IsVerkle(blockNumber, blockTime) is true and TransitionState(root).Ended is true
Verkle transition completes => use verkle tree
```

However, in your implementation, e.g., in the code below, it's wrong. As you mentioned,
the migration is only started if the base merkle state if finalized. `!ts.InTransition() && !ts.Transitioned()`
can refer to the situation that Verkle has been activated but the migration is not. In this
case, Overlay tree should be used instead of Merkle here. We should separate this part
of logic into a following PR.

```go
// OpenStorageTrie opens the storage trie of an account.
func (db *CachingDB) OpenStorageTrie(stateRoot common.Hash, address common.Address, root common.Hash, self Trie) (Trie, error) {
	ts := db.LoadTransitionState(stateRoot)
	// In the verkle case, there is only one tree. But the two-tree structure
	// is hardcoded in the codebase. So we need to return the same trie in this
	// case.
	if ts.InTransition() || ts.Transitioned() {
		return self, nil
	}
	tr, err := trie.NewStateTrie(trie.StorageTrieID(stateRoot, crypto.Keccak256Hash(address.Bytes()), root), db.triedb)
	if err != nil {
		return nil, err
	}
	return tr, nil
}
```