### PR TITLE
all: dump trie journal into file

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1674,6 +1674,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.IsSet(CacheFlag.Name) || ctx.IsSet(CacheSnapshotFlag.Name) {
 		cfg.SnapshotCache = ctx.Int(CacheFlag.Name) * ctx.Int(CacheSnapshotFlag.Name) / 100
 	}
+	if journal := ctx.String(CacheTrieJournalFlag.Name); journal != "" {
+		cfg.TrieJournal = stack.ResolvePath(journal)
+	}
 	if ctx.IsSet(CacheLogSizeFlag.Name) {
 		cfg.FilterLogCacheSize = ctx.Int(CacheLogSizeFlag.Name)
 	}
@@ -2178,6 +2181,9 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 		Preimages:           ctx.Bool(CachePreimagesFlag.Name),
 		StateScheme:         scheme,
 		StateHistory:        ctx.Uint64(StateHistoryFlag.Name),
+	}
+	if journal := ctx.String(CacheTrieJournalFlag.Name); journal != "" {
+		cache.TrieJournal = stack.ResolvePath(journal)
 	}
 	if cache.TrieDirtyDisabled && !cache.Preimages {
 		cache.Preimages = true

--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -63,6 +63,7 @@ var (
 	CacheTrieJournalFlag = &cli.StringFlag{
 		Name:     "cache.trie.journal",
 		Usage:    "Disk journal directory for trie cache to survive node restarts",
+		Value:    "trie-disklayer.rlp",
 		Category: flags.DeprecatedCategory,
 	}
 	CacheTrieRejournalFlag = &cli.DurationFlag{

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -166,6 +166,7 @@ type CacheConfig struct {
 	Preimages           bool          // Whether to store preimage of trie key to the disk
 	StateHistory        uint64        // Number of blocks from head whose state histories are reserved.
 	StateScheme         string        // Scheme used to store ethereum states and merkle tree nodes on top
+	TrieJournal         string        // Path used to store the trie pathdb journal
 
 	SnapshotNoBuild bool // Whether the background generation is allowed
 	SnapshotWait    bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
@@ -196,6 +197,7 @@ func (c *CacheConfig) triedbConfig(isVerkle bool) *triedb.Config {
 			// for flushing both trie data and state data to disk. The config name
 			// should be updated to eliminate the confusion.
 			WriteBufferSize: c.TrieDirtyLimit * 1024 * 1024,
+			Journal:     c.TrieJournal,
 		}
 	}
 	return config

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -205,6 +205,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			StateHistory:        config.StateHistory,
 			StateScheme:         scheme,
 			ChainHistoryMode:    config.HistoryMode,
+			TrieJournal:         config.TrieJournal,
 		}
 	)
 	if config.VMTrace != "" {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -126,6 +126,7 @@ type Config struct {
 	TrieTimeout    time.Duration
 	SnapshotCache  int
 	Preimages      bool
+	TrieJournal    string
 
 	// This is the number of blocks for which logs will be cached in the filter system.
 	FilterLogCacheSize int

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -120,6 +120,7 @@ type Config struct {
 	WriteBufferSize int    // Maximum memory allowance (in bytes) for write buffer
 	ReadOnly        bool   // Flag whether the database is opened in read only mode
 	SnapshotNoBuild bool   // Flag Whether the background generation is allowed
+	Journal         string
 }
 
 // sanitize checks the provided user configurations and changes anything that's

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -51,11 +52,24 @@ const journalVersion uint64 = 3
 
 // loadJournal tries to parse the layer journal from the disk.
 func (db *Database) loadJournal(diskRoot common.Hash) (layer, error) {
-	journal := rawdb.ReadTrieJournal(db.diskdb)
-	if len(journal) == 0 {
-		return nil, errMissJournal
+	var reader io.Reader
+	if db.config.Journal != "" && common.FileExist(db.config.Journal) {
+		log.Info("Load pathdb disklayer journal", "path", db.config.Journal)
+		// If a journal file is specified, read it from there
+		f, err := os.OpenFile(db.config.Journal, os.O_RDONLY, 0644)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read journal file %s: %w", db.config.Journal, err)
+		}
+		defer f.Close()
+		reader = f
+	} else {
+		journal := rawdb.ReadTrieJournal(db.diskdb)
+		if len(journal) == 0 {
+			return nil, errMissJournal
+		}
+		reader = bytes.NewReader(journal)
 	}
-	r := rlp.NewStream(bytes.NewReader(journal), 0)
+	r := rlp.NewStream(reader, 0)
 
 	// Firstly, resolve the first element as the journal version
 	version, err := r.Uint64()
@@ -333,8 +347,20 @@ func (db *Database) Journal(root common.Hash) error {
 	if err := l.journal(journal); err != nil {
 		return err
 	}
+
 	// Store the journal into the database and return
-	rawdb.WriteTrieJournal(db.diskdb, journal.Bytes())
+	if db.config.Journal != "" {
+		file, err := os.OpenFile(db.config.Journal, os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			return fmt.Errorf("failed to open journal file %s: %w", db.config.Journal, err)
+		}
+		defer file.Close()
+		if _, err := file.Write(journal.Bytes()); err != nil {
+			return fmt.Errorf("failed to write journal file %s: %w", db.config.Journal, err)
+		}
+	} else {
+		rawdb.WriteTrieJournal(db.diskdb, journal.Bytes())
+	}
 
 	// Set the db in read only mode to reject all following mutations
 	db.readOnly = true

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -329,8 +329,21 @@ func (db *Database) Journal(root common.Hash) error {
 	if db.readOnly {
 		return errDatabaseReadOnly
 	}
+
+	var journal io.Writer
+	// Store the journal into the database and return
+	if db.config.Journal != "" {
+		file, err := os.OpenFile(db.config.Journal, os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			return fmt.Errorf("failed to open journal file %s: %w", db.config.Journal, err)
+		}
+		defer file.Close()
+		journal = file
+	} else {
+		journal = new(bytes.Buffer)
+	}
+
 	// Firstly write out the metadata of journal
-	journal := new(bytes.Buffer)
 	if err := rlp.Encode(journal, journalVersion); err != nil {
 		return err
 	}
@@ -349,21 +362,18 @@ func (db *Database) Journal(root common.Hash) error {
 	}
 
 	// Store the journal into the database and return
-	if db.config.Journal != "" {
-		file, err := os.OpenFile(db.config.Journal, os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			return fmt.Errorf("failed to open journal file %s: %w", db.config.Journal, err)
-		}
-		defer file.Close()
-		if _, err := file.Write(journal.Bytes()); err != nil {
-			return fmt.Errorf("failed to write journal file %s: %w", db.config.Journal, err)
-		}
+	var size int
+	if db.config.Journal == "" {
+		data := journal.(*bytes.Buffer)
+		size = data.Len()
+		rawdb.WriteTrieJournal(db.diskdb, data.Bytes())
 	} else {
-		rawdb.WriteTrieJournal(db.diskdb, journal.Bytes())
+		stat, _ := journal.(*os.File).Stat()
+		size = int(stat.Size())
 	}
 
 	// Set the db in read only mode to reject all following mutations
 	db.readOnly = true
-	log.Info("Persisted dirty state to disk", "size", common.StorageSize(journal.Len()), "elapsed", common.PrettyDuration(time.Since(start)))
+	log.Info("Persisted dirty state to disk", "size", common.StorageSize(size), "elapsed", common.PrettyDuration(time.Since(start)))
 	return nil
 }


### PR DESCRIPTION
After the bloating, the size of trie journal will reached into 4GB++, will exceed pebble's write bactch size(4GB), so after the geth stop, it will panic as below:

```
INFO [06-04|00:49:21.888] HTTP server stopped                      endpoint=[::]:8543
INFO [06-04|00:49:21.889] IPC endpoint closed                      url=/data/geth-dev/geth.ipc
INFO [06-04|00:49:21.889] Ethereum protocol stopped
INFO [06-04|00:49:21.889] Transaction pool stopped
INFO [06-04|00:49:23.669] Imported new potential chain segment     number=64 hash=745cbd..6e876d blocks=1 txs=0 mgas=0.000 elapsed=2.055s     mgasps=0.000 triediffs=5.89GiB    triedirty=0.00B
INFO [06-04|00:49:23.670] Persisting dirty state to disk           head=63 root=6ac6c8..71f7de layers=63
WARN [06-04|00:49:23.670] Error performing sealing work            err="blockchain is stopped"
panic: pebble: batch too large: >= 4.0GB

goroutine 1 [running]:
github.com/cockroachdb/pebble.(*Batch).grow(0xc06e685200?, 0xc000138908?)
        github.com/cockroachdb/pebble@v1.1.5/batch.go:1414 +0x12d
github.com/cockroachdb/pebble.(*Batch).prepareDeferredKeyValueRecord(0xc06e685200, 0xb, 0x120482415, 0x1)
        github.com/cockroachdb/pebble@v1.1.5/batch.go:592 +0x93
github.com/cockroachdb/pebble.(*Batch).SetDeferred(...)
        github.com/cockroachdb/pebble@v1.1.5/batch.go:726
github.com/cockroachdb/pebble.(*Batch).Set(0xc06e685200, {0x2f91bf0, 0xb, 0x2712?}, {0xc7c96b4000, 0x120482415, 0x80?}, 0x80?)
        github.com/cockroachdb/pebble@v1.1.5/batch.go:708 +0x3c
github.com/cockroachdb/pebble.(*DB).Set(0xc0005c1b08, {0x2f91bf0, 0xb, 0xb}, {0xc7c96b4000, 0x120482415, 0x200000000}, 0x319ecd4)
        github.com/cockroachdb/pebble@v1.1.5/db.go:608 +0xd2
github.com/ethereum/go-ethereum/ethdb/pebble.(*Database).Put(0x20?, {0x2f91bf0?, 0x7f1bb2504a38?, 0x217c148?}, {0xc7c96b4000?, 0x6e7340?, 0x319f7a0?})
        github.com/ethereum/go-ethereum/ethdb/pebble/pebble.go:388 +0x14c
github.com/ethereum/go-ethereum/core/rawdb.WriteTrieJournal({0x7f1b484a0940?, 0xc000686660?}, {0xc7c96b4000?, 0xc404fcba20?, 0xc30cf0ea80?})
        github.com/ethereum/go-ethereum/core/rawdb/accessors_state.go:154 +0x52
github.com/ethereum/go-ethereum/triedb/pathdb.(*Database).Journal(0xc00107bda0, {0x6a, 0xc6, 0xc8, 0x52, 0x51, 0x42, 0xd4, 0x8d, 0x2c, ...})
        github.com/ethereum/go-ethereum/triedb/pathdb/journal.go:337 +0x705
github.com/ethereum/go-ethereum/triedb.(*Database).Journal(0xc000878e10?, {0x6a, 0xc6, 0xc8, 0x52, 0x51, 0x42, 0xd4, 0x8d, 0x2c, ...})
        github.com/ethereum/go-ethereum/triedb/database.go:312 +0x3a
github.com/ethereum/go-ethereum/core.(*BlockChain).Stop(0xc0412eac08)
        github.com/ethereum/go-ethereum/core/blockchain.go:1237 +0x225
github.com/ethereum/go-ethereum/eth.(*Ethereum).Stop(0xc000530340)
        github.com/ethereum/go-ethereum/eth/backend.go:517 +0xc5
github.com/ethereum/go-ethereum/node.(*Node).stopServices(0xc0001b49a0, {0xc0413eb380, 0x3, 0x1000000020002?})
        github.com/ethereum/go-ethereum/node/node.go:291 +0xbf
github.com/ethereum/go-ethereum/node.(*Node).Close(0xc0001b49a0)
```

Here we try to save the journal into file to bypass this issue.