### PR TITLE
fix prefetcher issue

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -147,6 +147,9 @@ func (s *stateObject) getTrie() (Trie, error) {
 func (s *stateObject) getPrefetchedTrie() Trie {
 	// If there's nothing to meaningfully return, let the user figure it out by
 	// pulling the trie from disk.
+	if s.db.trie != nil && s.db.trie.IsVerkle() {
+		return nil
+	}
 	if (s.data.Root == types.EmptyRootHash && !s.db.db.TrieDB().IsVerkle()) || s.db.prefetcher == nil {
 		return nil
 	}


### PR DESCRIPTION
 - Fix an issue in which the prefetcher was creating a new MPT tree in verkle mode, based on the fact that `triedb.IsVerkle()` was false.
 - Also fix the tree bootstrapping in the reader
 - generally, no longer use `db.triedb.IsVerkle()` as it's only true if the db is used when starting in verkle mode.