### PR TITLE
trie/bintrie: pack group-blob depth offsets into 3 bits

### DIFF
--- a/trie/bintrie/binary_node_test.go
+++ b/trie/bintrie/binary_node_test.go
@@ -40,9 +40,10 @@ func TestSerializeDeserializeInternalNode(t *testing.T) {
 	s.root = rootRef
 
 	// Serialize the node — grouped format at groupDepth=1:
-	// [type(1)][groupDepth(1)][bitmap(1)][depths(2)][leftHash(32)][rightHash(32)] = 69 bytes.
-	// Both children are at depthOffset=groupDepth=1 (the bottom of the
-	// 1-level group), so the depths section is [0x01, 0x01].
+	// [type(1)][groupDepth(1)][bitmap(1)][depths(1)][leftHash(32)][rightHash(32)] = 68 bytes.
+	// Both children are at depthOffset=groupDepth=1 (the bottom of the 1-level
+	// group). Each depth is stored as (offset-1)=0 in 3 bits, so the two entries
+	// pack into a single byte 0x00.
 	serialized := s.serializeNode(rootRef, 1)
 
 	if serialized[0] != nodeTypeInternal {
@@ -52,7 +53,7 @@ func TestSerializeDeserializeInternalNode(t *testing.T) {
 		t.Errorf("Expected groupDepth byte to be 1, got %d", serialized[1])
 	}
 
-	expectedLen := NodeTypeBytes + 1 + 1 + 2 + 2*HashSize // type + groupDepth + bitmap + 2 depths + 2 hashes = 69
+	expectedLen := NodeTypeBytes + 1 + 1 + 1 + 2*HashSize // type + groupDepth + bitmap + packed depths + 2 hashes = 68
 	if len(serialized) != expectedLen {
 		t.Errorf("Expected serialized length to be %d, got %d", expectedLen, len(serialized))
 	}
@@ -63,11 +64,12 @@ func TestSerializeDeserializeInternalNode(t *testing.T) {
 	}
 
 	depthsStart := NodeTypeBytes + 1 + 1
-	if serialized[depthsStart] != 1 || serialized[depthsStart+1] != 1 {
-		t.Errorf("Expected depth bytes [1,1], got [%d,%d]", serialized[depthsStart], serialized[depthsStart+1])
+	// Two depth offsets of 1 → stored as (1-1)=0 each → packed byte 0x00.
+	if serialized[depthsStart] != 0x00 {
+		t.Errorf("Expected packed depth byte 0x00, got 0x%02x", serialized[depthsStart])
 	}
 
-	hashesStart := depthsStart + 2
+	hashesStart := depthsStart + 1
 	if !bytes.Equal(serialized[hashesStart:hashesStart+HashSize], leftHash[:]) {
 		t.Error("Left hash not found at expected position")
 	}

--- a/trie/bintrie/format_test.go
+++ b/trie/bintrie/format_test.go
@@ -178,7 +178,7 @@ func TestDecodeRejectsInvalidDepthOffset(t *testing.T) {
 		bitmap := make([]byte, bitmapSize)
 		bitmap[0] = 0x80 // bit at position 0
 		depths := make([]byte, packedDepthsLen(1))
-		putDepth3(depths, 0, depthOffset-1)
+		writeDepth(depths, 0, depthOffset-1)
 		blob := []byte{nodeTypeInternal, byte(groupDepth)}
 		blob = append(blob, bitmap...)
 		blob = append(blob, depths...)

--- a/trie/bintrie/format_test.go
+++ b/trie/bintrie/format_test.go
@@ -151,8 +151,8 @@ func TestDecodeRejectsNonCanonicalPosition(t *testing.T) {
 	blob := []byte{nodeTypeInternal, 5}
 	// bitmap[0] = bit at position 5 → 1 << (7-5) = 0x04
 	blob = append(blob, 0x04, 0x00, 0x00, 0x00)
-	// depths[0] = 2
-	blob = append(blob, 2)
+	// depths[0] = 2, packed as (2-1)=1 in 3 bits MSB-first → 0b001_00000 = 0x20
+	blob = append(blob, 0x20)
 	// hashes[0] = 32 zero bytes
 	blob = append(blob, make([]byte, HashSize)...)
 
@@ -166,18 +166,22 @@ func TestDecodeRejectsNonCanonicalPosition(t *testing.T) {
 	}
 }
 
-// TestDecodeRejectsInvalidDepthOffset covers depthOffset=0 (a present entry
-// must consume ≥1 bit of natural path) and depthOffset>groupDepth (the
-// entry would live below the group's bottom layer, impossible by
-// construction).
+// TestDecodeRejectsInvalidDepthOffset covers depthOffset>groupDepth (the entry
+// would live below the group's bottom layer, impossible by construction). The
+// old depthOffset=0 and depthOffset>MaxGroupDepth cases are gone: the 3-bit
+// field stores (offset-1) ∈ [0,7], so offset 0 and offset 9 are unrepresentable
+// and can no longer be hand-crafted into a blob. Only offset>groupDepth with
+// groupDepth<MaxGroupDepth remains encodable and must still be rejected.
 func TestDecodeRejectsInvalidDepthOffset(t *testing.T) {
 	makeBlob := func(groupDepth int, depthOffset uint8) []byte {
 		bitmapSize := bitmapSizeForDepth(groupDepth)
 		bitmap := make([]byte, bitmapSize)
 		bitmap[0] = 0x80 // bit at position 0
+		depths := make([]byte, packedDepthsLen(1))
+		putDepth3(depths, 0, depthOffset-1)
 		blob := []byte{nodeTypeInternal, byte(groupDepth)}
 		blob = append(blob, bitmap...)
-		blob = append(blob, depthOffset)
+		blob = append(blob, depths...)
 		blob = append(blob, make([]byte, HashSize)...)
 		return blob
 	}
@@ -187,9 +191,10 @@ func TestDecodeRejectsInvalidDepthOffset(t *testing.T) {
 		groupDepth  int
 		depthOffset uint8
 	}{
-		{"depth=0", 5, 0},
-		{"depth>groupDepth", 5, 6},
-		{"depth>MaxGroupDepth", MaxGroupDepth, MaxGroupDepth + 1},
+		{"gd2/depth3", 2, 3},
+		{"gd3/depth4", 3, 4},
+		{"gd5/depth6", 5, 6},
+		{"gd7/depth8", 7, 8},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newNodeStore()
@@ -201,6 +206,30 @@ func TestDecodeRejectsInvalidDepthOffset(t *testing.T) {
 				t.Errorf("expected 'invalid depth offset', got %q", err.Error())
 			}
 		})
+	}
+}
+
+// TestDecodeRejectsNonCanonicalDepthPadding verifies the canonical-encoding
+// check on the packed depth stream: when k*3 is not a multiple of 8, the unused
+// low bits of the final packed byte must be zero. Here groupDepth=2 with a
+// single entry uses 3 bits, leaving 5 pad bits; a stray pad bit must be
+// rejected so that two encoders cannot produce differing blobs for the same
+// content.
+func TestDecodeRejectsNonCanonicalDepthPadding(t *testing.T) {
+	// groupDepth=2, one entry at bitmap position 0, depthOffset=2 (bottom layer).
+	// Packed depth = (2-1)=1 → 0b001_00000 = 0x20; set a stray low pad bit → 0x21.
+	blob := []byte{nodeTypeInternal, 2}
+	blob = append(blob, 0x80) // bitmap: bit at position 0
+	blob = append(blob, 0x21) // packed depths with a non-zero pad bit
+	blob = append(blob, make([]byte, HashSize)...)
+
+	s := newNodeStore()
+	_, err := s.deserializeNode(blob, 0)
+	if err == nil {
+		t.Fatal("expected non-canonical depth padding error, got nil")
+	}
+	if err.Error() != "non-canonical depth padding" {
+		t.Errorf("expected 'non-canonical depth padding', got %q", err.Error())
 	}
 }
 

--- a/trie/bintrie/format_test.go
+++ b/trie/bintrie/format_test.go
@@ -151,7 +151,7 @@ func TestDecodeRejectsNonCanonicalPosition(t *testing.T) {
 	blob := []byte{nodeTypeInternal, 5}
 	// bitmap[0] = bit at position 5 → 1 << (7-5) = 0x04
 	blob = append(blob, 0x04, 0x00, 0x00, 0x00)
-	// depths[0] = 2, packed as (2-1)=1 in 3 bits MSB-first → 0b001_00000 = 0x20
+	// depths[0] = 2, packed as (2-1)=1 in 3 bits MSB-first → 0b0010_0000 = 0x20
 	blob = append(blob, 0x20)
 	// hashes[0] = 32 zero bytes
 	blob = append(blob, make([]byte, HashSize)...)

--- a/trie/bintrie/store_commit.go
+++ b/trie/bintrie/store_commit.go
@@ -146,12 +146,48 @@ func (s *nodeStore) serializeSubtree(ref nodeRef, remainingDepth int, position i
 	}
 }
 
+// depthBits is the number of bits used to encode one depth offset. A depth
+// offset is in [1, MaxGroupDepth] and is stored as (offset-1) in [0, 7], so it
+// always fits in 3 bits.
+const depthBits = 3
+
+// packedDepthsLen returns the byte length of the packed depth stream for k
+// entries, rounding the k*depthBits bit stream up to whole bytes.
+func packedDepthsLen(k int) int {
+	return (k*depthBits + 7) / 8
+}
+
+// putDepth3 writes the 3-bit value v (0..7) for entry idx into buf, MSB-first:
+// entry idx occupies bit positions [idx*3, idx*3+2], where earlier entries take
+// the higher-order bits. buf must be at least packedDepthsLen(idx+1) bytes.
+func putDepth3(buf []byte, idx int, v uint8) {
+	pos := idx * depthBits
+	for i := 0; i < depthBits; i++ {
+		bit := (v >> (depthBits - 1 - i)) & 1
+		p := pos + i
+		buf[p>>3] |= bit << (7 - (p & 7))
+	}
+}
+
+// getDepth3 reads the 3-bit value (0..7) for entry idx from buf, inverse of
+// putDepth3.
+func getDepth3(buf []byte, idx int) uint8 {
+	pos := idx * depthBits
+	var v uint8
+	for i := 0; i < depthBits; i++ {
+		p := pos + i
+		bit := (buf[p>>3] >> (7 - (p & 7))) & 1
+		v = v<<1 | bit
+	}
+	return v
+}
+
 // SerializeNode serializes a node into the flat on-disk format.
 func (s *nodeStore) serializeNode(ref nodeRef, groupDepth int) []byte {
 	switch ref.Kind() {
 	case kindInternal:
 		// InternalNode group format:
-		//   [type(1)] [groupDepth(1)] [bitmap (2^groupDepth bits)] [depths(1B × K)] [hashes(32B × K)]
+		//   [type(1)] [groupDepth(1)] [bitmap (2^groupDepth bits)] [depths(3 bits × K, padded)] [hashes(32B × K)]
 		bitmapSize := bitmapSizeForDepth(groupDepth)
 		bitmap := make([]byte, bitmapSize)
 		var hashes []common.Hash
@@ -161,16 +197,19 @@ func (s *nodeStore) serializeNode(ref nodeRef, groupDepth int) []byte {
 
 		// Build serialized output
 		k := len(hashes)
-		serializedLen := NodeTypeBytes + 1 + bitmapSize + k + k*HashSize
+		depthsLen := packedDepthsLen(k)
+		serializedLen := NodeTypeBytes + 1 + bitmapSize + depthsLen + k*HashSize
 		serialized := make([]byte, serializedLen)
 		serialized[0] = nodeTypeInternal
 		serialized[1] = byte(groupDepth)
 		copy(serialized[2:2+bitmapSize], bitmap)
 
 		depthsOff := NodeTypeBytes + 1 + bitmapSize
-		copy(serialized[depthsOff:depthsOff+k], depths) // TODO: see if this can't be pre-allocated
+		for i, d := range depths {
+			putDepth3(serialized[depthsOff:depthsOff+depthsLen], i, d-1)
+		}
 
-		hashesOff := depthsOff + k
+		hashesOff := depthsOff + depthsLen
 		for i, h := range hashes {
 			copy(serialized[hashesOff+i*HashSize:hashesOff+(i+1)*HashSize], h.Bytes())
 		}
@@ -222,8 +261,11 @@ func (s *nodeStore) deserializeNodeWithHash(serialized []byte, depth int, hn com
 
 // deserializeSubtree reconstructs an InternalNode subtree from grouped serialization.
 func (s *nodeStore) deserializeSubtree(hn common.Hash, groupDepth int, nodeDepth int, bitmap []byte, depths []byte, hashData []byte, mustRecompute bool, dirty bool) (nodeRef, error) {
-	k := len(depths)
-	if len(hashData) != k*HashSize {
+	if len(hashData)%HashSize != 0 {
+		return emptyRef, errInvalidSerializedLength
+	}
+	k := len(hashData) / HashSize
+	if len(depths) != packedDepthsLen(k) {
 		return emptyRef, errInvalidSerializedLength
 	}
 	if k == 0 {
@@ -244,8 +286,8 @@ func (s *nodeStore) deserializeSubtree(hn common.Hash, groupDepth int, nodeDepth
 		if bitmap[bit/8]>>(7-(bit%8))&1 == 0 {
 			continue
 		}
-		depthOffset := int(depths[entryIdx])
-		if depthOffset < 1 || depthOffset > groupDepth {
+		depthOffset := int(getDepth3(depths, entryIdx)) + 1
+		if depthOffset > groupDepth {
 			return emptyRef, errors.New("invalid depth offset")
 		}
 		// Canonical-encoding check: trailing position bits must be zero.
@@ -313,7 +355,7 @@ func (s *nodeStore) decodeNode(serialized []byte, depth int, hn common.Hash, mus
 	case nodeTypeInternal:
 		// Grouped format:
 		//   [type(1)] [groupDepth(1)] [bitmap (2^groupDepth bits, padded to bitmapSize bytes)]
-		//   [depthOffsets (1B × K)] [hashes (32B × K)]
+		//   [depthOffsets (3 bits × K, padded to bytes)] [hashes (32B × K)]
 		if len(serialized) < NodeTypeBytes+1 {
 			return emptyRef, errInvalidSerializedLength
 		}
@@ -339,13 +381,23 @@ func (s *nodeStore) decodeNode(serialized []byte, depth int, hn common.Hash, mus
 		for _, b := range bitmap {
 			k += bits.OnesCount8(b)
 		}
-		expectedLen := NodeTypeBytes + 1 + bitmapSize + k + k*HashSize
+		depthsLen := packedDepthsLen(k)
+		expectedLen := NodeTypeBytes + 1 + bitmapSize + depthsLen + k*HashSize
 		if len(serialized) != expectedLen {
 			return emptyRef, errInvalidSerializedLength
 		}
 		depthsOff := NodeTypeBytes + 1 + bitmapSize
-		depths := serialized[depthsOff : depthsOff+k]
-		hashData := serialized[depthsOff+k : depthsOff+k+k*HashSize]
+		depths := serialized[depthsOff : depthsOff+depthsLen]
+		hashData := serialized[depthsOff+depthsLen : depthsOff+depthsLen+k*HashSize]
+
+		// Canonical-encoding check: the unused low bits of the last packed
+		// depth byte must be zero.
+		if usedBits := k * depthBits; usedBits%8 != 0 {
+			padMask := byte(0xFF) >> (usedBits % 8)
+			if depths[depthsLen-1]&padMask != 0 {
+				return emptyRef, errors.New("non-canonical depth padding")
+			}
+		}
 
 		return s.deserializeSubtree(hn, groupDepth, depth, bitmap, depths, hashData, mustRecompute, dirty)
 

--- a/trie/bintrie/store_commit.go
+++ b/trie/bintrie/store_commit.go
@@ -146,35 +146,29 @@ func (s *nodeStore) serializeSubtree(ref nodeRef, remainingDepth int, position i
 	}
 }
 
-// depthBits is the number of bits used to encode one depth offset. A depth
-// offset is in [1, MaxGroupDepth] and is stored as (offset-1) in [0, 7], so it
-// always fits in 3 bits.
+// depthBits is the number of bits used to encode one depth offset.
 const depthBits = 3
 
-// packedDepthsLen returns the byte length of the packed depth stream for k
-// entries, rounding the k*depthBits bit stream up to whole bytes.
+// packedDepthsLen returns the byte length of k packed depth entries
 func packedDepthsLen(k int) int {
 	return (k*depthBits + 7) / 8
 }
 
-// putDepth3 writes the 3-bit value v (0..7) for entry idx into buf, MSB-first:
-// entry idx occupies bit positions [idx*3, idx*3+2], where earlier entries take
-// the higher-order bits. buf must be at least packedDepthsLen(idx+1) bytes.
-func putDepth3(buf []byte, idx int, v uint8) {
+// writeDepth writes a depth entry at idx into the buf, MSB-first.
+func writeDepth(buf []byte, idx int, v uint8) {
 	pos := idx * depthBits
-	for i := 0; i < depthBits; i++ {
+	for i := range depthBits {
 		bit := (v >> (depthBits - 1 - i)) & 1
 		p := pos + i
 		buf[p>>3] |= bit << (7 - (p & 7))
 	}
 }
 
-// getDepth3 reads the 3-bit value (0..7) for entry idx from buf, inverse of
-// putDepth3.
-func getDepth3(buf []byte, idx int) uint8 {
+// readDepth reads a depth for entry idx from buf.
+func readDepth(buf []byte, idx int) uint8 {
 	pos := idx * depthBits
 	var v uint8
-	for i := 0; i < depthBits; i++ {
+	for i := range depthBits {
 		p := pos + i
 		bit := (buf[p>>3] >> (7 - (p & 7))) & 1
 		v = v<<1 | bit
@@ -206,7 +200,7 @@ func (s *nodeStore) serializeNode(ref nodeRef, groupDepth int) []byte {
 
 		depthsOff := NodeTypeBytes + 1 + bitmapSize
 		for i, d := range depths {
-			putDepth3(serialized[depthsOff:depthsOff+depthsLen], i, d-1)
+			writeDepth(serialized[depthsOff:depthsOff+depthsLen], i, d-1)
 		}
 
 		hashesOff := depthsOff + depthsLen
@@ -286,7 +280,7 @@ func (s *nodeStore) deserializeSubtree(hn common.Hash, groupDepth int, nodeDepth
 		if bitmap[bit/8]>>(7-(bit%8))&1 == 0 {
 			continue
 		}
-		depthOffset := int(getDepth3(depths, entryIdx)) + 1
+		depthOffset := int(readDepth(depths, entryIdx)) + 1
 		if depthOffset > groupDepth {
 			return emptyRef, errors.New("invalid depth offset")
 		}


### PR DESCRIPTION
## Summary

Builds on the per-entry depth offset added in this branch. A depth offset is in `[1, groupDepth]` and `groupDepth <= MaxGroupDepth (8)`, so it needs only 3 bits. This packs the depths section as a 3-bit-per-entry stream (storing `offset-1` in `[0,7]`) instead of one byte per entry.

- Blob format changes from `[type][groupDepth][bitmap][depths(1B × K)][hashes]` to `[type][groupDepth][bitmap][depths(3 bits × K, padded)][hashes]`. The depths section shrinks from `K` bytes to `ceil(3K/8)`.
- `putDepth3`/`getDepth3` pack/unpack MSB-first; the buffer is zero-initialized so unused pad bits stay zero.
- Decoder adds a canonical check rejecting a non-zero pad in the final packed byte (mirrors the existing bitmap-padding check).
- The `depthOffset > groupDepth` range check stays. The old `depthOffset < 1` check is dropped: the 3-bit field maps onto offsets `[1, 8]` and can never encode 0, which also makes the previous `depth=0` and `depth>MaxGroupDepth` decode-rejection tests unrepresentable.

## Test plan

- [x] `go test ./trie/bintrie/...`
- [x] `go test -race -run 'TestRootHashMatchesReadBackHash|TestMultiStemMixedDepths|TestRoundTripPersistence|TestDecodeRejects|TestSerializeDeserialize' ./trie/bintrie/`
- [x] `go vet ./trie/bintrie/`
- Updated `TestSerializeDeserializeInternalNode` (K=2 → 1 packed depth byte, blob 68 B).
- Reworked `TestDecodeRejectsInvalidDepthOffset` to the encodable `depthOffset>groupDepth` cases; added `TestDecodeRejectsNonCanonicalDepthPadding`.