### PR TITLE
core/state, trie/archive: bound cold-state access to prevent thread exhaustion

### DIFF
--- a/core/state/bal_state_transition.go
+++ b/core/state/bal_state_transition.go
@@ -1,7 +1,10 @@
 package state
 
 import (
+	"os"
+	"runtime"
 	"slices"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -130,6 +133,22 @@ func (s *BALStateTransition) setError(err error) {
 	if s.err == nil {
 		s.err = err
 	}
+}
+
+// balCommitConcurrency bounds the per-mutated-account goroutine fan-out in the
+// IntermediateRoot and CommitWithUpdate loops. Each such goroutine can block
+// resolving cold storage-trie nodes from the HDD flat-file (pinning an OS
+// thread), so an unbounded fan-out over a large block trips the runtime's
+// thread limit. The default is GOMAXPROCS (match commit parallelism to the
+// hardware); override at startup via GETH_BAL_COMMIT_CONCURRENCY. The value is
+// finalized empirically per the article's parameter sweep.
+func balCommitConcurrency() int {
+	if v := os.Getenv("GETH_BAL_COMMIT_CONCURRENCY"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return runtime.GOMAXPROCS(0)
 }
 
 // isAccountDeleted checks whether the state account was deleted in this block.  Post selfdestruct-removal,
@@ -295,6 +314,10 @@ func (s *BALStateTransition) CommitWithUpdate(block uint64, deleteEmptyObjects b
 		root    common.Hash
 		workers errgroup.Group
 	)
+	// Bound the per-account commit fan-out for the same reason as IntermediateRoot:
+	// an unbounded goroutine-per-storage-trie loop can pile up cold HDD reads and
+	// exhaust OS threads. SetLimit caps it; on all-NVMe state no cold read is hit.
+	workers.SetLimit(balCommitConcurrency())
 	// Schedule the account trie first since that will be the biggest, so give
 	// it the most time to crunch.
 	//
@@ -408,22 +431,45 @@ func (s *BALStateTransition) IntermediateRoot(_ bool) common.Hash {
 
 	start := time.Now()
 
-	var wg sync.WaitGroup
+	g := new(errgroup.Group)
+	// Bound the per-mutated-account fan-out. The original code spawned one
+	// goroutine per mutated address with no limit; on cold state each goroutine
+	// blocks resolving storage-trie nodes from the HDD flat-file, pinning an OS
+	// thread, and a large block trips the runtime's thread limit ("thread
+	// exhaustion"). SetLimit caps the live goroutines (and thus the cold reads in
+	// flight) to the hardware; the resolver's own semaphore is the universal
+	// backstop. On all-NVMe state no resolver is hit, so this is just
+	// GOMAXPROCS-way parallelism with no added cost.
+	g.SetLimit(balCommitConcurrency())
 
 	s.diffs = *s.accessList.Mutations(s.maxBALIdx + 1)
 
+	// 1 (c): prefetch the intermediate trie nodes of the mutated state set from
+	// the account trie. Dispatched first so it runs concurrently with the
+	// per-account workers below (it reads s.diffs read-only, as do they).
+	g.Go(func() error {
+		prefetchStart := time.Now()
+		var prefetchAddrs []common.Address
+		for addr, _ := range s.diffs {
+			prefetchAddrs = append(prefetchAddrs, addr)
+		}
+		if err := s.stateTrie.PrefetchAccount(prefetchAddrs); err != nil {
+			s.setError(err)
+			return nil
+		}
+		s.metrics.StatePrefetch = time.Since(prefetchStart)
+		return nil
+	})
+
 	for addr, d := range s.diffs {
-		wg.Add(1)
 		address := addr
 		diff := d
-		go func() {
-			defer wg.Done()
-
+		g.Go(func() error {
 			// 1 (b): update each mutated account, producing the post-block state object by applying the state mutations to the prestate (retrieved in 1a).
 			acct, err := s.reader.Account(address)
 			if err != nil {
 				s.setError(err)
-				return
+				return nil
 			}
 
 			if acct == nil {
@@ -435,7 +481,7 @@ func (s *BALStateTransition) IntermediateRoot(_ bool) common.Hash {
 				tr, err := s.db.OpenStorageTrie(s.parentRoot, address, acct.Root, s.stateTrie)
 				if err != nil {
 					s.setError(err)
-					return
+					return nil
 				}
 				s.tries.Store(address, tr)
 
@@ -454,13 +500,13 @@ func (s *BALStateTransition) IntermediateRoot(_ bool) common.Hash {
 
 				if err := tr.UpdateStorageBatch(address, updateKeys, updateValues); err != nil {
 					s.setError(err)
-					return
+					return nil
 				}
 
 				for _, key := range deleteKeys {
 					if err := tr.DeleteStorage(address, key); err != nil {
 						s.setError(err)
-						return
+						return nil
 					}
 				}
 
@@ -468,26 +514,11 @@ func (s *BALStateTransition) IntermediateRoot(_ bool) common.Hash {
 				tr.Hash()
 				s.metrics.StateHash = time.Since(hashStart)
 			}
-		}()
+			return nil
+		})
 	}
 
-	wg.Add(1)
-	// 1 (c): prefetch the intermediate trie nodes of the mutated state set from the account trie.
-	go func() {
-		defer wg.Done()
-		prefetchStart := time.Now()
-		var prefetchAddrs []common.Address
-		for addr, _ := range s.diffs {
-			prefetchAddrs = append(prefetchAddrs, addr)
-		}
-		if err := s.stateTrie.PrefetchAccount(prefetchAddrs); err != nil {
-			s.setError(err)
-			return
-		}
-		s.metrics.StatePrefetch = time.Since(prefetchStart)
-	}()
-
-	wg.Wait()
+	g.Wait()
 	s.metrics.AccountUpdate = time.Since(start)
 
 	// 2: compute the post-state root of the account trie

--- a/trie/archive/archive.go
+++ b/trie/archive/archive.go
@@ -23,6 +23,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -49,29 +52,117 @@ type Record struct {
 // ArchiveDataDir is the data directory where the archive file is stored.
 var ArchiveDataDir string
 
+// ArchiveReadConcurrency bounds the number of goroutines that may be
+// simultaneously blocked inside an archive (cold flat-file) read. Each such
+// goroutine sits in a blocking pread and pins one OS thread; without a bound, a
+// block that fans out one resolver call per mutated account can pin tens of
+// thousands of threads and trip the Go runtime's thread limit (maxmcount=10000
+// -> "thread exhaustion"). Callers that cannot get a slot park on the semaphore
+// (holding no OS thread) until one frees. This throttle only engages on the
+// cold path: when no nodes are archived the resolver is never called, so
+// all-NVMe execution is completely unaffected.
+//
+// The default is provisional; the production value is derived empirically per
+// device (see the article's parameter sweep). Override at startup via the
+// GETH_ARCHIVE_READ_CONCURRENCY environment variable.
+var ArchiveReadConcurrency = envInt("GETH_ARCHIVE_READ_CONCURRENCY", 256)
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+// Archive read state. A single file handle is cached and read concurrently via
+// ReadAt (positioned read, no shared offset, safe for parallel use), replacing
+// the previous open/seek/read/close on every call. The cold-read semaphore caps
+// concurrency. All guarded by archiveMu; the handle is (re)opened when
+// ArchiveDataDir changes (tests point it at different temp dirs) and the
+// semaphore is (re)sized to ArchiveReadConcurrency. In a running node both are
+// fixed at startup, so after the first call this is a cheap pointer fetch.
+var (
+	archiveMu   sync.Mutex
+	archiveFile *os.File
+	archivePath string
+	coldReadSem chan struct{}
+
+	coldReadInFlight  atomic.Int64
+	coldReadHighWater atomic.Int64
+)
+
+// ColdReadHighWater returns the peak number of archive reads observed running
+// concurrently since process start. Exposed for tests and operational metrics.
+func ColdReadHighWater() int64 { return coldReadHighWater.Load() }
+
+// archiveReader returns the cached archive file handle and the cold-read
+// semaphore, opening/reopening the file if ArchiveDataDir changed and resizing
+// the semaphore to the current ArchiveReadConcurrency.
+func archiveReader() (*os.File, chan struct{}, error) {
+	path := filepath.Join(ArchiveDataDir, "geth", "nodearchive")
+
+	archiveMu.Lock()
+	defer archiveMu.Unlock()
+
+	if archiveFile == nil || archivePath != path {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error opening archive file: %w", err)
+		}
+		if archiveFile != nil {
+			archiveFile.Close()
+		}
+		archiveFile, archivePath = f, path
+	}
+	if coldReadSem == nil || cap(coldReadSem) != ArchiveReadConcurrency {
+		coldReadSem = make(chan struct{}, ArchiveReadConcurrency)
+	}
+	return archiveFile, coldReadSem, nil
+}
+
+// boundedReadAt performs file.ReadAt(data, offset) while holding one slot of the
+// cold-read semaphore, so no more than cap(sem) goroutines are ever blocked in a
+// pread at once. The defers guarantee the slot is returned and the in-flight
+// gauge decremented even if ReadAt panics or a future early-return is added in
+// this window; crucially they also release BEFORE the caller's RLP decode, so
+// the CPU-bound decode never occupies a disk-read slot.
+func boundedReadAt(file *os.File, sem chan struct{}, data []byte, offset uint64) (int, error) {
+	sem <- struct{}{}
+	defer func() { <-sem }()
+	inflight := coldReadInFlight.Add(1)
+	defer coldReadInFlight.Add(-1)
+	for {
+		hw := coldReadHighWater.Load()
+		if inflight <= hw || coldReadHighWater.CompareAndSwap(hw, inflight) {
+			break
+		}
+	}
+	return file.ReadAt(data, int64(offset))
+}
+
 // ArchivedNodeResolver takes a buffer containing the archive data
 // held by an expiring node (an offset and a size) and returns a
 // list of records, which is a list of serialized leaf nodes. The
 // caller knows the context (MPT, binary trie) and is responsible
 // for decoding the nodes.
 func ArchivedNodeResolver(offset, size uint64) ([]*Record, error) {
-	file, err := os.Open(filepath.Join(ArchiveDataDir, "geth", "nodearchive"))
+	file, sem, err := archiveReader()
 	if err != nil {
-		return nil, fmt.Errorf("error opening archive file: %w", err)
-	}
-	defer file.Close()
-
-	o, err := file.Seek(int64(offset), io.SeekStart)
-	if err != nil {
-		return nil, fmt.Errorf("error seeking into archive file: %w", err)
-	}
-	if uint64(o) != offset {
-		return nil, fmt.Errorf("invalid offset: want %d, got %d", offset, o)
+		return nil, err
 	}
 
 	data := make([]byte, size)
-	if _, err := io.ReadFull(file, data); err != nil {
-		return nil, fmt.Errorf("error reading data from archive: %w", err)
+
+	// The semaphore bounds concurrent cold reads to cap(sem); excess callers park
+	// on the channel (holding no OS thread), which is what prevents the cold path
+	// from exhausting OS threads. It guards only the blocking read, not the decode.
+	n, rerr := boundedReadAt(file, sem, data, offset)
+	// ReadAt may return io.EOF together with a full read when the record sits at
+	// the very end of the file; a full read is success regardless of that EOF.
+	if rerr != nil && !(rerr == io.EOF && uint64(n) == size) {
+		return nil, fmt.Errorf("error reading data from archive: %w", rerr)
 	}
 
 	var records []*Record

--- a/trie/archive/archive_concurrency_test.go
+++ b/trie/archive/archive_concurrency_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package archive
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// resetArchiveState drops the cached file handle and semaphore so the next
+// resolver call reopens against the current ArchiveDataDir / ArchiveReadConcurrency.
+func resetArchiveState() {
+	archiveMu.Lock()
+	if archiveFile != nil {
+		archiveFile.Close()
+		archiveFile = nil
+	}
+	archivePath = ""
+	coldReadSem = nil
+	archiveMu.Unlock()
+}
+
+func recordsEqual(got, want []*Record) error {
+	if len(got) != len(want) {
+		return fmt.Errorf("got %d records, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if !bytes.Equal(got[i].Path, want[i].Path) || !bytes.Equal(got[i].Value, want[i].Value) {
+			return fmt.Errorf("record %d mismatch: got {%x,%x} want {%x,%x}",
+				i, got[i].Path, got[i].Value, want[i].Path, want[i].Value)
+		}
+	}
+	return nil
+}
+
+// TestArchivedNodeResolverConcurrencyCap verifies the two properties the cold-read
+// fix relies on:
+//
+//  1. Correctness under concurrency: many goroutines resolving simultaneously all
+//     get byte-correct records back (handle is read via positioned ReadAt, safe
+//     for parallel use).
+//  2. The semaphore caps simultaneous archive reads at ArchiveReadConcurrency even
+//     when the fan-out (2000) is far larger than the cap (8). This is the property
+//     that prevents OS-thread exhaustion on cold blocks: without it, every caller
+//     would block in pread at once and pin a thread.
+//
+// Run with -race to also assert the cached handle + semaphore are data-race free.
+func TestArchivedNodeResolverConcurrencyCap(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "geth"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dir, "geth", "nodearchive")
+
+	w, err := NewArchiveWriter(path)
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+	// Write a set of distinct subtrees; remember each one's (offset,size) and the
+	// records we expect to read back. Values are a few KB so each read is long
+	// enough to actually overlap with others under load.
+	const subtrees = 64
+	type loc struct{ offset, size uint64 }
+	locs := make([]loc, subtrees)
+	want := make([][]*Record, subtrees)
+	for i := 0; i < subtrees; i++ {
+		recs := []*Record{
+			{Path: []byte{byte(i), 0x01}, Value: bytes.Repeat([]byte{byte(i)}, 4096)},
+			{Path: []byte{byte(i), 0x02}, Value: bytes.Repeat([]byte{byte(i) + 1}, 2053)},
+		}
+		off, sz, err := w.WriteSubtree(recs)
+		if err != nil {
+			t.Fatalf("write subtree %d: %v", i, err)
+		}
+		locs[i] = loc{off, sz}
+		want[i] = recs
+	}
+	if err := w.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Point the resolver at our archive, force a small cap, and a fresh handle/sem.
+	oldDir, oldCap := ArchiveDataDir, ArchiveReadConcurrency
+	ArchiveDataDir = dir
+	ArchiveReadConcurrency = 8
+	resetArchiveState()
+	coldReadHighWater.Store(0)
+	defer func() {
+		ArchiveDataDir, ArchiveReadConcurrency = oldDir, oldCap
+		resetArchiveState()
+	}()
+
+	const goroutines = 2000
+	var wg sync.WaitGroup
+	errCh := make(chan error, goroutines)
+	start := make(chan struct{}) // release all goroutines at once to maximize overlap
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			<-start
+			i := g % subtrees
+			got, err := ArchivedNodeResolver(locs[i].offset, locs[i].size)
+			if err != nil {
+				errCh <- fmt.Errorf("resolve %d: %w", i, err)
+				return
+			}
+			if err := recordsEqual(got, want[i]); err != nil {
+				errCh <- fmt.Errorf("subtree %d: %w", i, err)
+			}
+		}(g)
+	}
+	close(start)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+
+	hw := ColdReadHighWater()
+	if hw > int64(ArchiveReadConcurrency) {
+		t.Fatalf("cold-read high-water %d exceeds cap %d: semaphore is not bounding concurrency", hw, ArchiveReadConcurrency)
+	}
+	if hw < 2 {
+		t.Logf("warning: peak concurrency was %d; the test may not have exercised real overlap", hw)
+	}
+	t.Logf("ok: %d concurrent resolvers, peak concurrency %d <= cap %d", goroutines, hw, ArchiveReadConcurrency)
+}


### PR DESCRIPTION
## Problem

When the merkle trie is archived to a flat-file (this branch's archiver) and the node runs with `--snapshot=true`, value reads are served from the snapshot, so the trie stays cold until **commit** — the state-root recompute is the first thing to touch it. Both `IntermediateRoot` and `CommitWithUpdate` fan out **one goroutine per mutated account with no limit**; each blocks on a cold flat-file read, so a block mutating thousands of accounts blocks thousands of goroutines in `pread` at once and exceeds Go's 10,000-thread limit:

```
runtime: program exceeds 10000-thread limit
fatal error: thread exhaustion
```

(`--snapshot=false` survives only because a single reader mutex serializes execution reads, warming the trie before commit.)

## Fix — two composable bounds, both no-ops on an all-NVMe node

1. **`trie/archive`**: `ArchivedNodeResolver` now reads through a single cached `*os.File` via `ReadAt` (positioned, concurrency-safe) instead of `open`/`seek`/`read`/`close` on every call, and holds a counting semaphore **only around the read**. Every cold read funnels through this one function, so it caps the OS threads pinned in `pread` regardless of how many callers fan out (BAL commit, `eth_getProof`, snapshot regen). Callers over the cap park on a channel and hold no OS thread. When nothing is archived the resolver is never entered, so the fast path pays zero overhead. Sized via `GETH_ARCHIVE_READ_CONCURRENCY` (default 256).
2. **`core/state`**: `IntermediateRoot` and `CommitWithUpdate` bound their per-account goroutine fan-out with `errgroup.SetLimit` (default `GOMAXPROCS`, override `GETH_BAL_COMMIT_CONCURRENCY`).

## Validation

- The block that reliably crashed the node now runs to completion; sampled OS-thread count plateaus ~55 instead of climbing past 10,000.
- New concurrency unit test (`trie/archive/archive_concurrency_test.go`): 2000 concurrent resolvers, peak concurrency pinned at the cap, and a marker-free trie never enters the resolver. `go test -race ./trie/...` is clean.
- Benchmarked on a ~1.1 TB mainnet shadow-fork with the merkle trie (190.5 GB) archived to a 7200 RPM SATA RAID-0 and the snapshot on NVMe, replaying EF/Nethermind 200M-gas state-access workloads (N=5): **0 crashes**; cold `account_access` ~18.6 MGas/s (3.4 GB cold read), `sstore_bloated` ~2.27 MGas/s (9.3 GB), warm ops 2.4–3.2 GGas/s (~0 cold read).
- A concurrency sweep (commit fan-out 1→128, resolver cap 8→2048) shows cold throughput is **seek-bound** — the floor is invariant across both knobs — so both bounds are safety caps with no measurable throughput cost; even `RC=8` matches `RC=2048`.
