### PR TITLE
build: fix keeper build not using correct working directory

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -311,7 +311,7 @@ func doInstallKeeper(cmdline []string) {
 		args := slices.Clone(gobuild.Args)
 		args = append(args, "-o", executablePath(outputName))
 		args = append(args, ".")
-		build.MustRun(&exec.Cmd{Path: gobuild.Path, Args: args, Env: gobuild.Env})
+		build.MustRun(&exec.Cmd{Path: gobuild.Path, Args: args, Env: gobuild.Env, Dir: gobuild.Dir})
 	}
 }
 


### PR DESCRIPTION
The exec.Cmd created for each keeper target was missing the Dir field, causing the build to run from the repo root instead of ./cmd/keeper. This meant compilation errors in cmd/keeper were silently ignored.