### PR TITLE
triedb/pathdb: fix TestTruncateOutOfRange after graceful head truncation change

### DIFF
--- a/triedb/pathdb/history_state_test.go
+++ b/triedb/pathdb/history_state_test.go
@@ -244,8 +244,8 @@ func TestTruncateOutOfRange(t *testing.T) {
 		target uint64
 		expErr error
 	}{
-		{0, head, nil}, // nothing to delete
-		{0, head + 1, errHeadTruncationOutOfRange},
+		{0, head, nil},     // nothing to delete
+		{0, head + 1, nil}, // gracefully handled after unclean shutdown
 		{0, tail - 1, errHeadTruncationOutOfRange},
 		{1, tail, nil}, // nothing to delete
 		{1, head + 1, errTailTruncationOutOfRange},


### PR DESCRIPTION
The streaming archival PR changed truncateFromHead to return nil (instead of an error) when nhead > ohead, gracefully handling unclean shutdowns where state history was not fully written. Update the test to expect nil for the head+1 case.