### PR TITLE
cmd, core: wire --bintrie.groupdepth flag to SetEthConfig

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1729,6 +1729,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.IsSet(TrienodeHistoryFullValueCheckpointFlag.Name) {
 		cfg.TrienodeHistory = ctx.Int64(TrienodeHistoryFullValueCheckpointFlag.Name)
 	}
+	if ctx.IsSet(BinTrieGroupDepthFlag.Name) {
+		cfg.BinTrieGroupDepth = ctx.Int(BinTrieGroupDepthFlag.Name)
+	}
 	if ctx.IsSet(StateSchemeFlag.Name) {
 		cfg.StateScheme = ctx.String(StateSchemeFlag.Name)
 	}


### PR DESCRIPTION
## Summary

- Fix `--bintrie.groupdepth` CLI flag being ignored during normal geth node startup
- The flag was defined and registered but `SetEthConfig()` never read it into the config
- Only `MakeChain()` (used for import/export commands) read the flag
- Geth always used the default `groupDepth=8` regardless of the CLI flag value

## Root Cause

When state-actor generates databases with `groupDepth != 8` (e.g. `groupDepth=1`), the serialized nodes use the requested group depth format. But geth always read/wrote them with `groupDepth=8`, causing a serialization format mismatch. This manifested as `"missing trie node"` errors during block validation because nodes were stored at gd=1 boundaries (every depth) but resolved expecting gd=8 boundaries (every 8th depth).

## Fix

Add the flag read to `SetEthConfig`, matching the pattern used by all other trie configuration flags (`StateHistory`, `TrienodeHistory`, etc.).

## Test plan

- [x] Verified `NEWTRIE: groupDepth=1` is printed when `--bintrie.groupdepth=1` is passed (was showing `groupDepth=8` before fix)
- [x] Generated fresh gd=1 100MB DB with state-actor, ran spamoor ERC20 bloater against it: 0 BAD BLOCKS, reached block 73+ with no errors (was failing at block 5-14 before fix)
- [x] Pure geth dev mode with gd=1 (no state-actor DB) continues to work correctly